### PR TITLE
Add support for stimulus trigger events from headstage-rhs2116

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.4.5</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/ConfigureRhs2116.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116.cs
@@ -187,6 +187,10 @@ namespace OpenEphys.Onix1
                         device.WriteRegister(Rhs2116.BW1, regs[3] << 6 | regs[2]);
                         device.WriteRegister(Rhs2116.FASTSETTLESAMPLES, Rhs2116Config.AnalogHighCutoffToFastSettleSamples[newValue]);
                     }),
+                    respectExternalActiveStim.SubscribeSafe(observer, newValue =>
+                    {
+                        device.WriteRegister(Rhs2116.RESPECTSTIMACTIVE, newValue ? 1u : 0u);
+                    }),
                     DeviceManager.RegisterDevice(deviceName, device, DeviceType)
                 );
             });

--- a/OpenEphys.Onix1/ConfigureRhs2116Pair.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116Pair.cs
@@ -149,6 +149,10 @@ namespace OpenEphys.Onix1
                     // consistency
                     device.WriteRegister(Rhs2116.FORMAT, format);
                     device.WriteRegister(Rhs2116.ENABLE, enable ? 1u : 0);
+
+                    // Force each device to respect each other's stimulation state since they are being
+                    // treated, de-facto, as a single chip.
+                    device.WriteRegister(Rhs2116.RESPECTSTIMACTIVE, 1u);
                 }
 
                 ConfigureChip(rhs2116A, enable, dspCutoff);

--- a/OpenEphys.Onix1/Rhs2116PairData.cs
+++ b/OpenEphys.Onix1/Rhs2116PairData.cs
@@ -10,7 +10,7 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of <see cref="Rhs2116DataFrame"/> objects from a synchronized pair of Intan
+    /// Produces a sequence of <see cref="Rhs2116PairDataFrame"/> objects from a synchronized pair of Intan
     /// Rhs2116 bidirectional bioacquisition chips.
     /// chips.
     /// </summary>
@@ -18,7 +18,7 @@ namespace OpenEphys.Onix1
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
     /// cref="ConfigureRhs2116Pair"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
-    public class Rhs2116PairData : Source<Rhs2116DataFrame>
+    public class Rhs2116PairData : Source<Rhs2116PairDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(Rhs2116Pair.NameConverter))]
@@ -31,20 +31,20 @@ namespace OpenEphys.Onix1
         /// This property determines the number of samples that are collected from each of the 32
         /// electrophysiology channels before data is propagated. For instance, if this value is set to 30,
         /// then 32x30 samples, along with 30 corresponding clock values, will be collected and packed into
-        /// each <see cref="Rhs2116DataFrame"/>. Because channels are sampled at ~30 kHz, this is equivalent
+        /// each <see cref="Rhs211Pair6DataFrame"/>. Because channels are sampled at ~30 kHz, this is equivalent
         /// to ~1 millisecond of data from each channel.
         /// </remarks>
         public int BufferSize { get; set; } = 30;
 
         /// <summary>
-        /// Generates a sequence of <see cref="Rhs2116DataFrame"/>s.
+        /// Generates a sequence of <see cref="Rhs2116PairDataFrame"/>s.
         /// </summary>
-        /// <returns>A sequence of <see cref="Rhs2116DataFrame"/>s.</returns>
-        public unsafe override IObservable<Rhs2116DataFrame> Generate()
+        /// <returns>A sequence of <see cref="Rhs211Pair6DataFrame"/>s.</returns>
+        public unsafe override IObservable<Rhs2116PairDataFrame> Generate()
         {
             var bufferSize = BufferSize;
             return DeviceManager.GetDevice(DeviceName).SelectMany(
-                deviceInfo => Observable.Create<Rhs2116DataFrame>(observer =>
+                deviceInfo => Observable.Create<Rhs2116PairDataFrame>(observer =>
                 {
                     var sampleIndex = 0;
                     var dualInfo = (Rhs2116PairDeviceInfo)deviceInfo;
@@ -52,6 +52,7 @@ namespace OpenEphys.Onix1
                     var rhs2116B = dualInfo.Rhs2116B;
                     var amplifierBuffer = new short[Rhs2116Pair.TotalChannels * bufferSize];
                     var dcBuffer = new short[Rhs2116Pair.TotalChannels * bufferSize];
+                    var recovery = new uint[bufferSize];
                     var hubClockBuffer = new ulong[bufferSize];
                     var clockBuffer = new ulong[bufferSize];
 
@@ -64,24 +65,27 @@ namespace OpenEphys.Onix1
                                 var payload = (Rhs2116Payload*)frame.Data.ToPointer();
                                 Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, offset, Rhs2116.AmplifierChannelCount);
                                 Marshal.Copy(new IntPtr(payload->DCData), dcBuffer, offset, Rhs2116.AmplifierChannelCount);
+                                recovery[sampleIndex] |= payload->Recovery;
 
                                 if (++sampleIndex >= bufferSize)
                                 {
                                     var amplifierData = BufferHelper.CopyTranspose(amplifierBuffer, bufferSize, Rhs2116Pair.TotalChannels, Depth.U16);
                                     var dcData = BufferHelper.CopyTranspose(dcBuffer, bufferSize, Rhs2116Pair.TotalChannels, Depth.U16);
-                                    observer.OnNext(new Rhs2116DataFrame(clockBuffer, hubClockBuffer, amplifierData, dcData));
+                                    observer.OnNext(new Rhs2116PairDataFrame(clockBuffer, hubClockBuffer, amplifierData, dcData, recovery));
                                     hubClockBuffer = new ulong[bufferSize];
+                                    recovery = new uint[bufferSize];
                                     clockBuffer = new ulong[bufferSize];
                                     sampleIndex = 0;
                                 }
                                 
-                            } else
+                            } else // Chip B
                             {
                                 var offset = sampleIndex * Rhs2116Pair.TotalChannels + Rhs2116Pair.ChannelsPerChip;
                                 var payload = (Rhs2116Payload*)frame.Data.ToPointer();
                                 Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, offset, Rhs2116.AmplifierChannelCount);
                                 Marshal.Copy(new IntPtr(payload->DCData), dcBuffer, offset, Rhs2116.AmplifierChannelCount);
                                 hubClockBuffer[sampleIndex] = payload->HubClock;
+                                recovery[sampleIndex] |= (uint)payload->Recovery << 16;
                                 clockBuffer[sampleIndex] = frame.Clock;
                             }
 

--- a/OpenEphys.Onix1/Rhs2116PairDataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116PairDataFrame.cs
@@ -1,25 +1,20 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Specialized;
-using System.Numerics;
-using System.Runtime.InteropServices;
-using OpenCV.Net;
+﻿using OpenCV.Net;
 
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Buffered data from a Rhs2116 device.
+    /// Buffered data from two Rhs2116 devices.
     /// </summary>
-    public class Rhs2116DataFrame : BufferedDataFrame
+    public class Rhs2116PairDataFrame : BufferedDataFrame
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Rhs2116DataFrame"/> class.
+        /// Initializes a new instance of the <see cref="Rhs2116PairDataFrame"/> class.
         /// </summary>
         /// <param name="clock">An array of <see cref="DataFrame.Clock"/> values.</param>
         /// <param name="hubClock">An array of hub clock counter values.</param>
         /// <param name="amplifierData">An array of multi-channel amplifier data.</param>
         /// <param name="dcData">An array of multi-channel DC data.</param>
-        public Rhs2116DataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, Mat dcData, ushort[] recoveryMask)
+        public Rhs2116PairDataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, Mat dcData, uint[] recoveryMask)
             : base(clock, hubClock)
         {
             AmplifierData = amplifierData;
@@ -31,8 +26,8 @@ namespace OpenEphys.Onix1
         /// Gets the high-gain electrophysiology data array.
         /// </summary>
         /// <remarks>
-        /// Electrophysiology samples are organized in a 16xN matrix with 16 rows representing electrophysiology
-        /// channel and N columns representing sample index. Each column is a 16-channel vector of ADC
+        /// Electrophysiology samples are organized in 32xN matrix with 32 rows representing electrophysiology
+        /// channel and N columns representing sample index. Each column is a M-channel vector of ADC
         /// samples whose acquisition time is indicated by the corresponding elements in <see
         /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is an 16-bit,
         /// offset binary value encoded as a <see cref="ushort"/>. The following equation can be used to
@@ -47,8 +42,8 @@ namespace OpenEphys.Onix1
         /// Gets the DC-coupled, low-gain amplifier data array for monitoring stimulation waveforms.
         /// </summary>
         /// <remarks>
-        /// DC-coupled samples are organized in 16xN matrix with 16 rows representing electrophysiology
-        /// channel and N columns representing sample index. Each column is a 16-channel vector of ADC
+        /// DC-coupled samples are organized in 32xN matrix with 32 rows representing electrophysiology
+        /// channel and N columns representing sample index. Each column is a 32-channel vector of ADC
         /// samples whose acquisition time is indicated by the corresponding elements in <see
         /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is an 10-bit,
         /// offset binary value encoded as a <see cref="ushort"/>. The following equation can be used to
@@ -66,20 +61,12 @@ namespace OpenEphys.Onix1
         /// During and following stimulus pulses, electrophysiology amplifiers can enter an artifact recovery
         /// mode which discharges the electrode and applies an aggressive high-pass filter to prevent
         /// amplifier saturation (see <see cref="ConfigureRhs2116.AnalogLowCutoffRecovery"/>). This 1xN vector
-        /// provides a per-sample bit mask indicating if artifact recovery mode is active on each of the 16
+        /// provides a per-sample bit mask indicating if artifact recovery mode is active on each of the 32
         /// electrophysiology channels. The bit position in each value indicates the channel number and the
-        /// logical state indicates if recovery is active. For instance a value of 0x0011 would indicate that
-        /// channels 0 and 4 were in artifact recovery mode and all other channels were in normal operation.
+        /// logical state indicates if recovery is active. For instance a value of 0x0001_0001 would
+        /// indicate that channels 0 and 16 were in artifact recovery mode and all other channels were in
+        /// normal operation.
         /// </remarks>
-        public ushort[] RecoveryMask { get; }
-    }
-
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    unsafe struct Rhs2116Payload
-    {
-        public ulong HubClock;
-        public fixed ushort AmplifierData[Rhs2116.AmplifierChannelCount];
-        public fixed ushort DCData[Rhs2116.AmplifierChannelCount];
-        public ushort Recovery;
+        public uint[] RecoveryMask { get; }
     }
 }

--- a/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
+++ b/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
@@ -7,7 +7,7 @@ using Bonsai;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Controls an RHS2116 stimulus sequence.
+    /// Controls an Rhs2116 stimulus sequence.
     /// </summary>
     /// <remarks>
     /// This operator must be linked to an appropriate configuration, such as a <see

--- a/OpenEphys.Onix1/Rhs2116TriggerData.cs
+++ b/OpenEphys.Onix1/Rhs2116TriggerData.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Produces a sequence of <see cref="Rhs2116TriggerDataFrame"/> objects indicating the time and
+    /// status of stimulus trigger events.
+    /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureRhs2116Trigger"/>, using a shared <c>DeviceName</c>.
+    /// </remarks>
+    [Description("Produces a sequence of Rhs2116TriggerDataFrame objects indicating the time and status of stimulus trigger events.")]
+    public class Rhs2116TriggerData : Source<Rhs2116TriggerDataFrame>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(Rhs2116Trigger.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        [Category(DeviceFactory.ConfigurationCategory)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Generates a sequence of <see cref="Rhs2116TriggerDataFrame"/>s.
+        /// </summary>
+        /// <returns>A sequence of <see cref="Rhs2116TriggerDataFrame"/>s.</returns>
+        public override IObservable<Rhs2116TriggerDataFrame> Generate()
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var device = deviceInfo.GetDeviceContext(typeof(Rhs2116Trigger));
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
+                    .Select(frame => new Rhs2116TriggerDataFrame(frame));
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/Rhs2116TriggerDataFrame.cs
+++ b/OpenEphys.Onix1/Rhs2116TriggerDataFrame.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A trigger event received by an Rhs2116 trigger device.
+    /// </summary>
+    /// <remarks>
+    /// These events provide synchronized recordings of stimulus trigger times. They provide information about
+    /// the source of the trigger and if it was applied or ignored and for what reason.
+    /// </remarks>
+    public class Rhs2116TriggerDataFrame : DataFrame
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rhs2116TriggerDataFrame"/> class.
+        /// </summary>
+        /// <param name="frame">An ONI data frame containing Rhs2116 trigger data.</param>
+        public unsafe Rhs2116TriggerDataFrame(oni.Frame frame)
+            : base(frame.Clock)
+        {
+            var payload = (Rhs2116TriggerPayload*)frame.Data.ToPointer();
+            HubClock = payload->HubClock;
+            Delay = 1e6 * ((payload->TriggerCode & 0b1111_1111_1111_1111_1111_0000_0000_0000) >> 12) / Rhs2116.SampleFrequencyHz;
+            Status = (Rhs2116TriggerResult)(payload->TriggerCode & 0b11);
+            Origin = (Rhs2116TriggerOrigin)((payload->TriggerCode & 0b11100) >> 2) ;
+        }
+
+        /// <summary>
+        /// Gets the delay, in microseconds, from this trigger to the physical application of the stimulus
+        /// sequence.
+        /// </summary>
+        /// <remarks>
+        /// This value is determined by the delay sequence provided as input to <see
+        /// cref="Rhs2116StimulusTrigger"/>.
+        /// </remarks>
+        public double Delay { get; }
+
+        /// <summary>
+        /// Gets the status of the trigger.
+        /// </summary>
+        public Rhs2116TriggerResult Status { get; }
+
+        /// <summary>
+        /// Gets the origin of the trigger.
+        /// </summary>
+        public Rhs2116TriggerOrigin Origin {get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct Rhs2116TriggerPayload
+    {
+        public ulong HubClock;
+        public uint TriggerCode;
+        public short Padding;
+    }
+
+    /// <summary>
+    /// Specifies the status of the trigger.
+    /// </summary>
+    [Flags]
+    public enum Rhs2116TriggerResult : byte
+    {
+        /// <summary>
+        /// Specifies that the trigger was applied successfully.
+        /// </summary>
+        Delivered = 0x0,
+
+        /// <summary>
+        /// Specifies that the trigger was ignored because the stimulator is disarmed.
+        /// </summary>
+        Disarmed = 0x1,
+
+        /// <summary>
+        /// Specifies that the trigger was ignored because the stimulus sequencer is in the middle of applying a stimulus sequence.
+        /// </summary>
+        SequencerBusy = 0x02,
+    }
+
+    /// <summary>
+    /// Specifies the origin of the trigger.
+    /// </summary>
+    [Flags]
+    public enum Rhs2116TriggerOrigin : byte
+    {
+        /// <summary>
+        /// Specifies the source of the trigger is unknown.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// Specifies the source of the trigger is a local Gpio pin.
+        /// </summary>
+        Gpio = 0x1,
+
+        /// <summary>
+        /// Specifies the source of the trigger is a a register.
+        /// </summary>
+        Register = 0x2,
+
+        /// <summary>
+        /// Specifies the source of the trigger is an external synchronization pin.
+        /// </summary>
+        External = 0x4
+    }
+}


### PR DESCRIPTION
- New trigger event data operators
- Add recovery mask to existing rhs2116 data operators
- Create new, explicitly Rhs2116PairDataFrame type because it was going to be a hack to reuse Rhs2116DataFrame with this new recovery information
- Partially addresses #384