### PR TITLE
Hide `PolledBno055` properties when embedded in a headstage

### DIFF
--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageEditor.cs
@@ -23,7 +23,7 @@ namespace OpenEphys.Onix1.Design
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
-                        configureHeadstage.Bno055.Enable = editorDialog.DialogBno055.ConfigureNode.Enable;
+                        configureHeadstage.Bno055.Enable = editorDialog.DialogBno055.Bno055.Enable;
 
                         configureHeadstage.NeuropixelsV1e.AdcCalibrationFile = editorDialog.DialogNeuropixelsV1e.ConfigureNode.AdcCalibrationFile;
                         configureHeadstage.NeuropixelsV1e.GainCalibrationFile = editorDialog.DialogNeuropixelsV1e.ConfigureNode.GainCalibrationFile;

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
@@ -31,7 +31,7 @@ namespace OpenEphys.Onix1.Design
         /// </summary>
         /// <param name="configureNeuropixelsV1A">Configuration settings for <see cref="ConfigureNeuropixelsV1f"/> A.</param>
         /// <param name="configureNeuropixelsV1B">Configuration settings for <see cref="ConfigureNeuropixelsV1f"/> B</param>
-        /// <param name="configureBno055">Configuration settings for a <see cref="PolledBno055"/>.</param>
+        /// <param name="configureBno055">Configuration settings for a <see cref="Onix1.PolledBno055"/>.</param>
         public NeuropixelsV1fHeadstageDialog(ConfigureNeuropixelsV1f configureNeuropixelsV1A, ConfigureNeuropixelsV1f configureNeuropixelsV1B, ConfigureBno055 configureBno055)
         {
             InitializeComponent();

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageEditor.cs
@@ -23,7 +23,7 @@ namespace OpenEphys.Onix1.Design
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
-                        configureV2eHeadstage.Bno055.Enable = editorDialog.DialogBno055.ConfigureNode.Enable;
+                        configureV2eHeadstage.Bno055.Enable = editorDialog.DialogBno055.Bno055.Enable;
 
                         configureV2eHeadstage.NeuropixelsV2e.Enable = editorDialog.DialogNeuropixelsV2e.ConfigureNode.Enable;
                         configureV2eHeadstage.NeuropixelsV2e.ProbeConfigurationA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationA;
@@ -40,7 +40,7 @@ namespace OpenEphys.Onix1.Design
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
-                        configureV2eBetaHeadstage.Bno055.Enable = editorDialog.DialogBno055.ConfigureNode.Enable;
+                        configureV2eBetaHeadstage.Bno055.Enable = editorDialog.DialogBno055.Bno055.Enable;
 
                         configureV2eBetaHeadstage.NeuropixelsV2eBeta.Enable = editorDialog.DialogNeuropixelsV2e.ConfigureNode.Enable;
                         configureV2eBetaHeadstage.NeuropixelsV2eBeta.ProbeConfigurationA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationA;

--- a/OpenEphys.Onix1.Design/PolledBno055Dialog.cs
+++ b/OpenEphys.Onix1.Design/PolledBno055Dialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace OpenEphys.Onix1.Design
 {
@@ -11,23 +12,32 @@ namespace OpenEphys.Onix1.Design
         /// Gets or sets the <see cref="ConfigurePolledBno055"/> object attached to
         /// the property grid.
         /// </summary>
-        public ConfigurePolledBno055 ConfigureNode
-        {
-            get => (ConfigurePolledBno055)propertyGrid.SelectedObject;
-            set => propertyGrid.SelectedObject = value;
-        }
+        internal InternalPolledBno055 Bno055 { get; set; }
 
         /// <summary>
         /// Initializes a new <see cref="PolledBno055Dialog"/> instance with the given
         /// <see cref="ConfigurePolledBno055"/> object.
         /// </summary>
         /// <param name="configureNode">A <see cref="ConfigurePolledBno055"/> object that contains configuration settings.</param>
-        public PolledBno055Dialog(ConfigurePolledBno055 configureNode)
+        /// <param name="allFieldsEditable">
+        /// Boolean that is true if this <see cref="ConfigurePolledBno055"/> should be allowed to 
+        /// edit the <see cref="ConfigurePolledBno055.AxisMap"/> and  <see cref="ConfigurePolledBno055.AxisSign"/>
+        /// properties. It is set to false when called from headstage editors.</param>
+        public PolledBno055Dialog(ConfigurePolledBno055 configureNode, bool allFieldsEditable = false)
         {
             InitializeComponent();
             Shown += FormShown;
 
-            ConfigureNode = new(configureNode);
+            Bno055 = new(configureNode);
+
+            if (allFieldsEditable)
+            {
+                propertyGrid.SelectedObject = Bno055.Bno055;
+            }
+            else
+            {
+                propertyGrid.SelectedObject = Bno055;
+            }
         }
 
         private void FormShown(object sender, EventArgs e)
@@ -40,5 +50,26 @@ namespace OpenEphys.Onix1.Design
                 MaximumSize = new System.Drawing.Size(0, 0);
             }
         }
+    }
+
+    internal class InternalPolledBno055
+    {
+        [TypeConverter(typeof(PolledBno055SingleDeviceFactoryConverter))]
+        [Category(DeviceFactory.ConfigurationCategory)]
+        public ConfigurePolledBno055 Bno055 { get; set; }
+
+        public InternalPolledBno055(ConfigurePolledBno055 polledBno)
+        {
+            Bno055 = polledBno;
+        }
+
+        [Browsable(false)]
+        public bool Enable { get => Bno055.Enable; }
+
+        [Browsable(false)]
+        public string DeviceName { get => Bno055.DeviceName; }
+
+        [Browsable(false)]
+        public uint DeviceAddress { get => Bno055.DeviceAddress; }
     }
 }

--- a/OpenEphys.Onix1.Design/PolledBno055Editor.cs
+++ b/OpenEphys.Onix1.Design/PolledBno055Editor.cs
@@ -14,13 +14,15 @@ namespace OpenEphys.Onix1.Design
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
                 if (editorState != null && !editorState.WorkflowRunning && component is ConfigurePolledBno055 configureBno055)
                 {
-                    using var editorDialog = new PolledBno055Dialog(configureBno055);
+                    using var editorDialog = new PolledBno055Dialog(configureBno055, true);
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
-                        configureBno055.Enable = editorDialog.ConfigureNode.Enable;
-                        configureBno055.DeviceAddress = editorDialog.ConfigureNode.DeviceAddress;
-                        configureBno055.DeviceName = editorDialog.ConfigureNode.DeviceName;
+                        configureBno055.Enable = editorDialog.Bno055.Enable;
+                        configureBno055.DeviceAddress = editorDialog.Bno055.DeviceAddress;
+                        configureBno055.DeviceName = editorDialog.Bno055.DeviceName;
+                        configureBno055.AxisMap = editorDialog.Bno055.Bno055.AxisMap;
+                        configureBno055.AxisSign = editorDialog.Bno055.Bno055.AxisSign;
 
                         return true;
                     }

--- a/OpenEphys.Onix1/ConfigurePolledBno055.cs
+++ b/OpenEphys.Onix1/ConfigurePolledBno055.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpenEphys.Onix1.Design")]
 
 namespace OpenEphys.Onix1
 {


### PR DESCRIPTION
Utilize the same type converter from the main library to hide `AxisMap` and `AxisSign` from the property grid when opened in dialogs. This is accomplished by creating an internal class that is only used to wrap the `ConfigurePolledBno055` class in a public get / set so that it acts like an expandable object.

These hidden properties are editable from the `ConfigurePolledBno055` operator, since right now I don't know how to distinguish a truly standalone `PolledBno055` from one that is part of a headstage, unless it is called from the headstage editor (i.e., `ConfigureNeuropixelsV1eHeadstage`). 

Fixes #314 