### PR TITLE
Added note explaining visual flicker for U10 data in minsicope

### DIFF
--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
@@ -192,7 +192,7 @@ namespace OpenEphys.Onix1
             DS90UB9x.Initialize933SerDesLink(device, DS90UB9xMode.Raw12BitLowFrequency);
 
             var deserializer = new I2CRegisterContext(device, DS90UB9x.DES_ADDR);
-     
+
             uint i2cAlias = UclaMiniscopeV4.AtMegaAddress << 1;
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveID1, i2cAlias);
             deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveAlias1, i2cAlias);
@@ -213,14 +213,10 @@ namespace OpenEphys.Onix1
 
         internal static void ConfigureCameraSystem(DeviceContext device, UclaMiniscopeV4FramesPerSecond frameRate, bool interleaveLed)
         {
-            const int WaitUntilPllSettles = 200;
-
             // set up Python480
             var atMega = new I2CRegisterContext(device, UclaMiniscopeV4.AtMegaAddress);
             WriteCameraRegister(atMega, 16, 3); // Turn on PLL
-            //Thread.Sleep(WaitUntilPllSettles); //This sometimes has good effects, sometimes adverse, we just might want to redo this entire section (see issue #331 )
             WriteCameraRegister(atMega, 32, 0x7007); // Turn on clock management
-            //Thread.Sleep(WaitUntilPllSettles);
             WriteCameraRegister(atMega, 199, 666); // Defines granularity (unit = 1/PLL clock) of exposure and reset_length
             WriteCameraRegister(atMega, 200, 3300); // Set frame rate to 30 Hz
             WriteCameraRegister(atMega, 201, 3000); // Set Exposure

--- a/OpenEphys.Onix1/UclaMiniscopeV4CameraData.cs
+++ b/OpenEphys.Onix1/UclaMiniscopeV4CameraData.cs
@@ -25,12 +25,13 @@ namespace OpenEphys.Onix1
         /// Gets or sets the data type used to represent pixel intensity values.
         /// </summary>
         /// <remarks>
-        /// The UCLA Miniscope V4 uses a 10-bit image sensor. To capture images that use the full
-        /// ADC resolution, this value can be set to <see cref="UclaMiniscopeV4ImageDepth.U10"/>.
-        /// This comes at the cost of limited codec support and larger file sizes. If <see
-        /// cref="UclaMiniscopeV4ImageDepth.U8"/> is selected, the two least significant bits of
-        /// each pixel sample will be discarded, which greatly increases codec options and reduces
-        /// file sizes.
+        /// The UCLA Miniscope V4 uses a 10-bit image sensor. To capture images that use the full ADC
+        /// resolution, this value can be set to <see cref="UclaMiniscopeV4ImageDepth.U10"/>. This comes at
+        /// the cost of limited codec support and larger file sizes. If <see
+        /// cref="UclaMiniscopeV4ImageDepth.U8"/> is selected, the two least significant bits of each pixel
+        /// sample will be discarded, which greatly increases codec options and reduces file sizes. Further,
+        /// we have noticed that Bonsai introduces flickering in the real-time video visualizer when using
+        /// 10-bit data. These artifacts are not present in the data itself, only in the real-time visualizer.
         /// </remarks>
         [Description("The bit-depth used to represent pixel intensity values.")]
         [Category(DeviceFactory.ConfigurationCategory)]


### PR DESCRIPTION
- Added to XML comments.
- It explains that is a visualizer artifact, not corrupt data