### PR TITLE
Edits to XML comments: issues 355-357

### DIFF
--- a/OpenEphys.Onix1/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64.cs
@@ -8,9 +8,9 @@ namespace OpenEphys.Onix1
     /// Configures an ONIX headstage-64 on the specified port.
     /// </summary>
     /// <remarks>
-    /// Headstage-64 is a 1.5g serialized, multifunction headstage for small animals. This headstage is
-    /// designed to function with passive probes such as tetrode microdrives, silicon arrays, EEG/ECOG arrays,
-    /// etc. It provides the following features:
+    /// Headstage-64 is a 1.5g serialized, multifunction headstage designed to function with passive
+    /// probes such as tetrode microdrives, silicon arrays, EEG/ECOG arrays, etc. It provides the
+    /// following features:
     /// <list type="bullet">
     /// <item><description>64 analog ephys channels and 3 auxiliary channels sampled at 30 kHz per
     /// channel.</description></item>
@@ -32,9 +32,10 @@ namespace OpenEphys.Onix1
         /// Initializes a new instance of the <see cref="ConfigureHeadstage64"/> class.
         /// </summary>
         /// <remarks>
-        /// Headstage-64 is a 1.5g serialized, multifunction headstage for small animals. This headstage is designed to function
-        /// with tetrode microdrives. Alternatively it can be used with other passive probes (e.g. silicon arrays, EEG/ECOG arrays,
-        /// etc.). It provides the following features on the headstage:
+        /// Headstage-64 is a 1.5g serialized, multifunction headstage designed to function with
+        /// tetrode microdrives. Alternatively it can be used with other passive probes (e.g.
+        /// silicon arrays, EEG/ECOG arrays, etc.). It provides the following features on the
+        /// headstage:
         /// <list type="bullet">
         /// <item><description>64 analog ephys channels and 3 auxiliary channels sampled at 30 kHz per channel.</description></item>
         /// <item><description>A Bno055 9-axis IMU for real-time, 3D orientation tracking.</description></item>

--- a/OpenEphys.Onix1/ConfigureHeadstageNric1384.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNric1384.cs
@@ -8,10 +8,10 @@ namespace OpenEphys.Onix1
     /// Configures a Nric1384 headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The Nric1384 Headstage is a 2.5g serialized, multifunction headstage for small animals built around the
-    /// IMEC Nric1384 bioacquisition chip. This headstage is designed to function with passive probes of the
-    /// user's choosing (e.g. silicon probe arrays, high-density tetrode drives, etc). It provides the
-    /// following features:
+    /// The Nric1384 Headstage is a 2.5g serialized, multifunction headstage built around the IMEC
+    /// Nric1384 bioacquisition chip and designed to function with passive probes of
+    /// the user's choosing (e.g. silicon probe arrays, high-density tetrode drives, etc). It
+    /// provides the following features:
     /// <list type="bullet">
     /// <item><description>384 analog ephys channels sampled at 30 kHz per channel and exposed via an array of
     /// 12x ultra-high density Molex 203390-0323 quad-row connectors. </description></item>

--- a/OpenEphys.Onix1/ConfigureHeadstageRhs2116.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageRhs2116.cs
@@ -8,10 +8,10 @@ namespace OpenEphys.Onix1
     /// Configures an ONIX Rhs2116 Headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The Rhs2116 Headstage is a serialized headstage for small animals with 32 bi-directional channels 
-    /// which each can be used to deliver electrical stimuli. The Rhs2116 Headstage can be used with passive 
-    /// probes (e.g. silicon arrays, EEG/ECOG arrays, etc) using a 36-Channel Omnetics EIB. It provides the
-    /// following features:
+    /// The Rhs2116 Headstage is a serialized headstage with 32 bi-directional channels that are
+    /// independently configurable to record electrophysiological signals or deliver electrical
+    /// stimuli. The Rhs2116 Headstage can be used with passive probes (e.g. silicon arrays,
+    /// EEG/ECOG arrays, etc) using a 36-Channel Omnetics EIB. It provides the following features:
     /// <list type="bullet">
     /// <item><description>Two, synchronized Rhs2116 ICs for a combined 32 bidirectional ephys channels.</description></item>
     /// <item><description>Real-time control of stimulation sequences.</description></item>

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1eHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1eHeadstage.cs
@@ -8,8 +8,8 @@ namespace OpenEphys.Onix1
     /// Configures a NeuropixelsV1e headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The NeuropixelsV1e Headstage is a 0.68g serialized, multifunction headstage for small animals. This
-    /// headstage is designed to function with IMEC Neuropixels V1 probes. It provides the following features:
+    /// The NeuropixelsV1e Headstage is a 0.68g serialized, multifunction headstage designed to
+    /// function with IMEC Neuropixels V1 probes. It provides the following features:
     /// <list type="bullet">
     /// <item><description>Support for a single IMEC Neuropixels 1.0 probe that features:
     /// <list type="bullet">

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1fHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1fHeadstage.cs
@@ -8,8 +8,8 @@ namespace OpenEphys.Onix1
     /// Configures a NeuropixelsV1f headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The NeuropixelsVf Headstage is a 1g serialized, multifunction headstage for small animals. This
-    /// headstage is designed to function with IMEC Neuropixels V1 probes. It provides the following features:
+    /// The NeuropixelsVf Headstage is a 1g serialized, multifunction headstage designed to function
+    /// with IMEC Neuropixels V1 probes. It provides the following features:
     /// <list type="bullet">
     /// <item><description>Support for a 2x IMEC Neuropixels 1.0 probes, each of which features:
     /// <list type="bullet">

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1fHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1fHeadstage.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// The NeuropixelsVf Headstage is a 1g serialized, multifunction headstage designed to function
     /// with IMEC Neuropixels V1 probes. It provides the following features:
     /// <list type="bullet">
-    /// <item><description>Support for a 2x IMEC Neuropixels 1.0 probes, each of which features:
+    /// <item><description>Support for up to 2x IMEC Neuropixels 1.0 probes, each of which features:
     /// <list type="bullet">
     /// <item><description>A single 1 cm long shank probe with a 70 x 24 µm shank cross-section.</description></item>
     /// <item><description>960-electrode low-impedance TiN electrodes.</description></item>

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -7,7 +7,7 @@ namespace OpenEphys.Onix1
     /// Configures a NeuropixelsV2eBeta headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The NeuropixelsV2e-Beta Headstage is a 0.64g serialized, multifunction headstage designed to
+    /// The NeuropixelsV2eBeta Headstage is a 0.64g serialized, multifunction headstage designed to
     /// function with IMEC Neuropixels V2Beta probes. It provides the following features:
     /// <list type="bullet">
     /// <item><description>Support for dual IMEC Neuropixels 2.0-Beta probes, each of which features:

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -7,8 +7,8 @@ namespace OpenEphys.Onix1
     /// Configures a NeuropixelsV2eBeta headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The NeuropixelsV2e-Beta Headstage is a 0.64g serialized, multifunction headstage for small animals. This
-    /// headstage is designed to function with IMEC Neuropixels V2Beta probes. It provides the following features:
+    /// The NeuropixelsV2e-Beta Headstage is a 0.64g serialized, multifunction headstage designed to
+    /// function with IMEC Neuropixels V2Beta probes. It provides the following features:
     /// <list type="bullet">
     /// <item><description>Support for dual IMEC Neuropixels 2.0-Beta probes, each of which features:
     /// <list type="bullet">

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eHeadstage.cs
@@ -7,8 +7,8 @@ namespace OpenEphys.Onix1
     /// Configures a NeuropixelsV2e headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The NeuropixelsV2e Headstage is a 0.64g serialized, multifunction headstage for small animals. This
-    /// headstage is designed to function with IMEC Neuropixels V2 probes. It provides the following features:
+    /// The NeuropixelsV2e Headstage is a 0.64g serialized, multifunction headstage designed to
+    /// function with IMEC Neuropixels V2 probes. It provides the following features:
     /// <list type="bullet">
     /// <item><description>Support for dual IMEC Neuropixels 2.0 probes, each of which features:
     /// <list type="bullet">

--- a/OpenEphys.Onix1/Rhd2164Data.cs
+++ b/OpenEphys.Onix1/Rhd2164Data.cs
@@ -10,13 +10,14 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of electrophysiology data frames from an Intan Rhd2164 bioacquisition chip.
+    /// Produces a sequence of <see cref="Rhd2164DataFrame"/> objects with data from an Intan
+    /// Rhd2164 bioacquisition chip.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
     /// cref="ConfigureRhd2164"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
-    [Description("Produces a sequence of electrophysiology data frames from an Intan Rhd2164 bioacquisition chip.")]
+    [Description("Produces a sequence of Rhd2164DataFrame objects with data from an Intan Rhd2164 bioacquisition chip.")]
     public class Rhd2164Data : Source<Rhd2164DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>

--- a/OpenEphys.Onix1/Rhs2116Data.cs
+++ b/OpenEphys.Onix1/Rhs2116Data.cs
@@ -10,12 +10,14 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of <see cref="Rhs2116DataFrame"/> objects from a NeuropixelsV2e headstage.
+    /// Produces a sequence of <see cref="Rhs2116DataFrame"/> objects with data from an Intan
+    /// Rhs2116 bioacquisition chip.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
     /// cref="ConfigureRhs2116"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
+    [Description("Produces a sequence of Rhs2116DataFrame objects with data from an Intan Rhs2116 bioacquisition chip.")]
     public class Rhs2116Data : Source<Rhs2116DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>

--- a/OpenEphys.Onix1/Rhs2116DataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116DataFrame.cs
@@ -29,9 +29,9 @@ namespace OpenEphys.Onix1
         /// Each row corresponds to a channel. Each column corresponds to a sample whose time is indicated by
         /// the corresponding element <see cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>.
         /// Samples are 16-bits each and are represented using unsigned 16-bit integers. To convert to
-        /// micro-volts, the following equation can be used:
+        /// microvolts, the following equation can be used:
         /// <code>
-        /// V_electrode (uV) = 0.195 µV × (ADC result – 32768)
+        /// V_electrode (µV) = 0.195 µV × (ADC result – 32768)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }
@@ -43,7 +43,7 @@ namespace OpenEphys.Onix1
         /// Each row corresponds to a channel. Each column corresponds to a sample whose time is indicated by
         /// the corresponding element <see cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>.
         /// Samples are 10-bits each and are represented using unsigned 16-bit integers. To convert to
-        /// micro-volts, the following equation can be used:
+        /// millivolts, the following equation can be used:
         /// <code>
         /// V_electrode (mV) = -19.23 mV × (ADC result – 512)
         /// </code>


### PR DESCRIPTION
I came across typos mentioned in issues 355 & 356 a few times while working on the docs, and they bothered me each time so I decided to quickly take care of all three of these issues related to typos in XML comments:
- Resolve #355 
- Resolve #356 
- Resolve #357

I also figure it would fit in well with the other typo fix if we end up doing a [0.4.2 release](https://github.com/open-ephys/bonsai-onix1/commit/7ab44ad84d890d2d1a133d53c26671e3807987bf)

---

https://github.com/open-ephys/bonsai-onix1/issues/357#issuecomment-2455037809:
> Remove small animals as well.

The above quote is in relation to the ConfigureHeadstageRhs2116 remarks. I took that feedback and applied it to the remarks of all `ConfigureXyzHeadstage` classes.

---

The following list describes all the changes made in 652784a:
- remove hyphens used for unit prefixes
- "microvolts" -> "millivolts" for DCData
- "NeuropixelsV2e headstage" to "Intan Rhs2116 bioacquisition chip" in Rhs2116Data  (like how it is in Rhd2164Data summary)
- add "\<see cref="Rhd2164DataFrame"/\>" in Rhd2164Data summary (like how it is in Rhs2116Data summary)
- add description attribute to Rhs2116Data class
- remove "for small animals" and combine 1st & 2nd sentences in remarks for all ConfigureXyzHeadstage classes