### PR TITLE
Change DigitalPortState backing type from ushort to byte

### DIFF
--- a/OpenEphys.Onix1/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix1/ConfigureDigitalIO.cs
@@ -84,7 +84,7 @@ namespace OpenEphys.Onix1
     /// Specifies the state of the ONIX breakout board's digital input pins.
     /// </summary>
     [Flags]
-    public enum DigitalPortState : ushort
+    public enum DigitalPortState : byte
     {
         /// <summary>
         /// Specifies that pin 0 is high.

--- a/OpenEphys.Onix1/DigitalInputDataFrame.cs
+++ b/OpenEphys.Onix1/DigitalInputDataFrame.cs
@@ -36,6 +36,7 @@ namespace OpenEphys.Onix1
     {
         public ulong HubClock;
         public DigitalPortState DigitalInputs;
+        public byte Pad; // NB: Pad comes after port state due to endianness change
         public BreakoutButtonState Buttons;
     }
 }


### PR DESCRIPTION
- MSBs are set to 0 by hardware so why waste the space
- Fixes #449 