### PR TITLE
Update bonsai

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -1,22 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Dsp.Design" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.System.Design" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
+    <Package id="Bonsai.Dsp.Design" version="2.9.0" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.System.Design" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Markdig" version="0.41.1" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
     <Package id="OpenTK.GLControl" version="3.1.0" />
@@ -24,14 +26,14 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -50,48 +52,50 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.Design.2.8.0/lib/net462/Bonsai.Dsp.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages/Bonsai.System.Design.2.8.0/lib/net462/Bonsai.System.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.Design.2.9.0/lib/net472/Bonsai.Dsp.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages/Bonsai.System.Design.2.9.0/lib/net472/Bonsai.System.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -2,24 +2,34 @@
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
     <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Arduino" version="2.8.1" />
+    <Package id="Bonsai.Audio" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
     <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Dsp.Design" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Osc" version="2.9.0" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.Shaders" version="2.9.0" />
+    <Package id="Bonsai.Shaders.Design" version="2.9.0" />
+    <Package id="Bonsai.StarterPack" version="2.9.0" />
     <Package id="Bonsai.System" version="2.9.0" />
     <Package id="Bonsai.System.Design" version="2.9.0" />
     <Package id="Bonsai.Vision" version="2.9.0" />
     <Package id="Bonsai.Vision.Design" version="2.9.0" />
+    <Package id="Bonsai.Windows.Input" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
     <Package id="Markdig" version="0.41.1" />
     <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
+    <Package id="openal.redist" version="2.0.7" />
     <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenEphys.Commutator" version="0.2.0" />
+    <Package id="OpenEphys.Sockets.Bonsai" version="1.0.3" />
     <Package id="OpenTK" version="3.1.0" />
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="Rx-Core" version="2.2.5" />
@@ -38,38 +48,54 @@
   </Packages>
   <AssemblyReferences>
     <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Arduino" />
+    <AssemblyReference assemblyName="Bonsai.Audio" />
     <AssemblyReference assemblyName="Bonsai.Core" />
     <AssemblyReference assemblyName="Bonsai.Design" />
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Dsp.Design" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Osc" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Shaders" />
+    <AssemblyReference assemblyName="Bonsai.Shaders.Design" />
     <AssemblyReference assemblyName="Bonsai.System" />
     <AssemblyReference assemblyName="Bonsai.System.Design" />
     <AssemblyReference assemblyName="Bonsai.Vision" />
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
+    <AssemblyReference assemblyName="Bonsai.Windows.Input" />
+    <AssemblyReference assemblyName="OpenEphys.Commutator" />
+    <AssemblyReference assemblyName="OpenEphys.Sockets.Bonsai" />
   </AssemblyReferences>
   <AssemblyLocations>
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Arduino" processorArchitecture="MSIL" location="Packages/Bonsai.Arduino.2.8.1/lib/net462/Bonsai.Arduino.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Audio" processorArchitecture="MSIL" location="Packages/Bonsai.Audio.2.9.0/lib/net472/Bonsai.Audio.dll" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.Design.2.9.0/lib/net472/Bonsai.Dsp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Osc" processorArchitecture="MSIL" location="Packages/Bonsai.Osc.2.9.0/lib/net472/Bonsai.Osc.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Shaders" processorArchitecture="MSIL" location="Packages/Bonsai.Shaders.2.9.0/lib/net472/Bonsai.Shaders.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Shaders.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Shaders.Design.2.9.0/lib/net472/Bonsai.Shaders.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages/Bonsai.System.Design.2.9.0/lib/net472/Bonsai.System.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Windows.Input" processorArchitecture="MSIL" location="Packages/Bonsai.Windows.Input.2.9.0/lib/net472/Bonsai.Windows.Input.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenEphys.Commutator" processorArchitecture="MSIL" location="Packages/OpenEphys.Commutator.0.2.0/lib/net472/OpenEphys.Commutator.dll" />
+    <AssemblyLocation assemblyName="OpenEphys.Sockets.Bonsai" processorArchitecture="MSIL" location="Packages/OpenEphys.Sockets.Bonsai.1.0.3/lib/net472/OpenEphys.Sockets.Bonsai.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
@@ -96,6 +122,8 @@
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
     <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/openal.redist.2.0.7.0/build/native/bin/x64" platform="x64" />
+    <LibraryFolder path="Packages/openal.redist.2.0.7.0/build/native/bin/x86" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/.bonsai/NuGet.config
+++ b/.bonsai/NuGet.config
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="Gallery" value="..\..\Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/.bonsai/Setup.ps1
+++ b/.bonsai/Setup.ps1
@@ -14,6 +14,5 @@ if (!(Test-Path "./Bonsai.exe")) {
     Expand-Archive "temp.zip" -DestinationPath "." -Force
     Move-Item -Path "temp.config" "NuGet.config" -Force
     Remove-Item -Path "temp.zip"
-	Remove-Item -Path "Bonsai32.exe"
 }
 & .\Bonsai.exe --no-editor

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
-    <add key="Boost Packages" value="https://www.myget.org/F/bonsai-boost/api/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
This PR updates Bonsai to v2.9.0, and updates the dependencies so that the documentation repo has everything it needs to build the SVG files. With this, v0.5.0 of this repo will be ready for publishing.