### PR TITLE
Modify Neuropixels aggregate names

### DIFF
--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
@@ -3,10 +3,10 @@
 namespace OpenEphys.Onix1.Design
 {
     /// <summary>
-    /// Partial class to create a GUI for <see cref="ConfigureNeuropixelsV1eHeadstage"/>.
+    /// Partial class to create a GUI for <see cref="ConfigureHeadstageNeuropixelsV1e"/>.
     /// </summary>
     /// <remarks>
-    /// Within the GUI, there is a tab for both devices encapsulated by a <see cref="ConfigureNeuropixelsV1eHeadstage"/>,
+    /// Within the GUI, there is a tab for both devices encapsulated by a <see cref="ConfigureHeadstageNeuropixelsV1e"/>,
     /// specifically a <see cref="ConfigureNeuropixelsV1e"/> and a <see cref="ConfigurePolledBno055"/>. 
     /// </remarks>
     public partial class NeuropixelsV1eHeadstageDialog : Form

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageEditor.cs
@@ -6,7 +6,7 @@ using System;
 namespace OpenEphys.Onix1.Design
 {
     /// <summary>
-    /// Class that opens a new dialog for a <see cref="ConfigureNeuropixelsV1eHeadstage"/>.
+    /// Class that opens a new dialog for a <see cref="ConfigureHeadstageNeuropixelsV1e"/>.
     /// </summary>
     public class NeuropixelsV1eHeadstageEditor : WorkflowComponentEditor
     {
@@ -17,7 +17,7 @@ namespace OpenEphys.Onix1.Design
             {
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
 
-                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV1eHeadstage configureHeadstage)
+                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureHeadstageNeuropixelsV1e configureHeadstage)
                 {
                     using var editorDialog = new NeuropixelsV1eHeadstageDialog(configureHeadstage.NeuropixelsV1e, configureHeadstage.Bno055);
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
@@ -3,10 +3,10 @@
 namespace OpenEphys.Onix1.Design
 {
     /// <summary>
-    /// Partial class to create a GUI for <see cref="ConfigureNeuropixelsV1fHeadstage"/>.
+    /// Partial class to create a GUI for <see cref="ConfigureHeadstageNeuropixelsV1f"/>.
     /// </summary>
     /// <remarks>
-    /// Within the GUI, there is a tab for all devices encapsulated by a <see cref="ConfigureNeuropixelsV1fHeadstage"/>,
+    /// Within the GUI, there is a tab for all devices encapsulated by a <see cref="ConfigureHeadstageNeuropixelsV1f"/>,
     /// specifically two <see cref="ConfigureNeuropixelsV1f"/> devices and one <see cref="ConfigureBno055"/>. 
     /// </remarks>
     public partial class NeuropixelsV1fHeadstageDialog : Form

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageEditor.cs
@@ -6,7 +6,7 @@ using System;
 namespace OpenEphys.Onix1.Design
 {
     /// <summary>
-    /// Class that opens a new dialog for a <see cref="ConfigureNeuropixelsV1eHeadstage"/>.
+    /// Class that opens a new dialog for a <see cref="ConfigureHeadstageNeuropixelsV1e"/>.
     /// </summary>
     public class NeuropixelsV1fHeadstageEditor : WorkflowComponentEditor
     {
@@ -17,7 +17,7 @@ namespace OpenEphys.Onix1.Design
             {
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
 
-                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV1fHeadstage configureHeadstage)
+                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureHeadstageNeuropixelsV1f configureHeadstage)
                 {
                     using var editorDialog = new NeuropixelsV1fHeadstageDialog(configureHeadstage.NeuropixelsV1A, configureHeadstage.NeuropixelsV1B, configureHeadstage.Bno055);
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
@@ -3,7 +3,7 @@
 namespace OpenEphys.Onix1.Design
 {
     /// <summary>
-    /// Partial class to create a GUI for <see cref="ConfigureNeuropixelsV2eHeadstage"/>.
+    /// Partial class to create a GUI for <see cref="ConfigureHeadstageNeuropixelsV2e"/>.
     /// </summary>
     public partial class NeuropixelsV2eHeadstageDialog : Form
     {

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageEditor.cs
@@ -6,7 +6,7 @@ using System;
 namespace OpenEphys.Onix1.Design
 {
     /// <summary>
-    /// Class that opens a new dialog for a <see cref="ConfigureNeuropixelsV2eHeadstage"/>.
+    /// Class that opens a new dialog for a <see cref="ConfigureHeadstageNeuropixelsV2e"/>.
     /// </summary>
     public class NeuropixelsV2eHeadstageEditor : WorkflowComponentEditor
     {
@@ -17,7 +17,7 @@ namespace OpenEphys.Onix1.Design
             {
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
 
-                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV2eHeadstage configureV2eHeadstage)
+                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureHeadstageNeuropixelsV2e configureV2eHeadstage)
                 {
                     using var editorDialog = new NeuropixelsV2eHeadstageDialog(configureV2eHeadstage.NeuropixelsV2e, configureV2eHeadstage.Bno055);
 
@@ -34,7 +34,7 @@ namespace OpenEphys.Onix1.Design
                         return true;
                     }
                 }
-                else if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV2eBetaHeadstage configureV2eBetaHeadstage)
+                else if (editorState != null && !editorState.WorkflowRunning && component is ConfigureHeadstageNeuropixelsV2eBeta configureV2eBetaHeadstage)
                 {
                     using var editorDialog = new NeuropixelsV2eHeadstageDialog(configureV2eBetaHeadstage.NeuropixelsV2eBeta, configureV2eBetaHeadstage.Bno055);
 

--- a/OpenEphys.Onix1/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64.cs
@@ -5,14 +5,14 @@ using System.Threading;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Configures an ONIX headstage-64 on the specified port.
+    /// Configures an ONIX multifunction 64-channel headstage on the specified port.
     /// </summary>
     /// <remarks>
     /// Headstage-64 is a 1.5g serialized, multifunction headstage designed to function with passive
     /// probes such as tetrode microdrives, silicon arrays, EEG/ECOG arrays, etc. It provides the
     /// following features:
     /// <list type="bullet">
-    /// <item><description>64 analog ephys channels and 3 auxiliary channels sampled at 30 kHz per
+    /// <item><description>64 electrophysiology channels and 3 auxiliary channels sampled at 30 kHz per
     /// channel.</description></item>
     /// <item><description>A BNO055 9-axis IMU for real-time, 3D orientation tracking.</description></item>
     /// <item><description>Three TS4231 light to digital converters for real-time, 3D position tracking with
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix1
     /// <item><description>Two optical stimulators (800 mA peak current per channel).</description></item>
     /// </list>
     /// </remarks>
-    [Description("Configures an ONIX headstage-64 in the specified port.")]
+    [Description("Configures an ONIX multifunction 64-channel headstage.")]
     public class ConfigureHeadstage64 : MultiDeviceFactory
     {
         PortName port;
@@ -31,19 +31,6 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigureHeadstage64"/> class.
         /// </summary>
-        /// <remarks>
-        /// Headstage-64 is a 1.5g serialized, multifunction headstage designed to function with
-        /// tetrode microdrives. Alternatively it can be used with other passive probes (e.g.
-        /// silicon arrays, EEG/ECOG arrays, etc.). It provides the following features on the
-        /// headstage:
-        /// <list type="bullet">
-        /// <item><description>64 analog ephys channels and 3 auxiliary channels sampled at 30 kHz per channel.</description></item>
-        /// <item><description>A Bno055 9-axis IMU for real-time, 3D orientation tracking.</description></item>
-        /// <item><description>Three TS4231 light to digital converters for real-time, 3D position tracking with HTC Vive base stations.</description></item>
-        /// <item><description>A single electrical stimulator (current controlled, +/-15V compliance, automatic electrode discharge).</description></item>
-        /// <item><description>Two optical stimulators (800 mA peak current per channel).</description></item>
-        /// </list>
-        /// </remarks>
         public ConfigureHeadstage64()
         {
             // WONTFIX: The issue with this headstage is that its locking voltage is far, far lower than the

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
@@ -22,8 +22,8 @@ namespace OpenEphys.Onix1
     /// <item><description>A BNO055 9-axis IMU for real-time, 3D orientation tracking.</description></item>
     /// </list>
     /// </remarks>
-    [Description("Configures a NeuropixelsV1e headstage.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV1eHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
+    [Description("Configures a NeuropixelsV1e headstage.")]
     public class ConfigureHeadstageNeuropixelsV1e : MultiDeviceFactory
     {
         PortName port;

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 
@@ -23,15 +24,15 @@ namespace OpenEphys.Onix1
     /// </remarks>
     [Description("Configures a NeuropixelsV1e headstage.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV1eHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
-    public class ConfigureNeuropixelsV1eHeadstage : MultiDeviceFactory
+    public class ConfigureHeadstageNeuropixelsV1e : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureNeuropixelsV1ePortController PortControl = new();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigureNeuropixelsV1eHeadstage"/> class.
+        /// Initializes a new instance of the <see cref="ConfigureHeadstageNeuropixelsV1e"/> class.
         /// </summary>
-        public ConfigureNeuropixelsV1eHeadstage()
+        public ConfigureHeadstageNeuropixelsV1e()
         {
             Port = PortName.PortA;
             PortControl.HubConfiguration = HubConfiguration.Passthrough;
@@ -133,4 +134,8 @@ namespace OpenEphys.Onix1
             }
         }
     }
+
+    /// <inheritdoc cref="ConfigureHeadstageNeuropixelsV1e"/>
+    [Obsolete("This operator is obsolete. Use ConfigureHeadstageNeuropixelsV1e instead. Will be removed in version 1.0.0.")]
+    public class ConfigureNeuropixelsV1eHeadstage : ConfigureHeadstageNeuropixelsV1e { }
 }

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1f.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 
@@ -25,15 +26,15 @@ namespace OpenEphys.Onix1
     /// </remarks>
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV1fHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     [Description("Configures a NeuropixelsV1f headstage.")]
-    public class ConfigureNeuropixelsV1fHeadstage : MultiDeviceFactory
+    public class ConfigureHeadstageNeuropixelsV1f : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureNeuropixels1fHeadstageLinkController PortControl = new();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigureNeuropixelsV1eHeadstage"/> class.
+        /// Initializes a new instance of the <see cref="ConfigureHeadstageNeuropixelsV1f"/> class.
         /// </summary>
-        public ConfigureNeuropixelsV1fHeadstage()
+        public ConfigureHeadstageNeuropixelsV1f()
         {
             Port = PortName.PortA;
             PortControl.HubConfiguration = HubConfiguration.Standard;
@@ -178,4 +179,8 @@ namespace OpenEphys.Onix1
             }
         }
     }
+
+    /// <inheritdoc cref="ConfigureHeadstageNeuropixelsV1f"/>
+    [Obsolete("This operator is obsolete. Use ConfigureHeadstageNeuropixelsV1f instead. Will be removed in version 1.0.0.")]
+    public class ConfigureNeuropixelsV1fHeadstage : ConfigureHeadstageNeuropixelsV1f { }
 }

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
@@ -1,18 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Configures a NeuropixelsV2eBeta headstage on the specified port.
+    /// Configures a NeuropixelsV2e headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The NeuropixelsV2eBeta Headstage is a 0.64g serialized, multifunction headstage designed to
-    /// function with IMEC Neuropixels V2Beta probes. It provides the following features:
+    /// The NeuropixelsV2e Headstage is a 0.64g serialized, multifunction headstage designed to
+    /// function with IMEC Neuropixels V2 probes. It provides the following features:
     /// <list type="bullet">
-    /// <item><description>Support for dual IMEC Neuropixels 2.0-Beta probes, each of which features:
+    /// <item><description>Support for dual IMEC Neuropixels 2.0 probes, each of which features:
     /// <list type="bullet">
-    /// <item><description>4x silicon shanks with a 70 x 24 µm cross-section.</description></item>
+    /// <item><description>Either 1x or 4x silicon shanks with a 70 x 24 µm cross-section.</description></item>
     /// <item><description>1280 electrodes low-impedance TiN electrodes per shank.</description></item>
     /// <item><description>384 parallel, full-band (AP, LFP), low-noise recording channels.</description></item>
     /// </list>
@@ -20,29 +21,29 @@ namespace OpenEphys.Onix1
     /// <item><description>A BNO055 9-axis IMU for real-time, 3D orientation tracking.</description></item>
     /// </list>
     /// </remarks>
-    [Description("Configures a NeuropixelsV2eBeta headstage.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
-    public class ConfigureNeuropixelsV2eBetaHeadstage : MultiDeviceFactory
+    [Description("Configures a NeuropixelsV2e headstage on the specified port.")]
+    public class ConfigureHeadstageNeuropixelsV2e : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureNeuropixelsV2ePortController PortControl = new();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigureNeuropixelsV2eBetaHeadstage"/> class.
+        /// Initializes a new instance of the <see cref="ConfigureNeuropixelsV2e"/> class.
         /// </summary>
-        public ConfigureNeuropixelsV2eBetaHeadstage()
+        public ConfigureHeadstageNeuropixelsV2e()
         {
             Port = PortName.PortA;
             PortControl.HubConfiguration = HubConfiguration.Passthrough;
         }
 
         /// <summary>
-        /// Gets or sets the NeuropixelsV2eBeta configuration.
+        /// Gets or sets the NeuropixelsV2e configuration.
         /// </summary>
         [Category(DevicesCategory)]
         [TypeConverter(typeof(SingleDeviceFactoryConverter))]
-        [Description("Specifies the configuration for the NeuropixelsV2eBeta device.")]
-        public ConfigureNeuropixelsV2eBeta NeuropixelsV2eBeta { get; set; } = new();
+        [Description("Specifies the configuration for the NeuropixelsV2e device.")]
+        public ConfigureNeuropixelsV2e NeuropixelsV2e { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
@@ -69,7 +70,7 @@ namespace OpenEphys.Onix1
                 port = value;
                 var offset = (uint)port << 8;
                 PortControl.DeviceAddress = (uint)port;
-                NeuropixelsV2eBeta.DeviceAddress = offset + 0;
+                NeuropixelsV2e.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
         }
@@ -80,11 +81,11 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// If a port voltage is defined this will override the automated voltage discovery and applies
         /// the specified voltage to the headstage. To enable automated voltage discovery, leave this field 
-        /// empty. Warning: This device requires 3.0V to 5.0V for proper operation. Voltages higher than 5.0V can 
+        /// empty. Warning: This device requires 3.0V to 5.5V for proper operation. Voltages higher than 5.5V can 
         /// damage the headstage
         /// </remarks>
         [Description("If defined, overrides automated voltage discovery and applies " +
-            "the specified voltage to the headstage. Warning: this device requires 3.0V to 5.0V " +
+            "the specified voltage to the headstage. Warning: this device requires 3.0V to 5.5V " +
             "for proper operation. Higher voltages can damage the headstage.")]
         [Category(ConfigurationCategory)]
         public double? PortVoltage
@@ -96,8 +97,12 @@ namespace OpenEphys.Onix1
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return PortControl;
-            yield return NeuropixelsV2eBeta;
+            yield return NeuropixelsV2e;
             yield return Bno055;
         }
     }
+
+    /// <inheritdoc cref="ConfigureHeadstageNeuropixelsV2e"/>
+    [Obsolete("This operator is obsolete. Use ConfigureHeadstageNeuropixelsV2e instead. Will be removed in version 1.0.0.")]
+    public class ConfigureNeuropixelsV2eHeadstage : ConfigureHeadstageNeuropixelsV2e{ }
 }

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix1
     /// </list>
     /// </remarks>
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
-    [Description("Configures a NeuropixelsV2e headstage on the specified port.")]
+    [Description("Configures a NeuropixelsV2e headstage.")]
     public class ConfigureHeadstageNeuropixelsV2e : MultiDeviceFactory
     {
         PortName port;

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
@@ -1,18 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Configures a NeuropixelsV2e headstage on the specified port.
+    /// Configures a NeuropixelsV2eBeta headstage on the specified port.
     /// </summary>
     /// <remarks>
-    /// The NeuropixelsV2e Headstage is a 0.64g serialized, multifunction headstage designed to
-    /// function with IMEC Neuropixels V2 probes. It provides the following features:
+    /// The NeuropixelsV2eBeta Headstage is a 0.64g serialized, multifunction headstage designed to
+    /// function with IMEC Neuropixels V2Beta probes. It provides the following features:
     /// <list type="bullet">
-    /// <item><description>Support for dual IMEC Neuropixels 2.0 probes, each of which features:
+    /// <item><description>Support for dual IMEC Neuropixels 2.0-Beta probes, each of which features:
     /// <list type="bullet">
-    /// <item><description>Either 1x or 4x silicon shanks with a 70 x 24 µm cross-section.</description></item>
+    /// <item><description>4x silicon shanks with a 70 x 24 µm cross-section.</description></item>
     /// <item><description>1280 electrodes low-impedance TiN electrodes per shank.</description></item>
     /// <item><description>384 parallel, full-band (AP, LFP), low-noise recording channels.</description></item>
     /// </list>
@@ -20,29 +21,29 @@ namespace OpenEphys.Onix1
     /// <item><description>A BNO055 9-axis IMU for real-time, 3D orientation tracking.</description></item>
     /// </list>
     /// </remarks>
+    [Description("Configures a NeuropixelsV2eBeta headstage.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
-    [Description("Configures a NeuropixelsV2e headstage on the specified port.")]
-    public class ConfigureNeuropixelsV2eHeadstage : MultiDeviceFactory
+    public class ConfigureHeadstageNeuropixelsV2eBeta : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureNeuropixelsV2ePortController PortControl = new();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigureNeuropixelsV2e"/> class.
+        /// Initializes a new instance of the <see cref="ConfigureHeadstageNeuropixelsV2eBeta"/> class.
         /// </summary>
-        public ConfigureNeuropixelsV2eHeadstage()
+        public ConfigureHeadstageNeuropixelsV2eBeta()
         {
             Port = PortName.PortA;
             PortControl.HubConfiguration = HubConfiguration.Passthrough;
         }
 
         /// <summary>
-        /// Gets or sets the NeuropixelsV2e configuration.
+        /// Gets or sets the NeuropixelsV2eBeta configuration.
         /// </summary>
         [Category(DevicesCategory)]
         [TypeConverter(typeof(SingleDeviceFactoryConverter))]
-        [Description("Specifies the configuration for the NeuropixelsV2e device.")]
-        public ConfigureNeuropixelsV2e NeuropixelsV2e { get; set; } = new();
+        [Description("Specifies the configuration for the NeuropixelsV2eBeta device.")]
+        public ConfigureNeuropixelsV2eBeta NeuropixelsV2eBeta { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
@@ -69,7 +70,7 @@ namespace OpenEphys.Onix1
                 port = value;
                 var offset = (uint)port << 8;
                 PortControl.DeviceAddress = (uint)port;
-                NeuropixelsV2e.DeviceAddress = offset + 0;
+                NeuropixelsV2eBeta.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
         }
@@ -80,11 +81,11 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// If a port voltage is defined this will override the automated voltage discovery and applies
         /// the specified voltage to the headstage. To enable automated voltage discovery, leave this field 
-        /// empty. Warning: This device requires 3.0V to 5.5V for proper operation. Voltages higher than 5.5V can 
+        /// empty. Warning: This device requires 3.0V to 5.0V for proper operation. Voltages higher than 5.0V can 
         /// damage the headstage
         /// </remarks>
         [Description("If defined, overrides automated voltage discovery and applies " +
-            "the specified voltage to the headstage. Warning: this device requires 3.0V to 5.5V " +
+            "the specified voltage to the headstage. Warning: this device requires 3.0V to 5.0V " +
             "for proper operation. Higher voltages can damage the headstage.")]
         [Category(ConfigurationCategory)]
         public double? PortVoltage
@@ -96,8 +97,12 @@ namespace OpenEphys.Onix1
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return PortControl;
-            yield return NeuropixelsV2e;
+            yield return NeuropixelsV2eBeta;
             yield return Bno055;
         }
     }
+
+    /// <inheritdoc cref="ConfigureHeadstageNeuropixelsV2eBeta"/>
+    [Obsolete("This operator is obsolete. Use ConfigureHeadstageNeuropixelsV2eBeta instead. Will be removed in version 1.0.0.")]
+    public class ConfigureNeuropixelsV2eBetaHeadstage : ConfigureHeadstageNeuropixelsV2eBeta { }
 }

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
@@ -21,8 +21,8 @@ namespace OpenEphys.Onix1
     /// <item><description>A BNO055 9-axis IMU for real-time, 3D orientation tracking.</description></item>
     /// </list>
     /// </remarks>
-    [Description("Configures a NeuropixelsV2eBeta headstage.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
+    [Description("Configures a NeuropixelsV2eBeta headstage.")]
     public class ConfigureHeadstageNeuropixelsV2eBeta : MultiDeviceFactory
     {
         PortName port;

--- a/OpenEphys.Onix1/ConfigureHeadstageNric1384.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNric1384.cs
@@ -23,7 +23,7 @@ namespace OpenEphys.Onix1
     /// electrode discharge).</description></item>
     /// </list>
     /// </remarks>
-    [Description("Configures a Nric1384 Headstage headstage.")]
+    [Description("Configures a Nric1384 headstage.")]
     public class ConfigureHeadstageNric1384 : MultiDeviceFactory
     {
         PortName port;

--- a/OpenEphys.Onix1/ConfigureHeadstageRhs2116.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageRhs2116.cs
@@ -13,17 +13,17 @@ namespace OpenEphys.Onix1
     /// stimuli. The Rhs2116 Headstage can be used with passive probes (e.g. silicon arrays,
     /// EEG/ECOG arrays, etc) using a 36-Channel Omnetics EIB. It provides the following features:
     /// <list type="bullet">
-    /// <item><description>Two, synchronized Rhs2116 ICs for a combined 32 bidirectional ephys channels.</description></item>
+    /// <item><description>Two, synchronized Rhs2116 ICs for a combined 32 bidirectional ephys channels
+    /// sampled at 30.1932367 kHz per channel.</description></item>
     /// <item><description>Real-time control of stimulation sequences.</description></item>
-    /// <item><description>Real-time control of filter settings and artifact recovery parameters.</description></item>
-    /// <item><description>~1 millisecond active stimulus artifact recovery.</description></item>
+    /// <item><description>Real-time control of filter settings.</description></item>
+    /// <item><description>Active post-stimulus electrode discharge and filtering allowing ~1 ms artifact recovery.</description></item>
     /// <item><description>Max stimulator current: 2.55mA @ +/-7V compliance.</description></item>
-    /// <item><description>Sample rate: 30193.2367 Hz.</description></item>
     /// <item><description>Stimulus active and stimulus trigger pins.</description></item>
-    /// <item><description>On-board Lattice Crosslink FPGA for real-time data arbitration.</description></item>
     /// </list>
     /// </remarks>
     [Editor("OpenEphys.Onix1.Design.HeadstageRhs2116Editor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
+    [Description("Configures an ONIX Rhs2116 headstage.")]
     public class ConfigureHeadstageRhs2116 : MultiDeviceFactory
     {
         PortName port;

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -50,7 +50,7 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureNeuropixelsV2eHeadstage"/> to configure both
+        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2e"/> to configure both
         /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
         /// </remarks>
         [Category(ConfigurationCategory)]
@@ -81,7 +81,7 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureNeuropixelsV2eHeadstage"/> to configure both
+        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2e"/> to configure both
         /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
         /// </remarks>
         [Category(ConfigurationCategory)]

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -65,7 +65,7 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureNeuropixelsV2eBetaHeadstage"/> to configure both
+        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2eBeta"/> to configure both
         /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
         /// </remarks>
         [Category(ConfigurationCategory)]
@@ -96,7 +96,7 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureNeuropixelsV2eBetaHeadstage"/> to configure both
+        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2eBeta"/> to configure both
         /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
         /// </remarks>
         [Category(ConfigurationCategory)]


### PR DESCRIPTION
To make sorting easier, all aggregates now follow the pattern of ConfigureHeadstage*.
To aid in the transition, the original names are kept and inherit from the new name, but with an Obsolete tag indicating they will be removed in the future.

Miniscope was not included in this PR, as it is something of a special case where the aggregate and the device are very closely tied together.

- Fixes #371 