### PR TITLE
Document Rhs2116Trigger's input double as delay

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.4.5</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
+++ b/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
@@ -20,9 +20,12 @@ namespace OpenEphys.Onix1
         public string DeviceName { get; set; }
 
         /// <summary>
-        /// Start an electrical stimulus sequence.
+        /// Start an electrical stimulus sequence with an optional hardware delay.
         /// </summary>
-        /// <param name="source">A sequence of double values indicating the delay in microseconds before the start of a stimulus sequence.</param>
+        /// <param name="source">A sequence of double values that serves a combined a stimulus trigger and
+        /// delay in microseconds. A value of 0 results in immediate stimulus delivery. A value of 100 results
+        /// stimulus delivery following a 100 microsecond delay. Delays are implemented in hardware and are
+        /// exact. </param>
         /// <returns>A sequence of double values that is identical to <paramref name="source"/></returns>
         public override IObservable<double> Process(IObservable<double> source)
         {

--- a/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
+++ b/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
@@ -22,8 +22,8 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Start an electrical stimulus sequence with an optional hardware delay.
         /// </summary>
-        /// <param name="source">A sequence of double values that serves a combined a stimulus trigger and
-        /// delay in microseconds. A value of 0 results in immediate stimulus delivery. A value of 100 results
+        /// <param name="source">A sequence of double values that serve as a combined stimulus trigger and
+        /// delay in microseconds. A value of 0 results in immediate stimulus delivery. A value of 100 results in
         /// stimulus delivery following a 100 microsecond delay. Delays are implemented in hardware and are
         /// exact. </param>
         /// <returns>A sequence of double values that is identical to <paramref name="source"/></returns>

--- a/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
+++ b/OpenEphys.Onix1/Rhs2116StimulusTrigger.cs
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Start an electrical stimulus sequence.
         /// </summary>
-        /// <param name="source">A sequence of double values that start the stimulus sequence when received.</param>
+        /// <param name="source">A sequence of double values indicating the delay in microseconds before the start of a stimulus sequence.</param>
         /// <returns>A sequence of double values that is identical to <paramref name="source"/></returns>
         public override IObservable<double> Process(IObservable<double> source)
         {


### PR DESCRIPTION
Doubles received by the Rhs2116Trigger node indicate the delay in microseconds before delivering the stimulation waveform.

Fix #453