### PR TITLE
Leave devices enabled or disabled as default

### DIFF
--- a/OpenEphys.Onix1/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64.cs
@@ -76,7 +76,7 @@ namespace OpenEphys.Onix1
         [Category(DevicesCategory)]
         [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the TS4231 device in the headstage-64.")]
-        public ConfigureTS4231V1 TS4231 { get; set; } = new() { Enable = false };
+        public ConfigureTS4231V1 TS4231 { get; set; } = new();
 
         /// <summary>
         /// Gets or sets onboard electrical stimulator configuration.

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1fHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1fHeadstage.cs
@@ -69,7 +69,7 @@ namespace OpenEphys.Onix1
         [Category(DevicesCategory)]
         [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the TS4231 device in the headstage-64.")]
-        public ConfigureTS4231V1 TS4231 { get; set; } = new() { Enable = false };
+        public ConfigureTS4231V1 TS4231 { get; set; } = new();
 
         internal override void UpdateDeviceNames()
         {


### PR DESCRIPTION
For `Headstage64` and `NeuropixelsV1fHeadstage`, the `TS4231` device was overridden to be disabled at the headstage level. Now it will be left at the default Enable value.

Fixes #322 