### PR TITLE
Rhs2116 step size algorithm now accounts for requested amplitude

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.4.2</VersionPrefix>
+    <VersionPrefix>0.4.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -1078,7 +1078,7 @@ namespace OpenEphys.Onix1.Design
                 return true;
             }
 
-            StepSize = Rhs2116StimulusSequence.GetStepSizeWithMinError(validStepSizes, Sequence.Stimuli, Sequence.CurrentStepSize);
+            StepSize = Rhs2116StimulusSequence.GetStepSizeWithMinError(validStepSizes, Sequence.Stimuli, amplitude, Sequence.CurrentStepSize);
             textBoxStepSize.Text = GetStepSizeStringuA(StepSize);
 
             return true;

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -1020,8 +1020,9 @@ namespace OpenEphys.Onix1.Design
             {
                 if (!UpdateStepSizeFromAmplitude(result))
                 {
-                    string text = result > MaxAmplitudeuA ? MaxAmplitudeuA.ToString() : "0";
-                    byte tag = result > MaxAmplitudeuA ? (byte)255 : (byte)0;
+                    string text = "0";
+                    byte tag = 0;
+                    textBox.Text = "";
 
                     UpdateAmplitudeTextBoxes(textBox, text, tag);
 

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -28,9 +28,6 @@ namespace OpenEphys.Onix1.Design
 
         internal readonly Rhs2116ChannelConfigurationDialog ChannelDialog;
 
-        const double MinAmplitudeuA = 0.01; // NB: Minimum possible amplitude is 10 nA (0.01 µA)
-        const double MaxAmplitudeuA = 2550; // NB: Maximum possible amplitude is 2550000 nA (2550 µA)
-
         /// <summary>
         /// Opens a dialog allowing for easy changing of stimulus sequence parameters, with visual feedback on what the resulting stimulus sequence looks like.
         /// </summary>
@@ -1052,19 +1049,9 @@ namespace OpenEphys.Onix1.Design
         {
             const string InvalidAmplitudeString = "Invalid Amplitude";
 
-            if (amplitude > MaxAmplitudeuA)
-            {
-                MessageBox.Show($"Warning: Amplitude is too high. Amplitude must be less than or equal to {MaxAmplitudeuA} µA.", InvalidAmplitudeString);
-                return false;
-            }
-            else if (amplitude < 0)
+            if (amplitude < 0)
             {
                 MessageBox.Show("Warning: Amplitude cannot be a negative value.", InvalidAmplitudeString);
-                return false;
-            }
-            else if (amplitude < MinAmplitudeuA && amplitude >= 0)
-            {
-                MessageBox.Show($"Amplitude is too small to be resolved. Amplitude must be greater than or equal to {MinAmplitudeuA} µA.", InvalidAmplitudeString);
                 return false;
             }
 

--- a/OpenEphys.Onix1/Rhs2116StimulusSequence.cs
+++ b/OpenEphys.Onix1/Rhs2116StimulusSequence.cs
@@ -230,7 +230,7 @@ namespace OpenEphys.Onix1
             }
         }
 
-        internal static Rhs2116StepSize GetStepSizeWithMinError(IEnumerable<Rhs2116StepSize> stepSizes, Rhs2116Stimulus[] stimuli, Rhs2116StepSize currentStepSize)
+        internal static Rhs2116StepSize GetStepSizeWithMinError(IEnumerable<Rhs2116StepSize> stepSizes, Rhs2116Stimulus[] stimuli, double requestedAmplitude, Rhs2116StepSize currentStepSize)
         {
             var numberOfStepSizes = stepSizes.Count();
             var maxError = new List<double>(numberOfStepSizes);
@@ -263,6 +263,12 @@ namespace OpenEphys.Onix1
 
                     maxError[s] = Math.Max(maxError[s], Math.Max(anodicError, cathodicError));
                 }
+
+                var requestedError = requestedAmplitude < stepSizesuA[s] || requestedAmplitude > stepSizesuA[s] * 255 ?
+                        double.PositiveInfinity :
+                        CalculateError(requestedAmplitude, stepSizesuA[s]);
+
+                maxError[s] = Math.Max(maxError[s], requestedError);
             }
 
             if (maxError.Distinct().Count() == 1)

--- a/OpenEphys.Onix1/Rhs2116StimulusSequence.cs
+++ b/OpenEphys.Onix1/Rhs2116StimulusSequence.cs
@@ -239,7 +239,9 @@ namespace OpenEphys.Onix1
 
             static double CalculateError(double amplitude, double stepSizeuA)
             {
-                return Math.Abs((amplitude - (stepSizeuA * Math.Round(amplitude / stepSizeuA))) / amplitude);
+                return Math.Round(amplitude / stepSizeuA) > 0 && Math.Round(amplitude / stepSizeuA) <= 255
+                    ? Math.Abs((amplitude - (stepSizeuA * Math.Round(amplitude / stepSizeuA))) / amplitude)
+                    : double.PositiveInfinity;
             }
 
             for (int s = 0; s < numberOfStepSizes; s++)
@@ -253,20 +255,13 @@ namespace OpenEphys.Onix1
                     var anodicAmp = stimuli[c].AnodicAmplitudeSteps * currentStepSizeuA;
                     var cathodicAmp = stimuli[c].CathodicAmplitudeSteps * currentStepSizeuA;
 
-                    var anodicError = anodicAmp < stepSizesuA[s] || anodicAmp > stepSizesuA[s] * 255 ?
-                        double.PositiveInfinity :
-                        CalculateError(anodicAmp, stepSizesuA[s]);
-
-                    var cathodicError = cathodicAmp < stepSizesuA[s] || cathodicAmp > stepSizesuA[s] * 255 ?
-                        double.PositiveInfinity :
-                        CalculateError(cathodicAmp, stepSizesuA[s]);
+                    var anodicError = CalculateError(anodicAmp, stepSizesuA[s]);
+                    var cathodicError = CalculateError(cathodicAmp, stepSizesuA[s]);
 
                     maxError[s] = Math.Max(maxError[s], Math.Max(anodicError, cathodicError));
                 }
 
-                var requestedError = requestedAmplitude < stepSizesuA[s] || requestedAmplitude > stepSizesuA[s] * 255 ?
-                        double.PositiveInfinity :
-                        CalculateError(requestedAmplitude, stepSizesuA[s]);
+                var requestedError = CalculateError(requestedAmplitude, stepSizesuA[s]);
 
                 maxError[s] = Math.Max(maxError[s], requestedError);
             }
@@ -277,7 +272,20 @@ namespace OpenEphys.Onix1
                 return stepSizes.OrderBy(s => Math.Abs(GetStepSizeuA(s) - currentStepSizeuA)).First();
             }
 
-            var optimalStepIndex = maxError.IndexOf(maxError.Min());
+            var minimumError = maxError.Min();
+            var optimalStepIndex = maxError
+                .Select((e, ind) =>
+                {
+                    if (e == minimumError)
+                    {
+                        return (Min: true, Ind: ind);
+                    }
+                    return (Min: false, Ind: -1);
+                })
+                .Where(e => e.Min)
+                .OrderBy(e => Math.Abs(GetStepSizeuA(stepSizes.ElementAt(e.Ind)) - currentStepSizeuA))
+                .Select(e => e.Ind)
+                .First();
 
             return stepSizes.ElementAt(optimalStepIndex);
         }


### PR DESCRIPTION
When calculating the error to find the optimum step size, the algorithm now utilizes the requested amplitude so that in the case when no stimuli are present, the error is correctly modified for each step size and the appropriate size is chosen for the requested amplitude

- Fixes #392 