### PR TITLE
Tie lifetime of oni.Context to that of ContextTask

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.4.3</VersionPrefix>
+    <VersionPrefix>0.4.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -35,7 +35,7 @@ namespace OpenEphys.Onix1
     /// </remarks>
     public class ContextTask : IDisposable
     {
-        oni.Context ctx;
+        readonly oni.Context ctx;
 
         /// <summary>
         /// Maximum amount of frames the reading queue will hold. If the queue fills or the read thread is not
@@ -115,11 +115,8 @@ namespace OpenEphys.Onix1
                     lock (readLock)
                         lock (writeLock)
                         {
-                            if (ctx != null)
-                            {
-                                ctx.Refresh();
-                                Initialize();
-                            }
+                            ctx.Refresh();
+                            Initialize();
                         }
                 }
         }
@@ -289,8 +286,9 @@ namespace OpenEphys.Onix1
                     }
 
                     if (!acquisition.IsCompleted)
+                    {
                         throw new InvalidOperationException("Acquisition already running in the current context.");
-
+                    }
 
                     // NB: Configure context before starting acquisition or the the settings (e.g. Block read
                     // and write sizes) will not be respected
@@ -486,7 +484,9 @@ namespace OpenEphys.Onix1
             lock (disposeLock)
             {
                 if (!disposed)
+                {
                     action();
+                }
             }
         }
 
@@ -562,8 +562,7 @@ namespace OpenEphys.Onix1
                     lock (readLock)
                         lock (writeLock)
                         {
-                            ctx?.Dispose();
-                            ctx = null;
+                            ctx.Dispose();
                         }
         }
 

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -93,12 +93,12 @@ namespace OpenEphys.Onix1
             groupedFrames.Connect();
             contextDriver = driver;
             contextIndex = index;
+            ctx = new oni.Context(contextDriver, contextIndex);
             Initialize();
         }
 
         private void Initialize()
         {
-            ctx = new oni.Context(contextDriver, contextIndex);
             SystemClockHz = ctx.SystemClockHz;
             AcquisitionClockHz = ctx.AcquisitionClockHz;
             MaxReadFrameSize = ctx.MaxReadFrameSize;
@@ -115,8 +115,11 @@ namespace OpenEphys.Onix1
                     lock (readLock)
                         lock (writeLock)
                         {
-                            ctx?.Dispose();
-                            Initialize();
+                            if (ctx != null)
+                            {
+                                ctx.Refresh();
+                                Initialize();
+                            }
                         }
                 }
         }
@@ -195,7 +198,6 @@ namespace OpenEphys.Onix1
         {
             return groupedFrames.Where(deviceFrames => deviceFrames.Key == deviceAddress).Merge();
         }
-
 
         void AssertConfigurationContext()
         {


### PR DESCRIPTION
- Instead of disposing and recreating oni.Context when a reset occurs, issue a oni.Context.Refresh() to existing object
- Fixes #407 

## Hardware Tests
I tried to put this throgh the ringer

|Test  |Desc  |Result  |
|---|---|---|
| Breakout only | Stated with breakout only, quickly hitting refresh during acqusition etc.  |  ✔️|
| Breakout , NP2.0e | Added np2.0e headstage, which reliese on passthrough configuration, quickly hitting refresh during acquisition etc. |  ✔️|
| Breakout, NP2.0, Rhs2116 headstage | A Rhs2116 headstage,  which uses a standard port but needs to issue a [second reset](https://github.com/open-ephys/bonsai-onix1/blob/067989b21f38169dad5282ce92b971120fe2d76e/OpenEphys.Onix1/ConfigureHeadstageRhs2116.cs#L148) after power up:  | ✔️ |
| Breakout, NP2.0, Rhs2116 headstage with auto voltage | Same as last but do auto voltage discovery on rhs2116 headstage  | ✔️ |
