### PR TITLE
Display automatically set port voltage value

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.4.5</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/AutoPortVoltage.cs
+++ b/OpenEphys.Onix1/AutoPortVoltage.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Xml.Serialization;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Represents a, possibly automatically set, port voltage. 
+    /// </summary>
+    public class AutoPortVoltage
+    {
+        /// <summary>
+        /// Gets or sets a value the requested port voltage. If null, the voltage will be set automatically.
+        /// </summary>
+        public double? Requested { get; set; }
+
+        /// <summary>
+        /// Gets or sets the currently applied port voltage
+        /// </summary>
+        [XmlIgnore]
+        public double? Applied { get; internal set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoPortVoltage"/> class.
+        /// </summary>
+        public AutoPortVoltage() 
+        {
+            Requested = null;
+            Applied = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoPortVoltage"/> class.
+        /// </summary>
+        /// <param name="value">A value determining the requested port voltage</param>
+        public AutoPortVoltage(double? value) 
+        {
+            Requested = value;
+            Applied = null;
+        }
+    }
+
+    internal class PortVoltageConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+                return true;
+
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is AutoPortVoltage portVoltage)
+            {
+                if (portVoltage.Requested.HasValue)
+                {
+                    return string.Format($"{portVoltage.Requested:0.0}");
+                }
+                else if (portVoltage.Applied.HasValue)
+                {
+                    return $"{portVoltage.Applied:0.0} (Auto)";
+                }
+                else
+                {
+                    return "";
+                } 
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+                return true;
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string stringValue)
+            {
+
+                if (string.IsNullOrEmpty(stringValue))
+                {
+                    return new AutoPortVoltage(null);
+                }
+                else if (double.TryParse(stringValue, NumberStyles.Number, culture ?? CultureInfo.CurrentCulture, out double result))
+                {
+                    return new AutoPortVoltage(result);
+                }
+
+                throw new FormatException($"'{stringValue}' is not a valid value for PortVoltage.");
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
@@ -89,7 +89,8 @@ namespace OpenEphys.Onix1
             "the specified voltage to the headstage. Warning: this device requires 3.8V to 5.0V " +
             "for proper operation. Higher voltages can damage the headstage.")]
         [Category(ConfigurationCategory)]
-        public double? PortVoltage
+        [TypeConverter(typeof(PortVoltageConverter))]
+        public AutoPortVoltage PortVoltage
         {
             get => PortControl.PortVoltage;
             set => PortControl.PortVoltage = value;
@@ -104,20 +105,22 @@ namespace OpenEphys.Onix1
 
         class ConfigureNeuropixelsV1ePortController : ConfigurePortController
         {
-            protected override bool ConfigurePortVoltage(DeviceContext device)
+            protected override bool ConfigurePortVoltage(DeviceContext device, out double voltage)
             {
                 const double MinVoltage = 3.3;
                 const double MaxVoltage = 5.5;
                 const double VoltageOffset = 1.0;
                 const double VoltageIncrement = 0.2;
 
-                for (double voltage = MinVoltage; voltage <= MaxVoltage; voltage += VoltageIncrement)
+                voltage = MinVoltage;
+                for (; voltage <= MaxVoltage; voltage += VoltageIncrement)
                 {
                     SetVoltage(device, voltage);
 
                     if (CheckLinkState(device))
                     {
-                        SetVoltage(device, voltage + VoltageOffset);
+                        voltage += VoltageOffset;
+                        SetVoltage(device, voltage);
                         return CheckLinkState(device);
                     }
                 }

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
@@ -88,7 +88,8 @@ namespace OpenEphys.Onix1
             "the specified voltage to the headstage. Warning: this device requires 3.0V to 5.5V " +
             "for proper operation. Higher voltages can damage the headstage.")]
         [Category(ConfigurationCategory)]
-        public double? PortVoltage
+        [TypeConverter(typeof(PortVoltageConverter))]
+        public AutoPortVoltage PortVoltage
         {
             get => PortControl.PortVoltage;
             set => PortControl.PortVoltage = value;

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
@@ -88,7 +88,8 @@ namespace OpenEphys.Onix1
             "the specified voltage to the headstage. Warning: this device requires 3.0V to 5.0V " +
             "for proper operation. Higher voltages can damage the headstage.")]
         [Category(ConfigurationCategory)]
-        public double? PortVoltage
+        [TypeConverter(typeof(PortVoltageConverter))]
+        public AutoPortVoltage PortVoltage
         {
             get => PortControl.PortVoltage;
             set => PortControl.PortVoltage = value;

--- a/OpenEphys.Onix1/ConfigureHeadstageNric1384.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNric1384.cs
@@ -95,7 +95,8 @@ namespace OpenEphys.Onix1
             "the specified voltage to the headstage. Warning: this device requires 3.8V to 5.5V " +
             "for proper operation. Higher voltages can damage the headstage.")]
         [Category(ConfigurationCategory)]
-        public double? PortVoltage
+        [TypeConverter(typeof(PortVoltageConverter))]
+        public AutoPortVoltage PortVoltage
         {
             get => PortControl.PortVoltage;
             set => PortControl.PortVoltage = value;
@@ -110,19 +111,21 @@ namespace OpenEphys.Onix1
 
         class ConfigureHeadstageNric1384PortController : ConfigurePortController
         {
-            protected override bool ConfigurePortVoltage(DeviceContext device)
+            protected override bool ConfigurePortVoltage(DeviceContext device, out double voltage)
             {
                 const double MinVoltage = 3.8;
                 const double MaxVoltage = 5.5;
                 const double VoltageOffset = 0.7;
                 const double VoltageIncrement = 0.2;
 
-                for (var voltage = MinVoltage; voltage <= MaxVoltage; voltage += VoltageIncrement)
+                voltage = MinVoltage;
+                for (; voltage <= MaxVoltage; voltage += VoltageIncrement)
                 {
                     SetPortVoltage(device, voltage);
                     if (base.CheckLinkState(device))
                     {
-                        SetPortVoltage(device, voltage + VoltageOffset);
+                        voltage += VoltageOffset;
+                        SetPortVoltage(device, voltage);
                         return CheckLinkState(device);
                     }
                 }

--- a/OpenEphys.Onix1/ConfigureHeadstageRhs2116.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageRhs2116.cs
@@ -100,7 +100,8 @@ namespace OpenEphys.Onix1
                      "to the headstage. Warning: this device requires 3.4V to 4.4V for proper operation." +
                      "Supplying higher voltages may result in damage to the headstage.")]
         [Category(ConfigurationCategory)]
-        public double? PortVoltage
+        [TypeConverter(typeof(PortVoltageConverter))]
+        public AutoPortVoltage PortVoltage
         {
             get => LinkController.PortVoltage;
             set => LinkController.PortVoltage = value;
@@ -115,19 +116,21 @@ namespace OpenEphys.Onix1
 
         class ConfigureHeadstageRhs2116LinkController : ConfigurePortController
         {
-            protected override bool ConfigurePortVoltage(DeviceContext device)
+            protected override bool ConfigurePortVoltage(DeviceContext device, out double voltage)
             {
                 const double MinVoltage = 3.3;
                 const double MaxVoltage = 4.4;
                 const double VoltageOffset = 2.0;
                 const double VoltageIncrement = 0.2;
 
-                for (var voltage = MinVoltage; voltage <= MaxVoltage; voltage += VoltageIncrement)
+                voltage = MinVoltage;
+                for (; voltage <= MaxVoltage; voltage += VoltageIncrement)
                 {
                     SetPortVoltage(device, voltage);
                     if (base.CheckLinkState(device))
                     {
-                        SetPortVoltage(device, voltage + VoltageOffset);
+                        voltage += VoltageOffset;
+                        SetPortVoltage(device, voltage);
                         return CheckLinkState(device);
                     }
                 }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2ePortController.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2ePortController.cs
@@ -4,20 +4,22 @@ namespace OpenEphys.Onix1
 {
     class ConfigureNeuropixelsV2ePortController : ConfigurePortController
     {
-        protected override bool ConfigurePortVoltage(DeviceContext device)
+        protected override bool ConfigurePortVoltage(DeviceContext device, out double voltage)
         {
             const double MinVoltage = 3.3;
             const double MaxVoltage = 5.5;
             const double VoltageOffset = 1.0;
             const double VoltageIncrement = 0.2;
 
-            for (double voltage = MinVoltage; voltage <= MaxVoltage; voltage += VoltageIncrement)
+            voltage = MinVoltage;
+            for (; voltage <= MaxVoltage; voltage += VoltageIncrement)
             {
                 SetVoltage(device, voltage);
 
                 if (CheckLinkState(device))
                 {
-                    SetVoltage(device, voltage + VoltageOffset);
+                    voltage += VoltageOffset;
+                    SetVoltage(device, voltage);
                     return CheckLinkState(device);
                 }
             }

--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4.cs
@@ -99,7 +99,8 @@ namespace OpenEphys.Onix1
                      "to the miniscope. Warning: this device requires 4.0 to 5.0V, measured at the scope, for proper operation. " +
                      "Supplying higher voltages may result in damage to the miniscope.")]
         [Category(ConfigurationCategory)]
-        public double? PortVoltage
+        [TypeConverter(typeof(PortVoltageConverter))]
+        public AutoPortVoltage PortVoltage
         {
             get => PortControl.PortVoltage;
             set => PortControl.PortVoltage = value;
@@ -116,12 +117,13 @@ namespace OpenEphys.Onix1
         {
             internal ConfigureUclaMiniscopeV4Camera Camera;
 
-            protected override bool ConfigurePortVoltage(DeviceContext device)
+            protected override bool ConfigurePortVoltage(DeviceContext device, out double voltage)
             {
                 const double MinVoltage = 5.2;
                 const double VoltageIncrement = 0.05;
 
-                for (var voltage = MinVoltage; voltage <= MaxVoltage; voltage += VoltageIncrement)
+                voltage = MinVoltage;
+                for (; voltage <= MaxVoltage; voltage += VoltageIncrement)
                 {
                     SetPortVoltage(device, voltage);
                     if (CheckLinkStateWithRetry(device))

--- a/OpenEphys.Onix1/Rhs2116Stimulus.cs
+++ b/OpenEphys.Onix1/Rhs2116Stimulus.cs
@@ -5,7 +5,7 @@ using Bonsai;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Defines a single stimulus sequence for a channel on an RHS2116 device.
+    /// Defines a single stimulus sequence for a channel on an Rhs2116 device.
     /// </summary>
     public class Rhs2116Stimulus
     {


### PR DESCRIPTION
- When the PortVoltage is null, the port voltage will be set automatically. If this procedure succeeds, the voltage will be displayed in the text box as "X.X (Auto)" where X.X is the voltage that is applied to the port.
- This text will only appear while the workflow is running. It will revert back to null after the workflow is stopped.
- If the voltage is set manually, the value will persist.
- Fixed #429 