### PR TITLE
Ensure block size is set just before context start

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -145,7 +145,7 @@ namespace OpenEphys.Onix
             }
         }
 
-        internal void Start()
+        internal void Start(int blockReadSize, int blockWriteSize)
         {
             lock (regLock)
             {
@@ -153,6 +153,8 @@ namespace OpenEphys.Onix
 
                 // NB: Configure context before starting acquisition
                 ContextConfiguration = ConfigureContext();
+                ctx.BlockReadSize = blockReadSize;
+                ctx.BlockWriteSize = blockWriteSize;
 
                 // NB: Stuff related to sync mode is 100% ONIX, not ONI, so long term another place
                 // to do this separation might be needed
@@ -289,10 +291,6 @@ namespace OpenEphys.Onix
             {
                 return ctx.BlockReadSize;
             }
-            set
-            {
-                ctx.BlockReadSize = value;
-            }
         }
 
         public int BlockWriteSize
@@ -300,10 +298,6 @@ namespace OpenEphys.Onix
             get
             {
                 return ctx.BlockWriteSize;
-            }
-            set
-            {
-                ctx.BlockWriteSize = value;
             }
         }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
@@ -21,9 +21,7 @@ namespace OpenEphys.Onix
                     var disposable = context.FrameReceived.SubscribeSafe(observer);
                     try
                     {
-                        context.BlockReadSize = ReadSize;
-                        context.BlockWriteSize = WriteSize;
-                        context.Start();
+                        context.Start(ReadSize, WriteSize);
                     }
                     catch
                     {


### PR DESCRIPTION
Context block size needs to be set after the last reset of the context, otherwise default block size is set to the minimal block size for latency.

Fixes #72 
Fixes #57 