### PR TITLE
Fix ConfigurePolledBno055 operation mode

### DIFF
--- a/OpenEphys.Onix1/ConfigurePolledBno055.cs
+++ b/OpenEphys.Onix1/ConfigurePolledBno055.cs
@@ -119,7 +119,7 @@ namespace OpenEphys.Onix1
             i2c.WriteByte(0x3F, 0x00); // Internal oscillator
             i2c.WriteByte(0x41, (uint)AxisMap);  // Axis map config
             i2c.WriteByte(0x42, (uint)AxisSign); // Axis sign
-            i2c.WriteByte(0x3D, 0x0C); // Operation mode is NOF
+            i2c.WriteByte(0x3D, 0x0C); // Operation mode is NDOF
         }
     }
 

--- a/OpenEphys.Onix1/ConfigurePolledBno055.cs
+++ b/OpenEphys.Onix1/ConfigurePolledBno055.cs
@@ -119,7 +119,7 @@ namespace OpenEphys.Onix1
             i2c.WriteByte(0x3F, 0x00); // Internal oscillator
             i2c.WriteByte(0x41, (uint)AxisMap);  // Axis map config
             i2c.WriteByte(0x42, (uint)AxisSign); // Axis sign
-            i2c.WriteByte(0x3D, 8); // Operation mode is NOF
+            i2c.WriteByte(0x3D, 0x0C); // Operation mode is NOF
         }
     }
 


### PR DESCRIPTION
- It was incorrectly configured in IMU mode (which only uses gyroscope and accelerometer). Now its correctly configured to use magnetometer in NDOF mode, which should reduce drift.
- Fixes #388 
- Fixes #378