### PR TITLE
Add support for i2c multibyte access and make polledbno use it

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -2,21 +2,29 @@
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
     <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Arduino" version="2.8.1" />
+    <Package id="Bonsai.Audio" version="2.8.0" />
     <Package id="Bonsai.Core" version="2.8.5" />
     <Package id="Bonsai.Design" version="2.8.5" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
     <Package id="Bonsai.Dsp.Design" version="2.8.0" />
     <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Osc" version="2.7.0" />
     <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Shaders" version="0.27.0" />
+    <Package id="Bonsai.Shaders.Design" version="0.27.0" />
+    <Package id="Bonsai.StarterPack" version="2.8.1" />
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.System.Design" version="2.8.0" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Windows.Input" version="2.7.0" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
     <Package id="Markdig" version="0.18.1" />
     <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="openal.redist" version="2.0.7" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
     <Package id="OpenTK.GLControl" version="3.1.0" />
@@ -36,33 +44,45 @@
   </Packages>
   <AssemblyReferences>
     <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Arduino" />
+    <AssemblyReference assemblyName="Bonsai.Audio" />
     <AssemblyReference assemblyName="Bonsai.Core" />
     <AssemblyReference assemblyName="Bonsai.Design" />
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Dsp.Design" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Osc" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Shaders" />
+    <AssemblyReference assemblyName="Bonsai.Shaders.Design" />
     <AssemblyReference assemblyName="Bonsai.System" />
     <AssemblyReference assemblyName="Bonsai.System.Design" />
     <AssemblyReference assemblyName="Bonsai.Vision" />
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
+    <AssemblyReference assemblyName="Bonsai.Windows.Input" />
   </AssemblyReferences>
   <AssemblyLocations>
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Arduino" processorArchitecture="MSIL" location="Packages/Bonsai.Arduino.2.8.1/lib/net462/Bonsai.Arduino.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Audio" processorArchitecture="MSIL" location="Packages/Bonsai.Audio.2.8.0/lib/net462/Bonsai.Audio.dll" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.Design.2.8.0/lib/net462/Bonsai.Dsp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Osc" processorArchitecture="MSIL" location="Packages/Bonsai.Osc.2.7.0/lib/net462/Bonsai.Osc.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Shaders" processorArchitecture="MSIL" location="Packages/Bonsai.Shaders.0.27.0/lib/net462/Bonsai.Shaders.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Shaders.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Shaders.Design.0.27.0/lib/net462/Bonsai.Shaders.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages/Bonsai.System.Design.2.8.0/lib/net462/Bonsai.System.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Windows.Input" processorArchitecture="MSIL" location="Packages/Bonsai.Windows.Input.2.7.0/lib/net462/Bonsai.Windows.Input.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
@@ -92,6 +112,8 @@
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/openal.redist.2.0.7.0/build/native/bin/x64" platform="x64" />
+    <LibraryFolder path="Packages/openal.redist.2.0.7.0/build/native/bin/x86" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/OpenEphys.Onix1/PolledBno055Data.cs
+++ b/OpenEphys.Onix1/PolledBno055Data.cs
@@ -115,46 +115,56 @@ namespace OpenEphys.Onix1
                                 registeredValues.Add(deviceName);
                             }
 
+                            // Preallocate the array to avoid unnecesary allocation each frame
+                            byte[] data = new byte[28];
                             var s = source.SubscribeSafe(observer, _ =>
                             {
                                 Bno055DataFrame frame = default;
                                 device.Context.EnsureContext(() =>
                                 {
-                                    byte[] data = {
-                                        polled.HasFlag(PolledBno055Registers.EulerAngle) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 0) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.EulerAngle) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 1) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.EulerAngle) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 2) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.EulerAngle) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 3) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.EulerAngle) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 4) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.EulerAngle) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 5) : (byte)0,
+                                      if (polled.HasFlag(PolledBno055Registers.EulerAngle))
+                                      {
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 0, 4, data, 0);
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 4, 2, data, 4);
+                                      }
+                                      else
+                                      {
+                                          Array.Clear(data, 0, 6);
+                                      }
 
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 6) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 7) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 8) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 9) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 10) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 11) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 12) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Quaternion) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 13) : (byte)0,
+                                      if (polled.HasFlag(PolledBno055Registers.Quaternion))
+                                      {
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 6, 4, data, 6);
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 10, 4, data, 10);
+                                      }
+                                      else
+                                      {
+                                          Array.Clear(data, 6, 8);
+                                      }
 
-                                        polled.HasFlag(PolledBno055Registers.Acceleration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 14) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Acceleration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 15) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Acceleration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 16) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Acceleration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 17) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Acceleration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 18) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Acceleration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 19) : (byte)0,
+                                      if (polled.HasFlag(PolledBno055Registers.Acceleration))
+                                      {
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 14, 4, data, 14);
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 18, 2, data, 18);
+                                      }
+                                      else
+                                      {
+                                          Array.Clear(data, 0, 6);
+                                      }
 
-                                        polled.HasFlag(PolledBno055Registers.Gravity) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 20) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Gravity) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 21) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Gravity) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 22) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Gravity) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 23) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Gravity) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 24) : (byte)0,
-                                        polled.HasFlag(PolledBno055Registers.Gravity) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 25) : (byte)0,
+                                      if (polled.HasFlag(PolledBno055Registers.Gravity))
+                                      {
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 20, 4, data, 20);
+                                          i2c.ReadWord(PolledBno055.EulerHeadingLsbAddress + 24, 2, data, 24);
+                                      }
+                                      else
+                                      {
+                                          Array.Clear(data, 0, 6);
+                                      }
 
-                                        polled.HasFlag(PolledBno055Registers.Temperature) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 26) : (byte)0,
-
-                                        polled.HasFlag(PolledBno055Registers.Calibration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 27) : (byte)0,
-                                    };
+                                      //NOTE: actual performance would be a little better if we merged these two so they could be read together
+                                      data[26] = polled.HasFlag(PolledBno055Registers.Temperature) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 26) : (byte)0;
+                                      data[27] = polled.HasFlag(PolledBno055Registers.Calibration) ? i2c.ReadByte(PolledBno055.EulerHeadingLsbAddress + 27) : (byte)0;
 
                                     ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
                                     clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;


### PR DESCRIPTION
Capitalizes on the gateware changes for multibyte i2c (required for this to work)

Measured a significant performance improvement, which brings bno polling to around 90Hz with all fields enabled.