### PR TITLE
Full shutdown and powerup sequences for MiniscopeV4 Python480 sensor

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
+    <Package id="AForge" version="2.2.5" />
+    <Package id="AForge.Video" version="2.2.5" />
+    <Package id="AForge.Video.DirectShow" version="2.2.5" />
     <Package id="Bonsai" version="2.8.5" />
     <Package id="Bonsai.Core" version="2.8.5" />
     <Package id="Bonsai.Design" version="2.8.5" />
@@ -12,6 +15,8 @@
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.System.Design" version="2.8.0" />
+    <Package id="Bonsai.Video" version="2.4.0" />
+    <Package id="Bonsai.Video.Design" version="2.4.0" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
@@ -46,10 +51,15 @@
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
     <AssemblyReference assemblyName="Bonsai.System" />
     <AssemblyReference assemblyName="Bonsai.System.Design" />
+    <AssemblyReference assemblyName="Bonsai.Video" />
+    <AssemblyReference assemblyName="Bonsai.Video.Design" />
     <AssemblyReference assemblyName="Bonsai.Vision" />
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
+    <AssemblyLocation assemblyName="AForge" processorArchitecture="MSIL" location="Packages/AForge.2.2.5/lib/AForge.dll" />
+    <AssemblyLocation assemblyName="AForge.Video" processorArchitecture="MSIL" location="Packages/AForge.Video.2.2.5/lib/AForge.Video.dll" />
+    <AssemblyLocation assemblyName="AForge.Video.DirectShow" processorArchitecture="MSIL" location="Packages/AForge.Video.DirectShow.2.2.5/lib/AForge.Video.DirectShow.dll" />
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
@@ -61,6 +71,8 @@
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages/Bonsai.System.Design.2.8.0/lib/net462/Bonsai.System.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Video" processorArchitecture="MSIL" location="Packages/Bonsai.Video.2.4.0/lib/net462/Bonsai.Video.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Video.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Video.Design.2.4.0/lib/net462/Bonsai.Video.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -166,8 +166,8 @@ namespace OpenEphys.Onix1
                 var deviceInfo = new NeuropixelsV1eDeviceInfo(context, DeviceType, deviceAddress, probeControl);
                 var shutdown = Disposable.Create(() =>
                 {
-                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, NeuropixelsV1e.DefaultGPO10Config);
-                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, NeuropixelsV1e.DefaultGPO32Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, NeuropixelsV1e.DefaultGPO10Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio32, NeuropixelsV1e.DefaultGPO32Config);
                 });
                 return new CompositeDisposable(
                     DeviceManager.RegisterDevice(deviceName, deviceInfo),
@@ -210,16 +210,16 @@ namespace OpenEphys.Onix1
         static void ResetProbe(I2CRegisterContext serializer, uint gpo10Config)
         {
             gpo10Config &= ~NeuropixelsV1e.Gpo10ResetMask;
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
             Thread.Sleep(1);
             gpo10Config |= NeuropixelsV1e.Gpo10ResetMask;
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
         }
 
         static uint TurnOnLed(I2CRegisterContext serializer, uint gpo23Config)
         {
             gpo23Config &= ~NeuropixelsV1e.Gpo32LedMask;
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, gpo23Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio32, gpo23Config);
 
             return gpo23Config;
         }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -141,8 +141,7 @@ namespace OpenEphys.Onix1
                 var serializer = new I2CRegisterContext(device, DS90UB9x.SER_ADDR);
 
                 // set I2C clock rate to ~400 kHz
-                serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.SCLHIGH, 20);
-                serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.SCLLOW, 20);
+                DS90UB9x.Set933I2CRate(device, 400e3);
 
                 // read probe metadata
                 var probeMetadata = new NeuropixelsV1eMetadata(serializer);
@@ -167,8 +166,8 @@ namespace OpenEphys.Onix1
                 var deviceInfo = new NeuropixelsV1eDeviceInfo(context, DeviceType, deviceAddress, probeControl);
                 var shutdown = Disposable.Create(() =>
                 {
-                    serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, NeuropixelsV1e.DefaultGPO10Config);
-                    serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO32, NeuropixelsV1e.DefaultGPO32Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, NeuropixelsV1e.DefaultGPO10Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, NeuropixelsV1e.DefaultGPO32Config);
                 });
                 return new CompositeDisposable(
                     DeviceManager.RegisterDevice(deviceName, deviceInfo),
@@ -194,10 +193,10 @@ namespace OpenEphys.Onix1
             device.WriteRegister(DS90UB9x.DATALINES0, 0x3245106B); // Sync, psb[0], psb[1], psb[2], psb[3], psb[4], psb[5], psb[6],
             device.WriteRegister(DS90UB9x.DATALINES1, 0xFFFFFFFF);
 
+            DS90UB9x.Initialize933SerDesLink(device, DS90UB9xMode.Raw12BitHighFrequency);
+
             // configure deserializer I2C aliases
             var deserializer = new I2CRegisterContext(device, DS90UB9x.DES_ADDR);
-            uint coaxMode = 0x4 + (uint)DS90UB9xMode.Raw12BitHighFrequency; // 0x4 maintains coax mode
-            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortMode, coaxMode);
 
             uint alias = NeuropixelsV1e.ProbeAddress << 1;
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveID1, alias);
@@ -211,16 +210,16 @@ namespace OpenEphys.Onix1
         static void ResetProbe(I2CRegisterContext serializer, uint gpo10Config)
         {
             gpo10Config &= ~NeuropixelsV1e.Gpo10ResetMask;
-            serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
             Thread.Sleep(1);
             gpo10Config |= NeuropixelsV1e.Gpo10ResetMask;
-            serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
         }
 
         static uint TurnOnLed(I2CRegisterContext serializer, uint gpo23Config)
         {
             gpo23Config &= ~NeuropixelsV1e.Gpo32LedMask;
-            serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO32, gpo23Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, gpo23Config);
 
             return gpo23Config;
         }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -137,9 +137,8 @@ namespace OpenEphys.Onix1
                 var gpo10Config = EnableProbeSupply(serializer);
 
                 // set I2C clock rate to ~400 kHz
-                serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.SCLHIGH, 20);
-                serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.SCLLOW, 20);
-
+                DS90UB9x.Set933I2CRate(device, 400e3);
+                
                 // read probe metadata
                 var probeAMetadata = ReadProbeMetadata(serializer, NeuropixelsV2e.ProbeASelected);
                 var probeBMetadata = ReadProbeMetadata(serializer, NeuropixelsV2e.ProbeBSelected);
@@ -210,7 +209,7 @@ namespace OpenEphys.Onix1
                 var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB);
                 var shutdown = Disposable.Create(() =>
                 {
-                    serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, NeuropixelsV2e.DefaultGPO10Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, NeuropixelsV2e.DefaultGPO10Config);
                     SelectProbe(serializer, NeuropixelsV2e.NoProbeSelected);
                 });
                 return new CompositeDisposable(
@@ -237,10 +236,10 @@ namespace OpenEphys.Onix1
             device.WriteRegister(DS90UB9x.DATALINES0, 0xFFFFF8A6); // NP A
             device.WriteRegister(DS90UB9x.DATALINES1, 0xFFFFF97B); // NP B
 
+            DS90UB9x.Initialize933SerDesLink(device, DS90UB9xMode.Raw12BitHighFrequency);
+
             // configure deserializer I2C aliases
             var deserializer = new I2CRegisterContext(device, DS90UB9x.DES_ADDR);
-            uint coaxMode = 0x4 + (uint)DS90UB9xMode.Raw12BitHighFrequency; // 0x4 maintains coax mode
-            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortMode, coaxMode);
 
             uint alias = NeuropixelsV2e.ProbeAddress << 1;
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveID1, alias);
@@ -257,7 +256,7 @@ namespace OpenEphys.Onix1
             SelectProbe(serializer, NeuropixelsV2e.NoProbeSelected);
 
             // turn on analog supply and wait for boot
-            serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
             System.Threading.Thread.Sleep(20);
             return gpo10Config;
         }
@@ -269,16 +268,16 @@ namespace OpenEphys.Onix1
         }
         static void SelectProbe(I2CRegisterContext serializer, byte probeSelect)
         {
-            serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO32, probeSelect);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, probeSelect);
             System.Threading.Thread.Sleep(20);
         }
 
         static void ResetProbes(I2CRegisterContext serializer, uint gpo10Config)
         {
             gpo10Config &= ~NeuropixelsV2e.GPO10ResetMask;
-            serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
             gpo10Config |= NeuropixelsV2e.GPO10ResetMask;
-            serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
         }
 
         static void ConfigureProbeStreaming(I2CRegisterContext i2cNP)

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -209,7 +209,7 @@ namespace OpenEphys.Onix1
                 var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB);
                 var shutdown = Disposable.Create(() =>
                 {
-                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, NeuropixelsV2e.DefaultGPO10Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, NeuropixelsV2e.DefaultGPO10Config);
                     SelectProbe(serializer, NeuropixelsV2e.NoProbeSelected);
                 });
                 return new CompositeDisposable(
@@ -256,7 +256,7 @@ namespace OpenEphys.Onix1
             SelectProbe(serializer, NeuropixelsV2e.NoProbeSelected);
 
             // turn on analog supply and wait for boot
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
             System.Threading.Thread.Sleep(20);
             return gpo10Config;
         }
@@ -268,16 +268,16 @@ namespace OpenEphys.Onix1
         }
         static void SelectProbe(I2CRegisterContext serializer, byte probeSelect)
         {
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, probeSelect);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio32, probeSelect);
             System.Threading.Thread.Sleep(20);
         }
 
         static void ResetProbes(I2CRegisterContext serializer, uint gpo10Config)
         {
             gpo10Config &= ~NeuropixelsV2e.GPO10ResetMask;
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
             gpo10Config |= NeuropixelsV2e.GPO10ResetMask;
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
         }
 
         static void ConfigureProbeStreaming(I2CRegisterContext i2cNP)

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -150,8 +150,8 @@ namespace OpenEphys.Onix1
                 var serializer = new I2CRegisterContext(device, DS90UB9x.SER_ADDR);
                 var gpo10Config = NeuropixelsV2eBeta.DefaultGPO10Config;
                 var gpo32Config = NeuropixelsV2eBeta.DefaultGPO32Config;
-                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
-                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, gpo32Config);
+                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
+                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio32, gpo32Config);
 
                 // set I2C clock rate to ~400 kHz
                 DS90UB9x.Set933I2CRate(device, 400e3);
@@ -169,7 +169,7 @@ namespace OpenEphys.Onix1
                 // REC_NRESET and NRESET go high on both probes to take the ASIC out of reset
                 // TODO: not sure if REC_NRESET and NRESET are tied together on flex
                 gpo10Config |= NeuropixelsV2eBeta.GPO10ResetMask | NeuropixelsV2eBeta.GPO10NResetMask;
-                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
                 System.Threading.Thread.Sleep(20);
 
                 // configure probe streaming
@@ -226,7 +226,7 @@ namespace OpenEphys.Onix1
 
                 // toggle probe LED
                 gpo32Config = (gpo32Config & ~NeuropixelsV2eBeta.GPO32LedMask) | (EnableLed ? 0 : NeuropixelsV2eBeta.GPO32LedMask);
-                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, gpo32Config);
+                serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio32, gpo32Config);
 
                 // Both probes are now streaming, hit them with a mux reset to (roughly) sync.
                 // NB: We have found that this gives PCLK-level synchronization MOST of the time.
@@ -237,8 +237,8 @@ namespace OpenEphys.Onix1
                 var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB);
                 var shutdown = Disposable.Create(() =>
                 {
-                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, NeuropixelsV2eBeta.DefaultGPO10Config);
-                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, NeuropixelsV2eBeta.DefaultGPO32Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, NeuropixelsV2eBeta.DefaultGPO10Config);
+                    serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio32, NeuropixelsV2eBeta.DefaultGPO32Config);
                 });
                 return new CompositeDisposable(
                     DeviceManager.RegisterDevice(deviceName, deviceInfo),
@@ -292,17 +292,17 @@ namespace OpenEphys.Onix1
                 NeuropixelsV2eBeta.SelectProbeB => gpo32Config & ~NeuropixelsV2eBeta.ProbeSelectMask,
                 _ => gpo32Config
             };
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO32, gpo32Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio32, gpo32Config);
             System.Threading.Thread.Sleep(20);
         }
 
         static void SyncProbes(I2CRegisterContext serializer, uint gpo10Config)
         {
             gpo10Config &= ~NeuropixelsV2eBeta.GPO10NResetMask;
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
 
             gpo10Config |= NeuropixelsV2eBeta.GPO10NResetMask;
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.GPIO10, gpo10Config);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, gpo10Config);
         }
 
         static void ConfigureProbeStreaming(I2CRegisterContext i2cNP)

--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4.cs
@@ -158,6 +158,7 @@ namespace OpenEphys.Onix1
                 const int FailureToWriteRegister = -6;
                 try
                 {
+                    ConfigureUclaMiniscopeV4Camera.ConfigureSerializer(ds90ub9x);
                     ConfigureUclaMiniscopeV4Camera.ConfigureCameraSystem(ds90ub9x, Camera.FrameRate, Camera.InterleaveLed);
                 }
                 catch (ONIException ex) when (ex.Number == FailureToWriteRegister)
@@ -165,6 +166,7 @@ namespace OpenEphys.Onix1
                     return false;
                 }
 
+                Thread.Sleep(150);
                 var linkState = device.ReadRegister(PortController.LINKSTATE);
                 return (linkState & PortController.LINKSTATE_SL) != 0;
             }

--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
@@ -205,11 +205,6 @@ namespace OpenEphys.Onix1
             i2cAlias = UclaMiniscopeV4.Max14574Address << 1;
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveID3, i2cAlias);
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveAlias3, i2cAlias);
-
-            // set I2C clock rate to ~100 kHz
-            var serializer = new I2CRegisterContext(device, DS90UB9x.SER_ADDR);
-            serializer.WriteByte((uint)0x11, 0x7A);
-            serializer.WriteByte((uint)0x12, 0x7A);
         }
 
         internal static void ConfigureSerializer(DeviceContext device)

--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
@@ -190,15 +190,10 @@ namespace OpenEphys.Onix1
             // acquisition. For this reason, the frame start needs to be marked.
             device.WriteRegister(DS90UB9x.MARK, (uint)DS90UB9xMarkMode.VsyncRising);
 
-            // set I2C clock rate to ~100 kHz
+            DS90UB9x.Initialize933SerDesLink(device, DS90UB9xMode.Raw12BitLowFrequency);
+
             var deserializer = new I2CRegisterContext(device, DS90UB9x.DES_ADDR);
-            deserializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.SCLHIGH, 0x7A);
-            deserializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.SCLLOW, 0x7A);
-
-            // configure deserializer I2C aliases
-            uint coaxMode = 0x4 + (uint)DS90UB9xMode.Raw12BitLowFrequency; // 0x4 maintains coax mode
-            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortMode, coaxMode);
-
+     
             uint i2cAlias = UclaMiniscopeV4.AtMegaAddress << 1;
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveID1, i2cAlias);
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveAlias1, i2cAlias);
@@ -210,6 +205,16 @@ namespace OpenEphys.Onix1
             i2cAlias = UclaMiniscopeV4.Max14574Address << 1;
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveID3, i2cAlias);
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveAlias3, i2cAlias);
+
+            // set I2C clock rate to ~100 kHz
+            var serializer = new I2CRegisterContext(device, DS90UB9x.SER_ADDR);
+            serializer.WriteByte((uint)0x11, 0x7A);
+            serializer.WriteByte((uint)0x12, 0x7A);
+        }
+
+        internal static void ConfigureSerializer(DeviceContext device)
+        {
+            DS90UB9x.Set933I2CRate(device, 80e3); //This is an arbitrary value that is proven to work, we need to test speed vs reliability vs bno sampling speed
         }
 
         internal static void ConfigureCameraSystem(DeviceContext device, UclaMiniscopeV4FramesPerSecond frameRate, bool interleaveLed)
@@ -219,9 +224,9 @@ namespace OpenEphys.Onix1
             // set up Python480
             var atMega = new I2CRegisterContext(device, UclaMiniscopeV4.AtMegaAddress);
             WriteCameraRegister(atMega, 16, 3); // Turn on PLL
-            Thread.Sleep(WaitUntilPllSettles);
+            //Thread.Sleep(WaitUntilPllSettles); //This sometimes has good effects, sometimes adverse, we just might want to redo this entire section (see issue #331 )
             WriteCameraRegister(atMega, 32, 0x7007); // Turn on clock management
-            Thread.Sleep(WaitUntilPllSettles);
+            //Thread.Sleep(WaitUntilPllSettles);
             WriteCameraRegister(atMega, 199, 666); // Defines granularity (unit = 1/PLL clock) of exposure and reset_length
             WriteCameraRegister(atMega, 200, 3300); // Set frame rate to 30 Hz
             WriteCameraRegister(atMega, 201, 3000); // Set Exposure

--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Drawing.Design;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
-using System.Threading;
 using System.Xml.Serialization;
 using Bonsai;
 

--- a/OpenEphys.Onix1/DS90UB9x.cs
+++ b/OpenEphys.Onix1/DS90UB9x.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace OpenEphys.Onix1
 {
@@ -34,12 +35,14 @@ namespace OpenEphys.Onix1
 
         internal static void Initialize933SerDesLink(DeviceContext device, DS90UB9xMode dataMode) //also valid for 913
         {
+            Thread.Sleep(100); // Empirical. The gateware seems to need some milliseconds to get i2c initialized.
+
             var deserializer = new I2CRegisterContext(device, DES_ADDR);
-            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortSel, 0x01); //Enable port 0
-            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortMode, 0x4 + (uint)dataMode); //0x4 maintains coax mode
-            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.I2CConfig, 0b01011000); //7: i2c pass all (0), 6: i2c pass (1), 5: auto_ack (0), 4: BC enable (1), 3: BC crc en (1), 2: reserved (0) 1:0: bc freq (00) 2.5Mbps
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortSel, 0x01); // Enable port 0
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortMode, 0x4 + (uint)dataMode); // 0x4 maintains coax mode
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.I2CConfig, 0b01011000); // 7: i2c pass all (0), 6: i2c pass (1), 5: auto_ack (0), 4: BC enable (1), 3: BC crc en (1), 2: reserved (0) 1:0: bc freq (00) 2.5Mbps
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SerAlias, SER_ADDR << 1);
-            //Enable backchannel GPIO on deserializer. It is then the serializer task to decide if using them or use manual output
+            // Enable backchannel GPIO on deserializer. It is then the serializer task to decide if using them or use manual output
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.GpioCtrl0, 0x10);
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.GpioCtrl0, 0x32);
         }
@@ -49,10 +52,9 @@ namespace OpenEphys.Onix1
             var serializer = new I2CRegisterContext(device, SER_ADDR);
             double SCLtimes = (1.0 / (100e-9 * i2cRate));
             uint SCLvalir = (uint)Math.Round(SCLtimes);
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.SCLHIGH, SCLvalir);
-            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.SCLLOW, SCLvalir);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.SclHigh, SCLvalir);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.SclLow, SCLvalir);
         }
-
     }
 
     enum DS90UB9xTriggerMode : uint
@@ -113,28 +115,20 @@ namespace OpenEphys.Onix1
         SlaveAlias7 = 0x6C,
     }
 
-//    enum DS90UB9xSerializerI2CRegister
-//    {
-//        GPIO10 = 0x0D,
-//        GPIO32 = 0x0E,
-//        SCLHIGH = 0x0A,
-//        SCLLOW = 0x0B
-//    }
-
     enum DS90UB933SerializerI2CRegister
     {
-        GPIO10 = 0x0D,
-        GPIO32 = 0x0E,
-        SCLHIGH = 0x11,
-        SCLLOW = 0x12
+        Gpio10 = 0x0D,
+        Gpio32 = 0x0E,
+        SclHigh = 0x11,
+        SclLow = 0x12
     }
 
     enum DS90UB953SerializerI2CRegister
     {
-        GPIO_DATA = 0x0D,
-        GPIO_IO_CTRL = 0x0E,
-        SCLHIGH = 0x0B,
-        SCLLOW = 0x0C
+        GpioData = 0x0D,
+        GpioIOControl = 0x0E,
+        SclHigh = 0x0B,
+        SclLow = 0x0C
     }
 
     enum DS90UB9xMode
@@ -149,6 +143,4 @@ namespace OpenEphys.Onix1
         Input = 0,
         Output = 1
     }  
-
-
 }

--- a/OpenEphys.Onix1/DS90UB9x.cs
+++ b/OpenEphys.Onix1/DS90UB9x.cs
@@ -35,13 +35,13 @@ namespace OpenEphys.Onix1
         internal static void Initialize933SerDesLink(DeviceContext device, DS90UB9xMode dataMode) //also valid for 913
         {
             var deserializer = new I2CRegisterContext(device, DES_ADDR);
-            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.PortSel, 0x01); //Enable port 0
-            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.PortMode, 0x4 + (uint)dataMode); //0x4 maintains coax mode
-            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.I2CConfig, 0b01011000); //7: i2c pass all (0), 6: i2c pass (1), 5: auto_ack (0), 4: BC enable (1), 3: BC crc en (1), 2: reserved (0) 1:0: bc freq (00) 2.5Mbps
-            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.SerAlias, SER_ADDR << 1);
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortSel, 0x01); //Enable port 0
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.PortMode, 0x4 + (uint)dataMode); //0x4 maintains coax mode
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.I2CConfig, 0b01011000); //7: i2c pass all (0), 6: i2c pass (1), 5: auto_ack (0), 4: BC enable (1), 3: BC crc en (1), 2: reserved (0) 1:0: bc freq (00) 2.5Mbps
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SerAlias, SER_ADDR << 1);
             //Enable backchannel GPIO on deserializer. It is then the serializer task to decide if using them or use manual output
-            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.GpioCtrl0, 0x10);
-            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.GpioCtrl0, 0x32);
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.GpioCtrl0, 0x10);
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.GpioCtrl0, 0x32);
         }
 
         internal static void Set933I2CRate(DeviceContext device, double i2cRate)

--- a/OpenEphys.Onix1/DS90UB9x.cs
+++ b/OpenEphys.Onix1/DS90UB9x.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenEphys.Onix1
+﻿using System;
+
+namespace OpenEphys.Onix1
 {
     static class DS90UB9x
     {
@@ -29,6 +31,28 @@
         // unmanaged default serializer / deserializer I2C addresses
         public const uint DES_ADDR = 0x30;
         public const uint SER_ADDR = 0x58;
+
+        internal static void Initialize933SerDesLink(DeviceContext device, DS90UB9xMode dataMode) //also valid for 913
+        {
+            var deserializer = new I2CRegisterContext(device, DES_ADDR);
+            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.PortSel, 0x01); //Enable port 0
+            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.PortMode, 0x4 + (uint)dataMode); //0x4 maintains coax mode
+            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.I2CConfig, 0b01011000); //7: i2c pass all (0), 6: i2c pass (1), 5: auto_ack (0), 4: BC enable (1), 3: BC crc en (1), 2: reserved (0) 1:0: bc freq (00) 2.5Mbps
+            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.SerAlias, SER_ADDR << 1);
+            //Enable backchannel GPIO on deserializer. It is then the serializer task to decide if using them or use manual output
+            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.GpioCtrl0, 0x10);
+            deserializer.WriteByte((uint)DS90UB934DeserializerI2CRegister.GpioCtrl0, 0x32);
+        }
+
+        internal static void Set933I2CRate(DeviceContext device, double i2cRate)
+        {
+            var serializer = new I2CRegisterContext(device, SER_ADDR);
+            double SCLtimes = (1.0 / (100e-9 * i2cRate));
+            uint SCLvalir = (uint)Math.Round(SCLtimes);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.SCLHIGH, SCLvalir);
+            serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.SCLLOW, SCLvalir);
+        }
+
     }
 
     enum DS90UB9xTriggerMode : uint
@@ -65,6 +89,12 @@
     enum DS90UB9xDeserializerI2CRegister
     {
         PortMode = 0x6D,
+        PortSel = 0x4C,
+        I2CConfig = 0x58,
+        GpioCtrl0 = 0x6E,
+        GpioCtrl1 = 0x6F,
+
+        SerAlias = 0x5C,
 
         SlaveID1 = 0x5E,
         SlaveID2 = 0x5F,
@@ -83,12 +113,28 @@
         SlaveAlias7 = 0x6C,
     }
 
-    enum DS90UB9xSerializerI2CRegister
+//    enum DS90UB9xSerializerI2CRegister
+//    {
+//        GPIO10 = 0x0D,
+//        GPIO32 = 0x0E,
+//        SCLHIGH = 0x0A,
+//        SCLLOW = 0x0B
+//    }
+
+    enum DS90UB933SerializerI2CRegister
     {
         GPIO10 = 0x0D,
         GPIO32 = 0x0E,
-        SCLHIGH = 0x0A,
-        SCLLOW = 0x0B
+        SCLHIGH = 0x11,
+        SCLLOW = 0x12
+    }
+
+    enum DS90UB953SerializerI2CRegister
+    {
+        GPIO_DATA = 0x0D,
+        GPIO_IO_CTRL = 0x0E,
+        SCLHIGH = 0x0B,
+        SCLLOW = 0x0C
     }
 
     enum DS90UB9xMode
@@ -102,5 +148,7 @@
     {
         Input = 0,
         Output = 1
-    }
+    }  
+
+
 }


### PR DESCRIPTION
This is built on top of the PassthroughTweaks branch included in #332, must only be merged after that PR is merged

Adds full powerdown and powerup sequences for python480. Tests need to be done to see if they improve reliability or image quality or if there is any noticeable performance hit at initialization.

Some custom tweaks to the init sequence are possible, they might have an effect.

Resolves #331 