### PR TITLE
Simplify PortStatusFrame

### DIFF
--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -53,7 +53,7 @@ namespace OpenEphys.Onix1
                 context.HubState = (PassthroughState)(((int)context.HubState & ~(1 << portShift)) | passthroughState);
 
                 // leave in standard mode when finished
-                return Disposable.Create(() => context.HubState = (PassthroughState)((int)context.HubState & ~(1 << portShift))); 
+                return Disposable.Create(() => context.HubState = (PassthroughState)((int)context.HubState & ~(1 << portShift)));
             })
             .ConfigureLink(context =>
             {
@@ -76,7 +76,7 @@ namespace OpenEphys.Onix1
                 }
                 return Disposable.Create(dispose);
             })
-            .ConfigureDevice(context => 
+            .ConfigureDevice(context =>
             {
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);
@@ -117,36 +117,40 @@ namespace OpenEphys.Onix1
     /// Specifies the headstage port status codes.
     /// </summary>
     [Flags]
-    public enum PortStatusCode : byte
+    public enum PortStatusCode : ushort
     {
-        /// <summary>
-        /// Specifies that the status code should be disregarded.
-        /// </summary>
-        Invalid = 0x0,
         /// <summary>
         /// Specifies a cyclic redundancy check failure.
         /// </summary>
-        CrcError = 0x1,
+        CrcError = 0x0001,
         /// <summary>
         /// Specifies that too many devices were indicated in the hub device table.
         /// </summary>
-        TooManyDevices = 0x2,
+        TooManyDevices = 0x0002,
         /// <summary>
         /// Specifies a hub initialization error.
         /// </summary>
-        InitializationError = 0x4,
+        InitializationError = 0x0004,
         /// <summary>
         /// Specifies the receipt of a badly formatted data packet.
         /// </summary>
-        BadPacketFormat = 0x8,
+        BadPacketFormat = 0x0008,
+        /// <summary>
+        /// Specifies the SERDES forward channel lock status.
+        /// </summary>
+        SerdesLock = 0x0100,
+        /// <summary>
+        /// Gets the SERDES on-chip parity check status.
+        /// </summary>
+        SerdesParityPass = 0x0200,
     }
 
     /// <summary>
     /// Specifies the physical port that a headstage is plugged into.
     /// </summary>
     /// <remarks>
-    /// ONIX uses a common protocol to communicate with a variety of devices using the same physical connection. For this reason
-    /// lots of different headstage types can be plugged into a headstage port.
+    /// ONIX uses a common protocol to communicate with a variety of devices using the same physical
+    /// connection. For this reason lots of different headstage types can be plugged into a headstage port.
     /// </remarks>
     public enum PortName
     {

--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -125,12 +125,12 @@ namespace OpenEphys.Onix1
         SerdesLock = 0x0001,
 
         /// <summary>
-        /// Gets the SERDES on-chip parity check status.
+        /// Specifies the SERDES on-chip parity check status.
         /// </summary>
         SerdesParityPass = 0x0002,
 
         /// <summary>
-        /// Specifies a cyclic redundancy check failure.
+        /// Specifies a cyclic redundancy check failure during data transmission.
         /// </summary>
         CrcError = 0x0100,
 
@@ -148,6 +148,11 @@ namespace OpenEphys.Onix1
         /// Specifies the receipt of a badly formatted data packet.
         /// </summary>
         BadPacketFormat = 0x0800,
+
+        /// <summary>
+        /// Specifies the a cyclic redundancy check failure during hub initialization.
+        /// </summary>
+        InitializationCrcError = 0x1000,
     }
 
     /// <summary>

--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -120,29 +120,34 @@ namespace OpenEphys.Onix1
     public enum PortStatusCode : ushort
     {
         /// <summary>
-        /// Specifies a cyclic redundancy check failure.
-        /// </summary>
-        CrcError = 0x0001,
-        /// <summary>
-        /// Specifies that too many devices were indicated in the hub device table.
-        /// </summary>
-        TooManyDevices = 0x0002,
-        /// <summary>
-        /// Specifies a hub initialization error.
-        /// </summary>
-        InitializationError = 0x0004,
-        /// <summary>
-        /// Specifies the receipt of a badly formatted data packet.
-        /// </summary>
-        BadPacketFormat = 0x0008,
-        /// <summary>
         /// Specifies the SERDES forward channel lock status.
         /// </summary>
-        SerdesLock = 0x0100,
+        SerdesLock = 0x0001,
+
         /// <summary>
         /// Gets the SERDES on-chip parity check status.
         /// </summary>
-        SerdesParityPass = 0x0200,
+        SerdesParityPass = 0x0002,
+
+        /// <summary>
+        /// Specifies a cyclic redundancy check failure.
+        /// </summary>
+        CrcError = 0x0100,
+
+        /// <summary>
+        /// Specifies that too many devices were indicated in the hub device table.
+        /// </summary>
+        TooManyDevices = 0x0200,
+
+        /// <summary>
+        /// Specifies a hub initialization error.
+        /// </summary>
+        InitializationError = 0x0400,
+
+        /// <summary>
+        /// Specifies the receipt of a badly formatted data packet.
+        /// </summary>
+        BadPacketFormat = 0x0800,
     }
 
     /// <summary>

--- a/OpenEphys.Onix1/PortStatusFrame.cs
+++ b/OpenEphys.Onix1/PortStatusFrame.cs
@@ -16,26 +16,13 @@ namespace OpenEphys.Onix1
         {
             var payload = (PortStatusPayload*)frame.Data.ToPointer();
             HubClock = payload->HubClock;
-            var statusCodeValid = (payload->SerdesStatus & 0x0004) == 4;
-            StatusCode = statusCodeValid ? payload->Code : PortStatusCode.Invalid;
-            SerdesLocked = (payload->SerdesStatus & 0x0001) == 1;
-            SerdesPass = (payload->SerdesStatus & 0x0002) == 2;
+            StatusCode = payload->Code;
         }
 
         /// <summary>
         /// Gets the port status code.
         /// </summary>
         public PortStatusCode StatusCode { get; }
-
-        /// <summary>
-        /// Gets the SERDES forward channel lock status.
-        /// </summary>
-        public bool SerdesLocked { get; }
-
-        /// <summary>
-        /// Gets the SERDES on-chip parity check status.
-        /// </summary>
-        public bool SerdesPass { get; }
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
@@ -43,6 +30,5 @@ namespace OpenEphys.Onix1
     {
         public ulong HubClock;
         public PortStatusCode Code;
-        public byte SerdesStatus;
     }
 }


### PR DESCRIPTION
- Instead of making SerdesPass and SerdesLock bools next to the code word, the a codeword valid flag required to indicate if the codeword should be none, jusst make the PortStatusCode flag enum 16-bits long and contain status code, lock, and pass status together
- Needs to be tested with hardware
- Code valid flag is currently not interpreted by PortStatusCode since its not relevant for this interpretation of the low level frame data, but I need to confirm that this is not going to do something strange to the StatusCode or result in exception
- Fixes #351 