### PR TITLE
Add support for persistent heartbeat device

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.4.5</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutBoard.cs
@@ -26,12 +26,12 @@ namespace OpenEphys.Onix1
         /// Gets or sets the heartbeat configuration.
         /// </summary>
         /// <remarks>
-        /// This heartbeat is always enabled and beats at 100 Hz.
+        /// This heartbeat is always enabled and beats at a minimum of 100 Hz.
         /// </remarks>
-        [TypeConverter(typeof(HeartbeatSingleDeviceFactoryConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the heartbeat device in the ONIX breakout board.")]
         [Category(DevicesCategory)]
-        public ConfigureHeartbeat Heartbeat { get; set; } = new ConfigureHeartbeat { Enable = true, BeatsPerSecond = 100 };
+        public ConfigurePersistentHeartbeat Heartbeat { get; set; } = new ConfigurePersistentHeartbeat { BeatsPerSecond = 100 };
 
         /// <summary>
         /// Gets or sets the breakout board's analog IO configuration.

--- a/OpenEphys.Onix1/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix1/ConfigureHeartbeat.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using Bonsai;
@@ -41,10 +40,6 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Gets or sets the rate at which beats are produced in Hz.
         /// </summary>
-        /// <remarks>
-        /// If set to true, a <see cref="HeartbeatData"/> instance that is linked to this configuration will produce data.
-        /// If set to false, it will not produce data.
-        /// </remarks>
         [Range(1, 10e6)]
         [Category(AcquisitionCategory)]
         [Description("Rate at which beats are produced (Hz).")]
@@ -100,23 +95,6 @@ namespace OpenEphys.Onix1
                 : base(typeof(Heartbeat))
             {
             }
-        }
-    }
-
-    // NB: Can be used to remove Enable and BeatsPerSecond properties from MultiDeviceFactories that
-    // include a Heartbeat when having those options would cause confusion
-    internal class HeartbeatSingleDeviceFactoryConverter : SingleDeviceFactoryConverter
-    {
-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
-        {
-            var properties = (from property in base.GetProperties(context, value, attributes).Cast<PropertyDescriptor>()
-                              where !property.IsReadOnly &&
-                                    !(property.DisplayName == "Enable") &&
-                                    !(property.DisplayName == "BeatsPerSecond") &&
-                                    property.ComponentType != typeof(SingleDeviceFactory)
-                              select property)
-                              .ToArray();
-            return new PropertyDescriptorCollection(properties).Sort(properties.Select(p => p.Name).ToArray());
         }
     }
 }

--- a/OpenEphys.Onix1/ConfigurePersistentHeartbeat.cs
+++ b/OpenEphys.Onix1/ConfigurePersistentHeartbeat.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Subjects;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Configures a persistent heartbeat device whose data stream cannot be disabled.
+    /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to a data IO operator, such as <see cref="HeartbeatData"/>,
+    /// using a shared <c>DeviceName</c>.
+    /// </remarks>
+    [Description("Configures a heartbeat device.")]
+    public class ConfigurePersistentHeartbeat : SingleDeviceFactory
+    {
+        readonly BehaviorSubject<uint> beatsPerSecond = new(100);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurePersistentHeartbeat"/> class.
+        /// </summary>
+        public ConfigurePersistentHeartbeat()
+            : base(typeof(PersistentHeartbeat))
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the rate at which beats are produced in Hz.
+        /// </summary>
+        [Range(100, 10e6)]
+        [Category(AcquisitionCategory)]
+        [Description("Rate at which beats are produced (Hz).")]
+        public uint BeatsPerSecond
+        {
+            get => beatsPerSecond.Value;
+            set => beatsPerSecond.OnNext(value);
+        }
+
+        /// <summary>
+        /// Configures a persistent heartbeat device.
+        /// </summary>
+        /// <remarks>
+        /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/>
+        /// instance prior to data acquisition.
+        /// </remarks>
+        /// <param name="source">A sequence of <see cref="ContextTask"/> instances that holds configuration
+        /// actions.</param>
+        /// <returns>The original sequence modified by adding additional configuration actions required to
+        /// configure a persistent heartbeat device./></returns>
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            //var enable = Enable;
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice((context, observer) =>
+            {
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
+                var subscription = beatsPerSecond.SubscribeSafe(observer, newValue =>
+                {
+                    var clkHz = device.ReadRegister(PersistentHeartbeat.CLK_HZ);
+                    var minHeartbeatHz = device.ReadRegister(PersistentHeartbeat.MIN_HB_HZ);
+
+                    if (newValue < minHeartbeatHz || newValue > 10e6)
+                    {
+                        throw new InvalidOperationException($"Value must be between {minHeartbeatHz} Hz and 10 MHz.");
+                    }
+
+                    device.WriteRegister(PersistentHeartbeat.CLK_DIV, clkHz / newValue);
+                });
+
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+            });
+        }
+    }
+
+    static class PersistentHeartbeat
+    {
+        public const int ID = 34;
+
+        public const uint ENABLE = 0; // Heartbeat enable state (read only; always enabled for this device).
+        public const uint CLK_DIV = 1; // Heartbeat clock divider ratio. Minimum value is CLK_HZ / 10e6.
+                                       // Maximum value is CLK_HZ / MIN_HB_HZ.Attempting to set to a value outside
+                                       // this range will result in error.
+        public const uint CLK_HZ = 2; // The frequency parameter, CLK_HZ, used in the calculation of CLK_DIV
+        public const uint MIN_HB_HZ = 3; // The minimum allowed beat frequency, in Hz, for this device
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(PersistentHeartbeat))
+            {
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -60,6 +60,7 @@ namespace OpenEphys.Onix1
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 void dispose() => device.WriteRegister(PortController.PORTVOLTAGE, 0);
                 device.WriteRegister(PortController.ENABLE, 1);
+                device.WriteRegister(PortController.DESPWR, 1); 
 
                 var serdesLock = portVoltage.HasValue
                     ? ConfigurePortVoltageOverride(device, portVoltage.GetValueOrDefault())

--- a/OpenEphys.Onix1/PersistentHeartbeatData.cs
+++ b/OpenEphys.Onix1/PersistentHeartbeatData.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Produces an persistent sequence of heartbeat data frames.
+    /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigurePersistentHeartbeat"/>, using a shared <c>DeviceName</c>.
+    /// </remarks>
+    [Description("Produces a persistent sequence of heartbeat data frames.")]
+    public class PersistentHeartbeatData : Source<HeartbeatDataFrame>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(PersistentHeartbeat.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        [Category(DeviceFactory.ConfigurationCategory)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Generates a sequence of <see cref="HeartbeatDataFrame"/> objects, each of which contains period signal from the
+        /// acquisition system indicating that it is active.
+        /// </summary>
+        /// <returns>A sequence of <see cref="HeartbeatDataFrame"/> objects.</returns>
+        public override IObservable<HeartbeatDataFrame> Generate()
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var device = deviceInfo.GetDeviceContext(typeof(PersistentHeartbeat));
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
+                    .Select(frame => new HeartbeatDataFrame(frame));
+            });
+        }
+    }
+}


### PR DESCRIPTION
- This will come in the next onix firmware verion
- Has fixed enable state which obviates the hacks we had to hide the enable property in ConfigureatHeartbeat.cs