### PR TITLE
Add microvolt conversion equations

### DIFF
--- a/OpenEphys.Onix1/AnalogInputDataFrame.cs
+++ b/OpenEphys.Onix1/AnalogInputDataFrame.cs
@@ -21,8 +21,24 @@ namespace OpenEphys.Onix1
         }
 
         /// <summary>
-        /// Get the buffered analog data array.
+        /// Gets the buffered analog data array.
         /// </summary>
+        /// <remarks>
+        /// Data has 16 rows which represent analog input channels and columns which represent
+        /// samples acquired at 100 kHz. Each column corresponds to an ADC sample whose time is
+        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. When <c>DataType</c> in <see
+        /// cref="OpenEphys.Onix1.AnalogInput"/> is set to <c>Volts</c>, pre-converted voltage
+        /// values are encoded as a <see cref="float"/>. When <c>DataType</c> is set to <c>S16</c>,
+        /// raw 16-bit ADC samples are encoded as a <see cref="ushort"/>. In this case, the following
+        /// equation can be used to convert it to volts:
+        /// <code> 
+        /// V_analogInput (V) = VoltageRange / 2^16 × AdcSample 
+        /// </code> 
+        /// where voltage range can be 5, 10, or 20 depending on how the analog input voltage range
+        /// is configured (±2.5, ±5, or ±10 volts) in <see
+        /// cref="OpenEphys.Onix1.ConfigureBreakoutBoard.AnalogIO"/>.
+        /// </remarks>
         public Mat AnalogData { get; }
     }
 

--- a/OpenEphys.Onix1/AnalogInputDataFrame.cs
+++ b/OpenEphys.Onix1/AnalogInputDataFrame.cs
@@ -24,20 +24,22 @@ namespace OpenEphys.Onix1
         /// Gets the buffered analog data array.
         /// </summary>
         /// <remarks>
-        /// Data has 16 rows which represent analog input channels and columns which represent
-        /// samples acquired at 100 kHz. Each column corresponds to an ADC sample whose time is
-        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. When <c>DataType</c> in <see
-        /// cref="OpenEphys.Onix1.AnalogInput"/> is set to <c>Volts</c>, each pre-converted voltage
-        /// value is encoded as a <see cref="float"/>. When <c>DataType</c> is set to <c>S16</c>,
-        /// each raw 16-bit ADC samples is encoded as a <see cref="short"/>. In this case, the
-        /// following equation can be used to convert it to volts:
+        /// Analog samples are organized in 12xN matrix with rows representing channel number and
+        /// N columns representing samples acquired at 100 kHz. Each column is a 12-channel vector of ADC
+        /// samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. When <see
+        /// cref="AnalogInput.DataType"/> is set to <see cref="AnalogIODataType.Volts"/>, each sample is
+        /// internally converted to a voltage value and are represented using a <see cref="float"/>. When <see
+        /// cref="AnalogInput.DataType"/> is set to <see cref="AnalogIODataType.S16"/>, each 16-bit ADC sample
+        /// is represented as a <see cref="short"/>. In this case, the following equation can be used to
+        /// convert a sample to volts:
         /// <code> 
-        /// Analog Voltage (V) = Voltage Range / 2^16 × ADC Sample 
+        /// Channel Voltage (V) = ADC Sample × (Input Span / 2^16)
         /// </code> 
-        /// where voltage range can be 5, 10, or 20 depending on how the analog input voltage range
-        /// is configured (±2.5, ±5, or ±10 volts) in <see
-        /// cref="OpenEphys.Onix1.ConfigureBreakoutBoard.AnalogIO"/>.
+        /// where <c>Input Span</c> is 5V, 10V, or 20V  when the <see cref="AnalogIOVoltageRange"/> is set to
+        /// ±2.5V, ±5V, or ±10V, respectively. Note that <see cref="AnalogIOVoltageRange"/> can be set
+        /// independently for each channel in <see cref="ConfigureBreakoutBoard.AnalogIO"/>. Therefore, the
+        /// conversion factor may be different for each channel.
         /// </remarks>
         public Mat AnalogData { get; }
     }

--- a/OpenEphys.Onix1/AnalogInputDataFrame.cs
+++ b/OpenEphys.Onix1/AnalogInputDataFrame.cs
@@ -28,12 +28,12 @@ namespace OpenEphys.Onix1
         /// samples acquired at 100 kHz. Each column corresponds to an ADC sample whose time is
         /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
         /// cref="DataFrame.HubClock"/>. When <c>DataType</c> in <see
-        /// cref="OpenEphys.Onix1.AnalogInput"/> is set to <c>Volts</c>, pre-converted voltage
-        /// values are encoded as a <see cref="float"/>. When <c>DataType</c> is set to <c>S16</c>,
-        /// raw 16-bit ADC samples are encoded as a <see cref="ushort"/>. In this case, the following
-        /// equation can be used to convert it to volts:
+        /// cref="OpenEphys.Onix1.AnalogInput"/> is set to <c>Volts</c>, each pre-converted voltage
+        /// value is encoded as a <see cref="float"/>. When <c>DataType</c> is set to <c>S16</c>,
+        /// each raw 16-bit ADC samples is encoded as a <see cref="short"/>. In this case, the
+        /// following equation can be used to convert it to volts:
         /// <code> 
-        /// V_analogInput (V) = VoltageRange / 2^16 × AdcSample 
+        /// Analog Voltage (V) = Voltage Range / 2^16 × ADC Sample 
         /// </code> 
         /// where voltage range can be 5, 10, or 20 depending on how the analog input voltage range
         /// is configured (±2.5, ±5, or ±10 volts) in <see

--- a/OpenEphys.Onix1/AnalogInputDataFrame.cs
+++ b/OpenEphys.Onix1/AnalogInputDataFrame.cs
@@ -29,7 +29,7 @@ namespace OpenEphys.Onix1
         /// samples whose acquisition time is indicated by the corresponding elements in <see
         /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. When <see
         /// cref="AnalogInput.DataType"/> is set to <see cref="AnalogIODataType.Volts"/>, each sample is
-        /// internally converted to a voltage value and are represented using a <see cref="float"/>. When <see
+        /// internally converted to a voltage value and represented using a <see cref="float"/>. When <see
         /// cref="AnalogInput.DataType"/> is set to <see cref="AnalogIODataType.S16"/>, each 16-bit ADC sample
         /// is represented as a <see cref="short"/>. In this case, the following equation can be used to
         /// convert a sample to volts:

--- a/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
@@ -27,46 +27,46 @@ namespace OpenEphys.Onix1
         /// Gets the frame count value array.
         /// </summary>
         /// <remarks>
-        /// A 20-bit counter on the probe that increments its value for every frame produced.
-        /// The value ranges from 0 to 1048575 (2^20-1), and should always increment by 1 until it wraps around back to 0.
-        /// This can be used to detect dropped frames.
+        /// A 20-bit counter on the probe that increments its value for every "frame" produced by the probe.
+        /// Thirteen frames are produced for each 384-channel column of samples in  <see cref="SpikeData"/>.
+        /// The value ranges from 0 to 1048575 (2^20-1), and should always increment by 1 until it wraps
+        /// around back to 0. This can be used to detect dropped frames.
         /// </remarks>
         public int[] FrameCount { get; }
 
         /// <summary>
-        /// Gets spike-band data array.
+        /// Gets spike-band electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 384 rows which represent spike-band electrophysiology channels and columns
-        /// which represent samples acquired at 30 kHz. Each column corresponds to an ADC sample
-        /// whose time is indicated by the corresponding elements in <see cref="DataFrame.Clock"/>
-        /// and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset binary value
-        /// encoded as a <see cref="ushort"/>. The following equation can be used to convert it to
-        /// microvolts:
+        /// Spike-band (0.3-10 kHz) samples are organized in 384xN matrix with rows representing
+        /// channel number and N columns representing samples acquired at 30 kHz. Each column is a 384-channel
+        /// vector of ADC samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset
+        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
+        /// a sample to microvolts:
         /// <code> 
-        /// Electrode Voltage (µV) = 1,171.875 / AP Gain × (ADC Sample – 512) 
+        /// Electrode Voltage (µV) = (1,171.875 / AP Gain) × (ADC Sample – 512) 
         /// </code>
-        /// where AP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
-        /// it's configured in the <see
-        /// cref="OpenEphys.Onix1.ConfigureNeuropixelsV1eHeadstage.NeuropixelsV1e"/> configuration GUI.
+        /// where <c>AP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
+        /// cref="NeuropixelsV1ProbeConfiguration.SpikeAmplifierGain"/>.
         /// </remarks>
         public Mat SpikeData { get; }
 
         /// <summary>
-        /// Gets LFP-band data array.
+        /// Gets LFP-band electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 384 rows which represent LFP-band electrophysiology channels and columns which
-        /// represent samples acquired at 2.5 kHz. Each column corresponds to an ADC sample whose
-        /// time is indicated by the every 12th element in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit offset, binary value encoded as
-        /// a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// LFP-band (0.5-500 Hz) samples are organized in 384xN matrix with rows representing channel
+        /// number and N columns representing samples acquired at 2.5 kHz. Each column is a 384-channel vector
+        /// of ADC samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset
+        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
+        /// a sample to microvolts:
         /// <code> 
-        /// Electrode Voltage (µV) = 1,171.875 / LFP Gain × (ADC Sample – 512) 
+        /// Electrode Voltage (µV) = (1,171.875 / LFP Gain) × (ADC Sample – 512)
         /// </code>
-        /// where LFP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
-        /// it's configured in the <see
-        /// cref="OpenEphys.Onix1.ConfigureNeuropixelsV1eHeadstage.NeuropixelsV1e"/> configuration GUI.
+        /// where <c>LFP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
+        /// cref="NeuropixelsV1ProbeConfiguration.LfpAmplifierGain"/>.
         /// </remarks>
         public Mat LfpData { get; }
     }

--- a/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
@@ -44,7 +44,7 @@ namespace OpenEphys.Onix1
         /// encoded as a <see cref="ushort"/>. The following equation can be used to convert it to
         /// microvolts:
         /// <code> 
-        /// V_electrode (µV) = 1,171.875 / ApGain × (AdcSample – 512) 
+        /// Electrode Voltage (µV) = 1,171.875 / AP Gain × (ADC Sample – 512) 
         /// </code>
         /// where AP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
         /// it's configured in the <see
@@ -62,7 +62,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit offset, binary value encoded as
         /// a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code> 
-        /// V_electrode (µV) = 1,171.875 / LfpGain × (AdcSample – 512) 
+        /// Electrode Voltage (µV) = 1,171.875 / LFP Gain × (ADC Sample – 512) 
         /// </code>
         /// where LFP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
         /// it's configured in the <see

--- a/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
@@ -34,28 +34,39 @@ namespace OpenEphys.Onix1
         public int[] FrameCount { get; }
 
         /// <summary>
-        /// Gets the spike-band data as a <see cref="Mat"/> object.
+        /// Gets spike-band data array.
         /// </summary>
         /// <remarks>
-        /// Spike-band data has 384 electrodes (rows) with columns representing the samples acquired at 30 kHz.
-        /// Each sample is a 10-bit, offset binary value encoded as a <see cref="ushort"/>. To convert to
-        /// microvolts, the following equation can be used:
-        /// <code>
-        /// V_electrode (uV) = 1171.875 uV / AP Gain × (ADC result – 512)
+        /// Data has 384 rows which represent spike-band electrophysiology channels and columns
+        /// which represent samples acquired at 30 kHz. Each column corresponds to an ADC sample
+        /// whose time is indicated by the corresponding elements in <see cref="DataFrame.Clock"/>
+        /// and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset binary value
+        /// encoded as a <see cref="ushort"/>. The following equation can be used to convert it to
+        /// microvolts:
+        /// <code> 
+        /// V_electrode (µV) = 1,171.875 / ApGain × (AdcSample – 512) 
         /// </code>
+        /// where AP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
+        /// it's configured in the <see
+        /// cref="OpenEphys.Onix1.ConfigureNeuropixelsV1eHeadstage.NeuropixelsV1e"/> configuration GUI.
         /// </remarks>
         public Mat SpikeData { get; }
 
         /// <summary>
-        /// Gets the LFP band data as a <see cref="Mat"/> object.
+        /// Gets LFP-band data array.
         /// </summary>
         /// <remarks>
-        /// LFP-band data has 384 electrodes (rows) with columns representing the samples acquired at 2.5 kHz.
-        /// Each sample is a 10-bit, offset binary value encoded as a <see cref="ushort"/>. To convert to
-        /// microvolts, the following equation can be used:
-        /// <code>
-        /// V_electrode (uV) = 1171.875 uV / LFP Gain × (ADC result – 512)
+        /// Data has 384 rows which represent LFP-band electrophysiology channels and columns which
+        /// represent samples acquired at 2.5 kHz. Each column corresponds to an ADC sample whose
+        /// time is indicated by the every 12th element in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit offset, binary value encoded as
+        /// a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// <code> 
+        /// V_electrode (µV) = 1,171.875 / LfpGain × (AdcSample – 512) 
         /// </code>
+        /// where LFP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
+        /// it's configured in the <see
+        /// cref="OpenEphys.Onix1.ConfigureNeuropixelsV1eHeadstage.NeuropixelsV1e"/> configuration GUI.
         /// </remarks>
         public Mat LfpData { get; }
     }

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
@@ -4,7 +4,7 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Buffered data from a NeuropixelsV2e device.
+    /// Buffered data from a NeuropixelsV2-Beta probe.
     /// </summary>
     public class NeuropixelsV2eBetaDataFrame : BufferedDataFrame
     {
@@ -26,11 +26,12 @@ namespace OpenEphys.Onix1
         /// Gets the buffered electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 384 rows which represent electrophysiology channels and columns which represent
-        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
-        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 14-bit, offset binary value encoded
-        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// Electrophysiology samples are organized in 384xN matrix with rows representing electrophysiology
+        /// channel number and N columns representing samples acquired at 30 kHz. Each column is a 384-channel
+        /// vector of ADC samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 14-bit, offset
+        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
+        /// a sample to microvolts:
         /// <code>
         /// Electrode Voltage (µV) = 0.76294 × (ADC Sample – 8192)
         /// </code>
@@ -38,12 +39,13 @@ namespace OpenEphys.Onix1
         public Mat AmplifierData { get; }
 
         /// <summary>
-        /// Gets the frame count array.
+        /// Gets the frame count value array.
         /// </summary>
         /// <remarks>
-        /// Frame count is a 20-bit counter on the probe that increments its value for every frame produced.
-        /// The value ranges from 0 to 1048575 (2^20-1), and should always increment by 1 until it wraps around back to 0.
-        /// This can be used to detect dropped frames.
+        /// A 20-bit counter on the probe that increments its value for every "frame" produced by the probe.
+        /// Sixteen frames are produced for each 384-channel column of samples in  <see cref="AmplifierData"/>.
+        /// The value ranges from 0 to 1048575 (2^20-1), and should always increment by 1 until it wraps
+        /// around back to 0. This can be used to detect dropped frames.
         /// </remarks>
         public int[] FrameCount { get; }
 

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
@@ -32,7 +32,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is a 14-bit, offset binary value encoded
         /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 0.76294 × (AdcSample – 8192)
+        /// Electrode Voltage (µV) = 0.76294 × (ADC Sample – 8192)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaDataFrame.cs
@@ -23,14 +23,16 @@ namespace OpenEphys.Onix1
         }
 
         /// <summary>
-        /// Gets the amplifier data array.
+        /// Gets the buffered electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Wide band (0.5 Hz - 10 kHz) electrophysiology data array. Each element is an amplified sample from
-        /// 384 electrodes (rows) acquired at 30 kHz (columns). Each sample is a 14-bit, offset binary value
-        /// encoded as a <see cref="ushort"/>. To convert to microvolts, the following equation can be used:
+        /// Data has 384 rows which represent electrophysiology channels and columns which represent
+        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
+        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 14-bit, offset binary value encoded
+        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 0.76294 µV/bit × (ADC result – 8192) bits
+        /// V_electrode (µV) = 0.76294 × (AdcSample – 8192)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }

--- a/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
@@ -21,14 +21,16 @@ namespace OpenEphys.Onix1
         }
 
         /// <summary>
-        /// Gets the amplifier data array.
+        /// Gets the buffered electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Wide band (0.5 Hz - 10 kHz) electrophysiology data array. Each element is an amplified sample from
-        /// 384 electrodes (rows) acquired at 30 kHz (columns). Each sample is a 12-bit, offset binary value
-        /// encoded as a <see cref="ushort"/>. To convert to microvolts, the following equation can be used:
+        /// Data has 384 rows which represent electrophysiology channels and columns which represent
+        /// samples acquired at 30 kHz. Each column corresponds to an qADC sample whose time is
+        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 12-bit, offset binary value encoded
+        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 3.05176 µV/bit × (ADC result – 2048) bits
+        /// V_electrode (µV) = 3.05176 × (AdcSample – 2048)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }

--- a/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
@@ -30,7 +30,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is a 12-bit, offset binary value encoded
         /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 3.05176 × (AdcSample – 2048)
+        /// Electrode Voltage (µV) = 3.05176 × (ADC Sample – 2048)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }

--- a/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
@@ -4,7 +4,7 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Buffered data from a NeuropixelsV2e device.
+    /// Buffered data from a NeuropixelsV2 probe.
     /// </summary>
     public class NeuropixelsV2eDataFrame : BufferedDataFrame
     {
@@ -24,11 +24,12 @@ namespace OpenEphys.Onix1
         /// Gets the buffered electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 384 rows which represent electrophysiology channels and columns which represent
-        /// samples acquired at 30 kHz. Each column corresponds to an qADC sample whose time is
-        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 12-bit, offset binary value encoded
-        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// Electrophysiology samples are organized in 384xN matrix with rows representing electrophysiology
+        /// channel number and N columns representing samples acquired at 30 kHz. Each column is a 384-channel
+        /// vector of ADC samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 12-bit, offset
+        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
+        /// a sample to microvolts:
         /// <code>
         /// Electrode Voltage (µV) = 3.05176 × (ADC Sample – 2048)
         /// </code>

--- a/OpenEphys.Onix1/Nric1384DataFrame.cs
+++ b/OpenEphys.Onix1/Nric1384DataFrame.cs
@@ -36,21 +36,38 @@ namespace OpenEphys.Onix1
 
 
         /// <summary>
-        /// Gets the spike-band data as a <see cref="Mat"/> object.
+        /// Gets spike-band data array.
         /// </summary>
         /// <remarks>
-        /// Spike-band data has 384 rows (channels) with columns representing the samples acquired at 30 kHz. Each sample is a
-        /// 10-bit, offset binary value encoded as a <see cref="ushort"/>.
+        /// Data has 384 rows which represent spike-band electrophysiology channels and columns
+        /// which represent samples acquired at 30 kHz. Each column corresponds to an ADC sample
+        /// whose time is indicated by the corresponding elements in <see cref="DataFrame.Clock"/>
+        /// and <see cref="DataFrame.HubClock"/>. Each ADC sample is an 10-bit, offset binary value
+        /// encoded as a <see cref="ushort"/>. The following equation can be used to convert it to
+        /// microvolts:
+        /// <code> 
+        /// V_electrode (µV) = 1,171.875 / ApGain × (AdcSample – 512) 
+        /// </code>
+        /// where AP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
+        /// it's configured in <see cref="OpenEphys.Onix1.ConfigureNric1384"/> .
         /// </remarks>
         public Mat SpikeData { get; }
 
 
         /// <summary>
-        /// Gets the LFP band data as a <see cref="Mat"/> object.
+        /// Gets LFP-band data array.
         /// </summary>
         /// <remarks>
-        /// LFP data has 32 rows (channels) with columns representing the samples acquired at 2.5 kHz. Each sample is a
-        /// 10-bit, offset binary value encoded as a <see cref="ushort"/>.
+        /// Data has 384 rows which represent LFP-band electrophysiology channels and columns which
+        /// represent samples acquired at 2.5 kHz. Each column corresponds to an ADC sample whose
+        /// time is indicated by the every 12th element in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is an 10-bit, offset binary value encoded
+        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// <code> 
+        /// V_electrode (µV) = 1,171.875 / LfpGain × (AdcSample – 512) 
+        /// </code>
+        /// where LFP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
+        /// it's configured in <see cref="OpenEphys.Onix1.ConfigureNric1384"/>.
         /// </remarks>
         public Mat LfpData { get; }
     }

--- a/OpenEphys.Onix1/Nric1384DataFrame.cs
+++ b/OpenEphys.Onix1/Nric1384DataFrame.cs
@@ -46,7 +46,7 @@ namespace OpenEphys.Onix1
         /// encoded as a <see cref="ushort"/>. The following equation can be used to convert it to
         /// microvolts:
         /// <code> 
-        /// V_electrode (µV) = 1,171.875 / ApGain × (AdcSample – 512) 
+        /// Electrode Voltage (µV) = 1,171.875 / AP Gain × (ADC Sample – 512) 
         /// </code>
         /// where AP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
         /// it's configured in <see cref="OpenEphys.Onix1.ConfigureNric1384"/> .
@@ -64,7 +64,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is an 10-bit, offset binary value encoded
         /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code> 
-        /// V_electrode (µV) = 1,171.875 / LfpGain × (AdcSample – 512) 
+        /// Electrode Voltage (µV) = 1,171.875 / LFP Gain × (ADC Sample – 512) 
         /// </code>
         /// where LFP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
         /// it's configured in <see cref="OpenEphys.Onix1.ConfigureNric1384"/>.

--- a/OpenEphys.Onix1/Nric1384DataFrame.cs
+++ b/OpenEphys.Onix1/Nric1384DataFrame.cs
@@ -4,7 +4,7 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Buffered data from a Nric1384 bioacquisition device.
+    /// Buffered data from a Nric1384 bioacquisition chip.
     /// </summary>
     public class Nric1384DataFrame : BufferedDataFrame
     {
@@ -28,46 +28,47 @@ namespace OpenEphys.Onix1
         /// Gets the frame count value array.
         /// </summary>
         /// <remarks>
-        /// A 20-bit counter on the chip that increments its value for every frame produced. The value ranges from 0 to
-        /// 1048575 (2^20-1), and should always increment by 13 (one count is taken per super-frame and there are 13 frames 
-        /// in a super frame) until it wraps around back to 0. This can be used to detect dropped frames.
+        /// A 20-bit counter on the probe that increments its value for every "frame" produced by the probe.
+        /// Thirteen frames are produced for each 384-channel column of samples in  <see cref="SpikeData"/>.
+        /// The value ranges from 0 to 1048575 (2^20-1), and should always increment by 1 until it wraps
+        /// around back to 0. This can be used to detect dropped frames.
         /// </remarks>
         public int[] FrameCount { get; }
 
-
         /// <summary>
-        /// Gets spike-band data array.
+        /// Gets spike-band electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 384 rows which represent spike-band electrophysiology channels and columns
-        /// which represent samples acquired at 30 kHz. Each column corresponds to an ADC sample
-        /// whose time is indicated by the corresponding elements in <see cref="DataFrame.Clock"/>
-        /// and <see cref="DataFrame.HubClock"/>. Each ADC sample is an 10-bit, offset binary value
-        /// encoded as a <see cref="ushort"/>. The following equation can be used to convert it to
-        /// microvolts:
+        /// Spike-band (0.3-10 kHz) samples are organized in 384xN matrix with rows representing
+        /// channel number and N columns representing samples acquired at 30 kHz. Each column is a 384-channel
+        /// vector of ADC samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset
+        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
+        /// a sample to microvolts:
         /// <code> 
-        /// Electrode Voltage (µV) = 1,171.875 / AP Gain × (ADC Sample – 512) 
+        /// Electrode Voltage (µV) = (1,171.875 / AP Gain) × (ADC Sample – 512) 
         /// </code>
-        /// where AP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
-        /// it's configured in <see cref="OpenEphys.Onix1.ConfigureNric1384"/> .
+        /// where <c>AP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
+        /// cref="ConfigureNric1384.SpikeAmplifierGain"/>.
         /// </remarks>
         public Mat SpikeData { get; }
 
 
         /// <summary>
-        /// Gets LFP-band data array.
+        /// Gets LFP-band electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 384 rows which represent LFP-band electrophysiology channels and columns which
-        /// represent samples acquired at 2.5 kHz. Each column corresponds to an ADC sample whose
-        /// time is indicated by the every 12th element in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is an 10-bit, offset binary value encoded
-        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// LFP-band (0.5-500 Hz) samples are organized in 384xN matrix with rows representing channel
+        /// number and N columns representing samples acquired at 2.5 kHz. Each column is a 384-channel vector
+        /// of ADC samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset
+        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
+        /// a sample to microvolts:
         /// <code> 
-        /// Electrode Voltage (µV) = 1,171.875 / LFP Gain × (ADC Sample – 512) 
+        /// Electrode Voltage (µV) = (1,171.875 / LFP Gain) × (ADC Sample – 512)
         /// </code>
-        /// where LFP gain can be 50, 125, 250, 500, 1,000, 1,500, 2,000, or 3,000 depending on how
-        /// it's configured in <see cref="OpenEphys.Onix1.ConfigureNric1384"/>.
+        /// where <c>LFP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
+        /// cref="ConfigureNric1384.LfpAmplifierGain"/>.
         /// </remarks>
         public Mat LfpData { get; }
     }

--- a/OpenEphys.Onix1/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix1/Rhd2164DataFrame.cs
@@ -32,7 +32,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
         /// as a <see cref="ushort"/>. TThe following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 0.195 × (AdcSample – 32768)
+        /// Electrode Voltage (µV) = 0.195 × (ADC Sample – 32768)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }
@@ -47,7 +47,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
         /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 0.195 × (AdcSample – 32768)
+        /// Electrode Voltage (µV) = 0.195 × (ADC Sample – 32768)
         /// </code>
         /// </remarks>
         public Mat AuxData { get; }

--- a/OpenEphys.Onix1/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix1/Rhd2164DataFrame.cs
@@ -26,11 +26,12 @@ namespace OpenEphys.Onix1
         /// Gets the buffered electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 64 rows which represent electrophysiology channels and columns which represent
-        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
-        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
-        /// as a <see cref="ushort"/>. TThe following equation can be used to convert it to microvolts:
+        /// Electrophysiology samples are organized in 64xN matrix with rows representing electrophysiology
+        /// channel number and N columns representing sample index. Each column is a 64-channel vector of ADC
+        /// samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit,
+        /// offset binary value encoded as a <see cref="ushort"/>. The following equation can be used to
+        /// convert a sample to microvolts:
         /// <code>
         /// Electrode Voltage (µV) = 0.195 × (ADC Sample – 32768)
         /// </code>
@@ -38,17 +39,19 @@ namespace OpenEphys.Onix1
         public Mat AmplifierData { get; }
 
         /// <summary>
-        /// Gets the buffered auxiliary data array.
+        /// Gets the buffered auxiliary data array. 
         /// </summary>
         /// <remarks>
-        /// Data has 3 rows representing electrophysiology channels and columns representing samples acquired at 30
-        /// kHz. Each column corresponds to an ADC sample whose time is indicated by the
-        /// corresponding element <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
-        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// Auxiliary samples are organized in 3xN matrix with rows representing electrophysiology channel
+        /// number and N columns representing sample index. Each column is a 3-channel vector of ADC samples
+        /// whose acquisition time is indicated by the corresponding elements in <see cref="DataFrame.Clock"/>
+        /// and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit <see cref="ushort"/>. The
+        /// following equation can be used to convert a sample to volts:
         /// <code>
-        /// Electrode Voltage (µV) = 0.195 × (ADC Sample – 32768)
+        /// Auxiliary Voltage (V) = 0.0000374 × ADC Sample
         /// </code>
+        /// Note that auxiliary inputs have a 0.10-2.45V input range. Nonlinearities may occur if voltages
+        /// outside of this range are applied to auxiliary inputs.
         /// </remarks>
         public Mat AuxData { get; }
     }

--- a/OpenEphys.Onix1/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix1/Rhd2164DataFrame.cs
@@ -26,12 +26,13 @@ namespace OpenEphys.Onix1
         /// Gets the buffered electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Each row corresponds to a channel. Each column corresponds to a sample whose time is indicated by
-        /// the corresponding element <see cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>.
-        /// Samples are 16-bits each and are represented using unsigned 16-bit integers. To convert to
-        /// micro-volts, the following equation can be used:
+        /// Data has 64 rows which represent electrophysiology channels and columns which represent
+        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
+        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
+        /// as a <see cref="ushort"/>. TThe following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (uV) = 0.195 µV × (ADC result – 32768)
+        /// V_electrode (µV) = 0.195 × (AdcSample – 32768)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }
@@ -40,8 +41,14 @@ namespace OpenEphys.Onix1
         /// Gets the buffered auxiliary data array.
         /// </summary>
         /// <remarks>
-        /// Each row corresponds to a channel. Each column corresponds to a sample whose time is indicated by
-        /// the corresponding element <see cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>.
+        /// Data has 3 rows representing electrophysiology channels and columns representing samples acquired at 30
+        /// kHz. Each column corresponds to an ADC sample whose time is indicated by the
+        /// corresponding element <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
+        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// <code>
+        /// V_electrode (µV) = 0.195 × (AdcSample – 32768)
+        /// </code>
         /// </remarks>
         public Mat AuxData { get; }
     }

--- a/OpenEphys.Onix1/Rhs2116Data.cs
+++ b/OpenEphys.Onix1/Rhs2116Data.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
 {
     /// <summary>
     /// Produces a sequence of <see cref="Rhs2116DataFrame"/> objects with data from an Intan
-    /// Rhs2116 bioacquisition chip.
+    /// Rhs2116 bidirectional bioacquisition chip.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
@@ -28,11 +28,11 @@ namespace OpenEphys.Onix1
         /// Gets or sets the buffer size.
         /// </summary>
         /// <remarks>
-        /// This property determines the number of samples that are collected from each of the 16 ephys
-        /// channels before data is propagated. For instance, if this value is set to 30, then 16x30 samples,
-        /// along with 30 corresponding clock values, will be collected and packed into each <see
-        /// cref="Rhs2116DataFrame"/>. Because channels are sampled at 30 kHz, this is equivalent to 1
-        /// millisecond of data from each channel.
+        /// This property determines the number of samples that are collected from each of the 16
+        /// electrophysiology channels before data is propagated. For instance, if this value is set to 30,
+        /// then 16x30 samples, along with 30 corresponding clock values, will be collected and packed into
+        /// each <see cref="Rhs2116DataFrame"/>. Because channels are sampled at 30 kHz, this is equivalent to
+        /// 1 millisecond of data from each channel.
         /// </remarks>
         public int BufferSize { get; set; } = 30;
 

--- a/OpenEphys.Onix1/Rhs2116DataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116DataFrame.cs
@@ -32,7 +32,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is an 16-bit, offset binary value encoded
         /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 0.195 × (AdcSample – 32768)
+        /// Electrode Voltage (µV) = 0.195 × (ADC Sample – 32768)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }
@@ -47,7 +47,7 @@ namespace OpenEphys.Onix1
         /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
         /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (mV) = -19.23 × (AdcSample – 512)
+        /// Electrode Voltage (mV) = -19.23 × (ADC Sample – 512)
         /// </code>
         /// </remarks>
         public Mat DCData { get; }

--- a/OpenEphys.Onix1/Rhs2116DataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116DataFrame.cs
@@ -23,29 +23,31 @@ namespace OpenEphys.Onix1
         }
 
         /// <summary>
-        /// Gets the high-gain AC-coupled ephys amplifier data.
+        /// Gets the high-gain AC-coupled amplifier data array.
         /// </summary>
         /// <remarks>
-        /// Each row corresponds to a channel. Each column corresponds to a sample whose time is indicated by
-        /// the corresponding element <see cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>.
-        /// Samples are 16-bits each and are represented using unsigned 16-bit integers. To convert to
-        /// microvolts, the following equation can be used:
+        /// Data has 16 rows which represent AC-coupled electrophysiology channels and columns which represent
+        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
+        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is an 16-bit, offset binary value encoded
+        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (µV) = 0.195 µV × (ADC result – 32768)
+        /// V_electrode (µV) = 0.195 × (AdcSample – 32768)
         /// </code>
         /// </remarks>
         public Mat AmplifierData { get; }
 
         /// <summary>
-        /// Gets the DC-coupled low-gain amplifier data for monitoring stimulation waveforms.
+        /// Gets the DC-coupled low-gain amplifier data array for monitoring stimulation waveforms.
         /// </summary>
         /// <remarks>
-        /// Each row corresponds to a channel. Each column corresponds to a sample whose time is indicated by
-        /// the corresponding element <see cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>.
-        /// Samples are 10-bits each and are represented using unsigned 16-bit integers. To convert to
-        /// millivolts, the following equation can be used:
+        /// Data has 16 rows which represent DC-coupled electrophysiology channels and columns which represent
+        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
+        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
+        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
+        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
         /// <code>
-        /// V_electrode (mV) = -19.23 mV × (ADC result – 512)
+        /// V_electrode (mV) = -19.23 × (AdcSample – 512)
         /// </code>
         /// </remarks>
         public Mat DCData { get; }

--- a/OpenEphys.Onix1/Rhs2116DataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116DataFrame.cs
@@ -4,7 +4,7 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Buffered data from an RHS2116 device.
+    /// Buffered data from one or more Rhs2116 devices.
     /// </summary>
     public class Rhs2116DataFrame : BufferedDataFrame
     {
@@ -23,14 +23,15 @@ namespace OpenEphys.Onix1
         }
 
         /// <summary>
-        /// Gets the high-gain AC-coupled amplifier data array.
+        /// Gets the high-gain electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Data has 16 rows which represent AC-coupled electrophysiology channels and columns which represent
-        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
-        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is an 16-bit, offset binary value encoded
-        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// Electrophysiology samples are organized in MxN matrix with M rows representing electrophysiology
+        /// channel number and N columns representing sample index. Each column is a M-channel vector of ADC
+        /// samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is an 16-bit,
+        /// offset binary value encoded as a <see cref="ushort"/>. The following equation can be used to
+        /// convert a sample to microvolts:
         /// <code>
         /// Electrode Voltage (µV) = 0.195 × (ADC Sample – 32768)
         /// </code>
@@ -38,14 +39,15 @@ namespace OpenEphys.Onix1
         public Mat AmplifierData { get; }
 
         /// <summary>
-        /// Gets the DC-coupled low-gain amplifier data array for monitoring stimulation waveforms.
+        /// Gets the DC-coupled, low-gain amplifier data array for monitoring stimulation waveforms.
         /// </summary>
         /// <remarks>
-        /// Data has 16 rows which represent DC-coupled electrophysiology channels and columns which represent
-        /// samples acquired at 30 kHz. Each column corresponds to an ADC sample whose time is
-        /// indicated by the corresponding elements in <see cref="DataFrame.Clock"/> and <see
-        /// cref="DataFrame.HubClock"/>. Each ADC sample is a 16-bit, offset binary value encoded
-        /// as a <see cref="ushort"/>. The following equation can be used to convert it to microvolts:
+        /// DC-coupled samples are organized in MxN matrix with M rows representing electrophysiology
+        /// channel number and N columns representing sample index. Each column is a M-channel vector of ADC
+        /// samples whose acquisition time is indicated by the corresponding elements in <see
+        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is an 10-bit,
+        /// offset binary value encoded as a <see cref="ushort"/>. The following equation can be used to
+        /// convert a sample to millivolts:
         /// <code>
         /// Electrode Voltage (mV) = -19.23 × (ADC Sample – 512)
         /// </code>

--- a/OpenEphys.Onix1/Rhs2116PairData.cs
+++ b/OpenEphys.Onix1/Rhs2116PairData.cs
@@ -10,7 +10,9 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of <see cref="Rhs2116DataFrame"/> objects from a Rhs2116Pair.
+    /// Produces a sequence of <see cref="Rhs2116DataFrame"/> objects from a synchronized pair of Intan
+    /// Rhs2116 bidirectional bioacquisition chips.
+    /// chips.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
@@ -26,11 +28,11 @@ namespace OpenEphys.Onix1
         /// Gets or sets the buffer size.
         /// </summary>
         /// <remarks>
-        /// This property determines the number of samples that are collected from each of the 16 ephys
-        /// channels before data is propagated. For instance, if this value is set to 30, then 16x30 samples,
-        /// along with 30 corresponding clock values, will be collected and packed into each <see
-        /// cref="Rhs2116DataFrame"/>. Because channels are sampled at 30 kHz, this is equivalent to 1
-        /// millisecond of data from each channel.
+        /// This property determines the number of samples that are collected from each of the 32
+        /// electrophysiology channels before data is propagated. For instance, if this value is set to 30,
+        /// then 32x30 samples, along with 30 corresponding clock values, will be collected and packed into
+        /// each <see cref="Rhs2116DataFrame"/>. Because channels are sampled at ~30 kHz, this is equivalent
+        /// to ~1 millisecond of data from each channel.
         /// </remarks>
         public int BufferSize { get; set; } = 30;
 


### PR DESCRIPTION
This needed to be done for every ephys device that provides raw ADC values and AnalogInput.

I noticed different headstages provided different information, so I also made an attempt to standardize the description for ephys data as much as I could.

Here's an image for your reference
![image](https://github.com/user-attachments/assets/cd9935ea-9dd1-4116-bb73-cd7eea9fc0d2)

- Fixes #405 