### PR TITLE
Only export ProbeInterface contact annotations if they exist

### DIFF
--- a/OpenEphys.Onix1.Design/DesignHelper.cs
+++ b/OpenEphys.Onix1.Design/DesignHelper.cs
@@ -50,7 +50,12 @@ namespace OpenEphys.Onix1.Design
 
         public static void SerializeObject(object _object, string filepath)
         {
-            var stringJson = JsonConvert.SerializeObject(_object, Formatting.Indented);
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+            };
+
+            var stringJson = JsonConvert.SerializeObject(_object, Formatting.Indented, serializerSettings);
 
             File.WriteAllText(filepath, stringJson);
         }

--- a/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
+++ b/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Bonsai.Design" Version="2.8.5" />
     <PackageReference Include="Bonsai.Design.Visualizers" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.1.1" />
+    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.2.0" />
     <PackageReference Include="ZedGraph" Version="5.1.7" />
   </ItemGroup>
 

--- a/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
@@ -15,23 +15,28 @@ namespace OpenEphys.Onix1
         /// Initializes a new instance of the <see cref="NeuropixelsV1eProbeGroup"/> class.
         /// </summary>
         public NeuropixelsV1eProbeGroup()
-            : base("probeinterface", "0.2.21",
-                  new List<Probe>()
-                  {
-                      new(ProbeNdim.Two,
-                          ProbeSiUnits.um,
-                          new ProbeAnnotations("Neuropixels 1.0", "IMEC"),
-                          new ContactAnnotations(new string[0]),
-                          DefaultContactPositions(NeuropixelsV1.ElectrodeCount),
-                          Probe.DefaultContactPlaneAxes(NeuropixelsV1.ElectrodeCount),
-                          Probe.DefaultContactShapes(NeuropixelsV1.ElectrodeCount, ContactShape.Square),
-                          Probe.DefaultSquareParams(NeuropixelsV1.ElectrodeCount, 12.0f),
-                          DefaultProbePlanarContour(),
-                          DefaultDeviceChannelIndices(NeuropixelsV1.ChannelCount, NeuropixelsV1.ElectrodeCount),
-                          Probe.DefaultContactIds(NeuropixelsV1.ElectrodeCount),
-                          DefaultShankIds(NeuropixelsV1.ElectrodeCount))
-                  }.ToArray())
+            : base("probeinterface", "0.2.21", DefaultProbes())
         {
+        }
+
+        private static Probe[] DefaultProbes()
+        {
+            var probe = new Probe[1];
+
+            probe[0] = new(ProbeNdim.Two,
+                           ProbeSiUnits.um,
+                           new ProbeAnnotations("Neuropixels 1.0", "IMEC"),
+                           null,
+                           DefaultContactPositions(NeuropixelsV1.ElectrodeCount),
+                           Probe.DefaultContactPlaneAxes(NeuropixelsV1.ElectrodeCount),
+                           Probe.DefaultContactShapes(NeuropixelsV1.ElectrodeCount, ContactShape.Square),
+                           Probe.DefaultSquareParams(NeuropixelsV1.ElectrodeCount, 12.0f),
+                           DefaultProbePlanarContour(),
+                           DefaultDeviceChannelIndices(NeuropixelsV1.ChannelCount, NeuropixelsV1.ElectrodeCount),
+                           Probe.DefaultContactIds(NeuropixelsV1.ElectrodeCount),
+                           DefaultShankIds(NeuropixelsV1.ElectrodeCount));
+
+            return probe;
         }
 
         /// <summary>

--- a/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
@@ -24,23 +24,28 @@ namespace OpenEphys.Onix1
         /// the default settings for all contacts, including their positions, shapes, and IDs.
         /// </remarks>
         public NeuropixelsV2eProbeGroup()
-            : base("probeinterface", "0.2.21",
-                  new List<Probe>()
-                  {
-                      new(ProbeNdim.Two,
-                          ProbeSiUnits.um,
-                          new ProbeAnnotations("Neuropixels 2.0 - Multishank", "IMEC"),
-                          new ContactAnnotations(new string[0]),
-                          DefaultContactPositions(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
-                          Probe.DefaultContactPlaneAxes(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
-                          Probe.DefaultContactShapes(NeuropixelsV2.ElectrodePerShank * numberOfShanks, ContactShape.Square),
-                          Probe.DefaultSquareParams(NeuropixelsV2.ElectrodePerShank * numberOfShanks, 12.0f),
-                          DefaultProbePlanarContourQuadShank(),
-                          DefaultDeviceChannelIndices(NeuropixelsV2.ChannelCount, NeuropixelsV2.ElectrodePerShank * numberOfShanks),
-                          Probe.DefaultContactIds(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
-                          DefaultShankIds(NeuropixelsV2.ElectrodePerShank * numberOfShanks))
-                  })
+            : base("probeinterface", "0.2.21", DefaultProbes())
         {
+        }
+
+        private static Probe[] DefaultProbes()
+        {
+            var probe = new Probe[1];
+
+            probe[0] = new(ProbeNdim.Two,
+                           ProbeSiUnits.um,
+                           new ProbeAnnotations("Neuropixels 2.0 - Multishank", "IMEC"),
+                           null,
+                           DefaultContactPositions(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
+                           Probe.DefaultContactPlaneAxes(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
+                           Probe.DefaultContactShapes(NeuropixelsV2.ElectrodePerShank * numberOfShanks, ContactShape.Square),
+                           Probe.DefaultSquareParams(NeuropixelsV2.ElectrodePerShank * numberOfShanks, 12.0f),
+                           DefaultProbePlanarContourQuadShank(),
+                           DefaultDeviceChannelIndices(NeuropixelsV2.ChannelCount, NeuropixelsV2.ElectrodePerShank * numberOfShanks),
+                           Probe.DefaultContactIds(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
+                           DefaultShankIds(NeuropixelsV2.ElectrodePerShank * numberOfShanks));
+
+            return probe;
         }
 
         /// <summary>

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -13,6 +13,6 @@
     <PackageReference Include="Bonsai.Core" Version="2.8.5" />
     <PackageReference Include="clroni" Version="6.1.2" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
-    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.1.1" />
+    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.2.0" />
   </ItemGroup>
 </Project>

--- a/OpenEphys.Onix1/Rhs2116ProbeGroup.cs
+++ b/OpenEphys.Onix1/Rhs2116ProbeGroup.cs
@@ -20,37 +20,41 @@ namespace OpenEphys.Onix1
         /// the default settings for two probes, including the contact positions, shapes, and IDs.
         /// </remarks>
         public Rhs2116ProbeGroup()
-            : base("probeinterface", "0.2.21",
-                new List<Probe>()
-                {
-                    new(
-                        ProbeNdim.Two,
-                        ProbeSiUnits.mm,
-                        new ProbeAnnotations("Rhs2116A", ""),
-                        new ContactAnnotations(new string[0]),
-                        DefaultContactPositions(DefaultNumberOfChannelsPerProbe, 0),
-                        Probe.DefaultContactPlaneAxes(DefaultNumberOfChannelsPerProbe),
-                        Probe.DefaultContactShapes(DefaultNumberOfChannelsPerProbe, ContactShape.Circle),
-                        Probe.DefaultCircleParams(DefaultNumberOfChannelsPerProbe, 0.3f),
-                        DefaultProbePlanarContour(0),
-                        Probe.DefaultDeviceChannelIndices(DefaultNumberOfChannelsPerProbe, 0),
-                        Probe.DefaultContactIds(DefaultNumberOfChannelsPerProbe),
-                        Probe.DefaultShankIds(DefaultNumberOfChannelsPerProbe)),
-                    new(
-                        ProbeNdim.Two,
-                        ProbeSiUnits.mm,
-                        new ProbeAnnotations("Rhs2116B", ""),
-                        new ContactAnnotations(new string[0]),
-                        DefaultContactPositions(DefaultNumberOfChannelsPerProbe, 1),
-                        Probe.DefaultContactPlaneAxes(DefaultNumberOfChannelsPerProbe),
-                        Probe.DefaultContactShapes(DefaultNumberOfChannelsPerProbe, ContactShape.Circle),
-                        Probe.DefaultCircleParams(DefaultNumberOfChannelsPerProbe, 0.3f),
-                        DefaultProbePlanarContour(1),
-                        Probe.DefaultDeviceChannelIndices(DefaultNumberOfChannelsPerProbe, DefaultNumberOfChannelsPerProbe),
-                        Probe.DefaultContactIds(DefaultNumberOfChannelsPerProbe),
-                        Probe.DefaultShankIds(DefaultNumberOfChannelsPerProbe))
-                }.ToArray())
+            : base("probeinterface", "0.2.21", DefaultProbes())
         {
+        }
+
+        private static Probe[] DefaultProbes()
+        {
+            var probe = new Probe[2];
+
+            probe[0] = new(ProbeNdim.Two,
+                           ProbeSiUnits.mm,
+                           new ProbeAnnotations("Rhs2116A", ""),
+                           null,
+                           DefaultContactPositions(DefaultNumberOfChannelsPerProbe, 0),
+                           Probe.DefaultContactPlaneAxes(DefaultNumberOfChannelsPerProbe),
+                           Probe.DefaultContactShapes(DefaultNumberOfChannelsPerProbe, ContactShape.Circle),
+                           Probe.DefaultCircleParams(DefaultNumberOfChannelsPerProbe, 0.3f),
+                           DefaultProbePlanarContour(0),
+                           Probe.DefaultDeviceChannelIndices(DefaultNumberOfChannelsPerProbe, 0),
+                           Probe.DefaultContactIds(DefaultNumberOfChannelsPerProbe),
+                           Probe.DefaultShankIds(DefaultNumberOfChannelsPerProbe));
+
+            probe[1] = new(ProbeNdim.Two,
+                           ProbeSiUnits.mm,
+                           new ProbeAnnotations("Rhs2116B", ""),
+                           null,
+                           DefaultContactPositions(DefaultNumberOfChannelsPerProbe, 1),
+                           Probe.DefaultContactPlaneAxes(DefaultNumberOfChannelsPerProbe),
+                           Probe.DefaultContactShapes(DefaultNumberOfChannelsPerProbe, ContactShape.Circle),
+                           Probe.DefaultCircleParams(DefaultNumberOfChannelsPerProbe, 0.3f),
+                           DefaultProbePlanarContour(1),
+                           Probe.DefaultDeviceChannelIndices(DefaultNumberOfChannelsPerProbe, DefaultNumberOfChannelsPerProbe),
+                           Probe.DefaultContactIds(DefaultNumberOfChannelsPerProbe),
+                           Probe.DefaultShankIds(DefaultNumberOfChannelsPerProbe));
+
+            return probe;
         }
 
         /// <summary>


### PR DESCRIPTION
- Set the property to null as the default, and ensure that the serializer settings include `NullValueHandling.Ignore`
- Update `OpenEphys.ProbeInterface.NET` to 0.2.0