### PR TITLE
NeuropixelsV2eHeadstage panels correctly resize with window changes

### DIFF
--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
@@ -52,10 +52,10 @@
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(747, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonCancel.Location = new System.Drawing.Point(996, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(108, 26);
+            this.buttonCancel.Size = new System.Drawing.Size(144, 32);
             this.buttonCancel.TabIndex = 6;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -63,10 +63,10 @@
             // buttonOkay
             // 
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOkay.Location = new System.Drawing.Point(635, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonOkay.Location = new System.Drawing.Point(846, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(108, 26);
+            this.buttonOkay.Size = new System.Drawing.Size(144, 32);
             this.buttonOkay.TabIndex = 5;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
@@ -79,32 +79,31 @@
             this.fileToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(863, 24);
+            this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip1.Size = new System.Drawing.Size(1151, 26);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.AutoSize = true;
-            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(863, 503);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1151, 623);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // tabControl1
@@ -112,43 +111,42 @@
             this.tabControl1.Controls.Add(this.tabPageNeuropixelsV2e);
             this.tabControl1.Controls.Add(this.tabPageBno055);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl1.Location = new System.Drawing.Point(2, 2);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControl1.Location = new System.Drawing.Point(3, 2);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(859, 463);
+            this.tabControl1.Size = new System.Drawing.Size(1145, 577);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV2e
             // 
             this.tabPageNeuropixelsV2e.Controls.Add(this.panelNeuropixelsV2e);
-            this.tabPageNeuropixelsV2e.Location = new System.Drawing.Point(4, 22);
-            this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPageNeuropixelsV2e.Location = new System.Drawing.Point(4, 25);
+            this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageNeuropixelsV2e.Name = "tabPageNeuropixelsV2e";
-            this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(851, 437);
+            this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(1137, 548);
             this.tabPageNeuropixelsV2e.TabIndex = 0;
             this.tabPageNeuropixelsV2e.Text = "NeuropixelsV2e";
             this.tabPageNeuropixelsV2e.UseVisualStyleBackColor = true;
             // 
             // panelNeuropixelsV2e
             // 
-            this.panelNeuropixelsV2e.AutoSize = true;
             this.panelNeuropixelsV2e.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelNeuropixelsV2e.Location = new System.Drawing.Point(2, 2);
-            this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
+            this.panelNeuropixelsV2e.Location = new System.Drawing.Point(3, 2);
+            this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV2e.Name = "panelNeuropixelsV2e";
-            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(847, 433);
+            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(1131, 544);
             this.panelNeuropixelsV2e.TabIndex = 0;
             // 
             // tabPageBno055
             // 
             this.tabPageBno055.Controls.Add(this.panelBno055);
-            this.tabPageBno055.Location = new System.Drawing.Point(4, 22);
-            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPageBno055.Location = new System.Drawing.Point(4, 25);
+            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageBno055.Name = "tabPageBno055";
-            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageBno055.Size = new System.Drawing.Size(851, 430);
+            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabPageBno055.Size = new System.Drawing.Size(1137, 541);
             this.tabPageBno055.TabIndex = 1;
             this.tabPageBno055.Text = "Bno055";
             this.tabPageBno055.UseVisualStyleBackColor = true;
@@ -157,10 +155,10 @@
             // 
             this.panelBno055.AutoSize = true;
             this.panelBno055.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelBno055.Location = new System.Drawing.Point(2, 2);
-            this.panelBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.panelBno055.Location = new System.Drawing.Point(3, 2);
+            this.panelBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(847, 426);
+            this.panelBno055.Size = new System.Drawing.Size(1131, 537);
             this.panelBno055.TabIndex = 0;
             // 
             // flowLayoutPanel1
@@ -171,23 +169,25 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 470);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 585);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(857, 30);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1143, 34);
             this.flowLayoutPanel1.TabIndex = 1;
             // 
             // NeuropixelsV2eHeadstageDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(863, 527);
+            this.ClientSize = new System.Drawing.Size(1151, 649);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip1);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV2eHeadstageDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Headstage Configuration";
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
@@ -195,7 +195,6 @@
             this.tableLayoutPanel1.PerformLayout();
             this.tabControl1.ResumeLayout(false);
             this.tabPageNeuropixelsV2e.ResumeLayout(false);
-            this.tabPageNeuropixelsV2e.PerformLayout();
             this.tabPageBno055.ResumeLayout(false);
             this.tabPageBno055.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);


### PR DESCRIPTION
The TableLayoutPanel was set to `AutoSize` instead of `Percent - 100%`, so when the window was made smaller it did not resize the sub-panels correctly.

Fixes #310 