### PR TITLE
Rename channel configuration to probe group for clarity

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ChannelConfigurationDialog.cs
@@ -29,7 +29,7 @@ namespace OpenEphys.Onix1.Design
         /// </summary>
         /// <param name="probeConfiguration">A <see cref="NeuropixelsV1ProbeConfiguration"/> object holding the current configuration settings.</param>
         public NeuropixelsV1ChannelConfigurationDialog(NeuropixelsV1ProbeConfiguration probeConfiguration)
-            : base(probeConfiguration.ChannelConfiguration)
+            : base(probeConfiguration.ProbeGroup)
         {
             zedGraphChannels.ZoomButtons = MouseButtons.None;
             zedGraphChannels.ZoomButtons2 = MouseButtons.None;
@@ -57,7 +57,7 @@ namespace OpenEphys.Onix1.Design
         internal override void LoadDefaultChannelLayout()
         {
             ProbeConfiguration = new(ProbeConfiguration.SpikeAmplifierGain, ProbeConfiguration.LfpAmplifierGain, ProbeConfiguration.Reference, ProbeConfiguration.SpikeFilter);
-            ProbeGroup = ProbeConfiguration.ChannelConfiguration;
+            ProbeGroup = ProbeConfiguration.ProbeGroup;
 
             OnFileOpenHandler();
         }
@@ -67,7 +67,7 @@ namespace OpenEphys.Onix1.Design
             if (base.OpenFile<NeuropixelsV1eProbeGroup>())
             {
                 ProbeConfiguration = new((NeuropixelsV1eProbeGroup)ProbeGroup, ProbeConfiguration.SpikeAmplifierGain, ProbeConfiguration.LfpAmplifierGain, ProbeConfiguration.Reference, ProbeConfiguration.SpikeFilter);
-                ProbeGroup = ProbeConfiguration.ChannelConfiguration;
+                ProbeGroup = ProbeConfiguration.ProbeGroup;
 
                 OnFileOpenHandler();
 
@@ -114,7 +114,7 @@ namespace OpenEphys.Onix1.Design
             const int MinorTickIncrement = 10;
             const int MinorTickLength = 5;
 
-            if (ProbeConfiguration.ChannelConfiguration.Probes.ElementAt(0).SiUnits != ProbeSiUnits.um)
+            if (ProbeConfiguration.ProbeGroup.Probes.ElementAt(0).SiUnits != ProbeSiUnits.um)
             {
                 MessageBox.Show("Warning: Expected ProbeGroup units to be in microns, but it is in millimeters. Scale might not be accurate.");
             }
@@ -216,7 +216,7 @@ namespace OpenEphys.Onix1.Design
 
         internal override void UpdateContactLabels()
         {
-            if (ProbeConfiguration.ChannelConfiguration == null)
+            if (ProbeConfiguration.ProbeGroup == null)
                 return;
 
             var textObjs = zedGraphChannels.GraphPane.GraphObjList.OfType<TextObj>()

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -170,7 +170,7 @@ namespace OpenEphys.Onix1.Design
         private void SetChannelPreset(ChannelPreset preset)
         {
             var probeConfiguration = ChannelConfiguration.ProbeConfiguration;
-            var electrodes = NeuropixelsV1eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ChannelConfiguration);
+            var electrodes = NeuropixelsV1eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup);
 
             switch (preset)
             {
@@ -432,7 +432,7 @@ namespace OpenEphys.Onix1.Design
 
         private void EnableSelectedContacts()
         {
-            var electrodes = NeuropixelsV1eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ChannelConfiguration);
+            var electrodes = NeuropixelsV1eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup);
 
             var selectedElectrodes = electrodes.Where((e, ind) => ChannelConfiguration.SelectedContacts[ind])
                                                .ToArray();

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
@@ -27,7 +27,7 @@ namespace OpenEphys.Onix1.Design
         /// </summary>
         /// <param name="probeConfiguration">A <see cref="NeuropixelsV2QuadShankProbeConfiguration"/> object holding the current configuration settings.</param>
         public NeuropixelsV2eChannelConfigurationDialog(NeuropixelsV2QuadShankProbeConfiguration probeConfiguration)
-            : base(probeConfiguration.ChannelConfiguration)
+            : base(probeConfiguration.ProbeGroup)
         {
             zedGraphChannels.ZoomButtons = MouseButtons.None;
             zedGraphChannels.ZoomButtons2 = MouseButtons.None;
@@ -52,7 +52,7 @@ namespace OpenEphys.Onix1.Design
         internal override void LoadDefaultChannelLayout()
         {
             ProbeConfiguration = new(ProbeConfiguration.Probe, ProbeConfiguration.Reference);
-            ProbeGroup = ProbeConfiguration.ChannelConfiguration;
+            ProbeGroup = ProbeConfiguration.ProbeGroup;
 
             OnFileOpenHandler();
         }
@@ -108,7 +108,7 @@ namespace OpenEphys.Onix1.Design
             const int MinorTickIncrement = 10;
             const int MinorTickLength = 5;
 
-            if (ProbeConfiguration.ChannelConfiguration.Probes.ElementAt(0).SiUnits != ProbeSiUnits.um)
+            if (ProbeConfiguration.ProbeGroup.Probes.ElementAt(0).SiUnits != ProbeSiUnits.um)
             {
                 MessageBox.Show("Warning: Expected ProbeGroup units to be in microns, but it is in millimeters. Scale might not be accurate.");
             }
@@ -211,7 +211,7 @@ namespace OpenEphys.Onix1.Design
 
         internal override void UpdateContactLabels()
         {
-            if (ProbeConfiguration.ChannelConfiguration == null)
+            if (ProbeConfiguration.ProbeGroup == null)
                 return;
 
             var textObjs = zedGraphChannels.GraphPane.GraphObjList.OfType<TextObj>()

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -76,7 +76,6 @@ namespace OpenEphys.Onix1.Design
                 if (channelConfiguration.Tag != sendingDialog.Tag)
                 {
                     channelConfiguration.SetInvertPolarity(sendingDialog.InvertPolarity);
-                    //channelConfiguration.Refresh();
                 }
             }
         }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -168,7 +168,7 @@ namespace OpenEphys.Onix1.Design
         private void SetChannelPreset(ChannelPreset preset)
         {
             var probeConfiguration = ChannelConfiguration.ProbeConfiguration;
-            var electrodes = NeuropixelsV2eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ChannelConfiguration);
+            var electrodes = NeuropixelsV2eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup);
 
             switch (preset)
             {
@@ -622,7 +622,7 @@ namespace OpenEphys.Onix1.Design
 
         private void EnableSelectedContacts()
         {
-            var selected = NeuropixelsV2eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ChannelConfiguration)
+            var selected = NeuropixelsV2eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup)
                                                    .Where((e, ind) => ChannelConfiguration.SelectedContacts[ind])
                                                    .ToArray();
 

--- a/OpenEphys.Onix1/NeuropixelsV1ProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1ProbeConfiguration.cs
@@ -43,7 +43,7 @@ namespace OpenEphys.Onix1
         /// </summary>
         public NeuropixelsV1ProbeConfiguration()
         {
-            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(ChannelConfiguration);
+            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(ProbeGroup);
         }
 
         /// <summary>
@@ -60,28 +60,28 @@ namespace OpenEphys.Onix1
             LfpAmplifierGain = lfpAmplifierGain;
             Reference = reference;
             SpikeFilter = spikeFilter;
-            ChannelConfiguration = new();
-            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(ChannelConfiguration);
+            ProbeGroup = new();
+            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(ProbeGroup);
         }
 
         /// <summary>
         /// Copy constructor initializes a new instance of <see cref="NeuropixelsV1ProbeConfiguration"/> using the given <see cref="NeuropixelsV1eProbeGroup"/>
         /// values and the given gain / reference / filter settings.
         /// </summary>
-        /// <param name="channelConfiguration">Desired or current <see cref="NeuropixelsV1eProbeGroup"/> variable.</param>
+        /// <param name="probeGroup">Desired or current <see cref="NeuropixelsV1eProbeGroup"/> variable.</param>
         /// <param name="spikeAmplifierGain">Desired or current <see cref="NeuropixelsV1Gain"/> for the spike-band.</param>
         /// <param name="lfpAmplifierGain">Desired or current <see cref="NeuropixelsV1Gain"/> for the LFP-band.</param>
         /// <param name="reference">Desired or current <see cref="NeuropixelsV1ReferenceSource"/>.</param>
         /// <param name="spikeFilter">Desired or current option to filer the spike-band.</param>
-        public NeuropixelsV1ProbeConfiguration(NeuropixelsV1eProbeGroup channelConfiguration, NeuropixelsV1Gain spikeAmplifierGain, NeuropixelsV1Gain lfpAmplifierGain, NeuropixelsV1ReferenceSource reference, bool spikeFilter)
+        public NeuropixelsV1ProbeConfiguration(NeuropixelsV1eProbeGroup probeGroup, NeuropixelsV1Gain spikeAmplifierGain, NeuropixelsV1Gain lfpAmplifierGain, NeuropixelsV1ReferenceSource reference, bool spikeFilter)
         {
             SpikeAmplifierGain = spikeAmplifierGain;
             LfpAmplifierGain = lfpAmplifierGain;
             Reference = reference;
             SpikeFilter = spikeFilter;
-            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(channelConfiguration);
-            ChannelConfiguration = new();
-            ChannelConfiguration.UpdateDeviceChannelIndices(ChannelMap);
+            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(probeGroup);
+            ProbeGroup = new();
+            ProbeGroup.UpdateDeviceChannelIndices(ChannelMap);
         }
 
         /// <summary>
@@ -95,9 +95,9 @@ namespace OpenEphys.Onix1
             LfpAmplifierGain = probeConfiguration.LfpAmplifierGain;
             Reference = probeConfiguration.Reference;
             SpikeFilter = probeConfiguration.SpikeFilter;
-            ChannelConfiguration = new();
-            ChannelConfiguration.UpdateDeviceChannelIndices(probeConfiguration.ChannelMap);
-            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(ChannelConfiguration);
+            ProbeGroup = new();
+            ProbeGroup.UpdateDeviceChannelIndices(probeConfiguration.ChannelMap);
+            ChannelMap = NeuropixelsV1eProbeGroup.ToChannelMap(ProbeGroup);
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace OpenEphys.Onix1
                 }
             }
 
-            ChannelConfiguration.UpdateDeviceChannelIndices(ChannelMap);
+            ProbeGroup.UpdateDeviceChannelIndices(ChannelMap);
         }
 
         /// <summary>
@@ -180,29 +180,29 @@ namespace OpenEphys.Onix1
         /// </summary>
         [XmlIgnore]
         [Category("Configuration")]
-        [Description("Defines the shape of the probe, and which contacts are currently selected for streaming")]
-        public NeuropixelsV1eProbeGroup ChannelConfiguration { get; set; } = new();
+        [Description("Defines all aspects of the probe group, including probe contours, electrode size and location, enabled channels, etc.")]
+        public NeuropixelsV1eProbeGroup ProbeGroup { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets a string defining the <see cref="ChannelConfiguration"/> in Base64.
+        /// Gets or sets a string defining the <see cref="ProbeGroup"/> in Base64.
         /// This variable is needed to properly save a workflow in Bonsai, but it is not
         /// directly accessible in the Bonsai editor.
         /// </summary>
         [Browsable(false)]
         [Externalizable(false)]
-        [XmlElement(nameof(ChannelConfiguration))]
-        public string ChannelConfigurationString
+        [XmlElement(nameof(ProbeGroup))]
+        public string ProbeGroupString
         {
             get
             {
-                var jsonString = JsonConvert.SerializeObject(ChannelConfiguration);
+                var jsonString = JsonConvert.SerializeObject(ProbeGroup);
                 return Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonString));
             }
             set
             {
                 var jsonString = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-                ChannelConfiguration = JsonConvert.DeserializeObject<NeuropixelsV1eProbeGroup>(jsonString);
-                SelectElectrodes(NeuropixelsV1eProbeGroup.ToChannelMap(ChannelConfiguration));
+                ProbeGroup = JsonConvert.DeserializeObject<NeuropixelsV1eProbeGroup>(jsonString);
+                SelectElectrodes(NeuropixelsV1eProbeGroup.ToChannelMap(ProbeGroup));
             }
         }
     }

--- a/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
@@ -191,11 +191,11 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Convert a <see cref="NeuropixelsV1eProbeGroup"/> object to a list of electrodes, which only includes currently enabled electrodes
         /// </summary>
-        /// <param name="channelConfiguration">A <see cref="NeuropixelsV1eProbeGroup"/> object</param>
+        /// <param name="probeGroup">A <see cref="NeuropixelsV1eProbeGroup"/> object</param>
         /// <returns>List of <see cref="NeuropixelsV1Electrode"/>'s that are enabled</returns>
-        public static NeuropixelsV1Electrode[] ToChannelMap(NeuropixelsV1eProbeGroup channelConfiguration)
+        public static NeuropixelsV1Electrode[] ToChannelMap(NeuropixelsV1eProbeGroup probeGroup)
         {
-            var enabledContacts = channelConfiguration.GetContacts().Where(c => c.DeviceId != -1);
+            var enabledContacts = probeGroup.GetContacts().Where(c => c.DeviceId != -1);
 
             if (enabledContacts.Count() != NeuropixelsV1.ChannelCount)
             {
@@ -212,13 +212,13 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Convert a ProbeInterface object to a list of electrodes, which includes all possible electrodes.
         /// </summary>
-        /// <param name="channelConfiguration">A <see cref="NeuropixelsV1eProbeGroup"/> object.</param>
+        /// <param name="probeGroup">A <see cref="NeuropixelsV1eProbeGroup"/> object.</param>
         /// <returns>List of <see cref="NeuropixelsV1Electrode"/> electrodes.</returns>
-        public static List<NeuropixelsV1Electrode> ToElectrodes(NeuropixelsV1eProbeGroup channelConfiguration)
+        public static List<NeuropixelsV1Electrode> ToElectrodes(NeuropixelsV1eProbeGroup probeGroup)
         {
             List<NeuropixelsV1Electrode> electrodes = new();
 
-            foreach (var c in channelConfiguration.GetContacts())
+            foreach (var c in probeGroup.GetContacts())
             {
                 electrodes.Add(new NeuropixelsV1Electrode(c.Index));
             }

--- a/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
@@ -115,25 +115,25 @@ namespace OpenEphys.Onix1
         public NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2QuadShankProbeConfiguration probeConfiguration)
         {
             Reference = probeConfiguration.Reference;
-            var probes = probeConfiguration.ChannelConfiguration.Probes.ToList().Select(probe => new Probe(probe));
-            ChannelConfiguration = new(probeConfiguration.ChannelConfiguration.Specification, probeConfiguration.ChannelConfiguration.Version, probes.ToArray());
-            ChannelMap = NeuropixelsV2eProbeGroup.ToChannelMap(ChannelConfiguration);
+            var probes = probeConfiguration.ProbeGroup.Probes.ToList().Select(probe => new Probe(probe));
+            ProbeGroup = new(probeConfiguration.ProbeGroup.Specification, probeConfiguration.ProbeGroup.Version, probes.ToArray());
+            ChannelMap = NeuropixelsV2eProbeGroup.ToChannelMap(ProbeGroup);
             Probe = probeConfiguration.Probe;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NeuropixelsV2QuadShankProbeConfiguration"/> class with the given
         /// <see cref="NeuropixelsV2eProbeGroup"/> channel configuration. The <see cref="ChannelMap"/> is automatically 
-        /// generated from the <see cref="ChannelConfiguration"/>. 
+        /// generated from the <see cref="ProbeGroup"/>. 
         /// </summary>
-        /// <param name="channelConfiguration">The existing <see cref="NeuropixelsV2eProbeGroup"/> instance to use.</param>
+        /// <param name="probeGroup">The existing <see cref="NeuropixelsV2eProbeGroup"/> instance to use.</param>
         /// <param name="reference">The <see cref="NeuropixelsV2QuadShankReference"/> reference value.</param>
         /// <param name="probe">The <see cref="NeuropixelsV2Probe"/> for this probe.</param>
         [JsonConstructor]
-        public NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2eProbeGroup channelConfiguration, NeuropixelsV2QuadShankReference reference, NeuropixelsV2Probe probe)
+        public NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2eProbeGroup probeGroup, NeuropixelsV2QuadShankReference reference, NeuropixelsV2Probe probe)
         {
-            ChannelMap = NeuropixelsV2eProbeGroup.ToChannelMap(channelConfiguration);
-            ChannelConfiguration = channelConfiguration;
+            ChannelMap = NeuropixelsV2eProbeGroup.ToChannelMap(probeGroup);
+            ProbeGroup = probeGroup;
             Reference = reference;
             Probe = probe;
         }
@@ -193,7 +193,7 @@ namespace OpenEphys.Onix1
                 }
             }
 
-            ChannelConfiguration.UpdateDeviceChannelIndices(ChannelMap);
+            ProbeGroup.UpdateDeviceChannelIndices(ChannelMap);
         }
 
         /// <summary>
@@ -202,28 +202,28 @@ namespace OpenEphys.Onix1
         [XmlIgnore]
         [Category("Configuration")]
         [Description("Defines the shape of the probe, and which contacts are currently selected for streaming")]
-        public NeuropixelsV2eProbeGroup ChannelConfiguration { get; private set; } = new();
+        public NeuropixelsV2eProbeGroup ProbeGroup { get; private set; } = new();
 
         /// <summary>
-        /// Gets or sets a string defining the <see cref="ChannelConfiguration"/> in Base64.
+        /// Gets or sets a string defining the <see cref="ProbeGroup"/> in Base64.
         /// This variable is needed to properly save a workflow in Bonsai, but it is not
         /// directly accessible in the Bonsai editor.
         /// </summary>
         [Browsable(false)]
         [Externalizable(false)]
-        [XmlElement(nameof(ChannelConfiguration))]
-        public string ChannelConfigurationString
+        [XmlElement(nameof(ProbeGroup))]
+        public string ProbeGroupString
         {
             get
             {
-                var jsonString = JsonConvert.SerializeObject(ChannelConfiguration);
+                var jsonString = JsonConvert.SerializeObject(ProbeGroup);
                 return Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonString));
             }
             set
             {
                 var jsonString = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-                ChannelConfiguration = JsonConvert.DeserializeObject<NeuropixelsV2eProbeGroup>(jsonString);
-                SelectElectrodes(NeuropixelsV2eProbeGroup.ToChannelMap(ChannelConfiguration));
+                ProbeGroup = JsonConvert.DeserializeObject<NeuropixelsV2eProbeGroup>(jsonString);
+                SelectElectrodes(NeuropixelsV2eProbeGroup.ToChannelMap(ProbeGroup));
             }
         }
     }

--- a/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
@@ -221,13 +221,13 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Convert a ProbeInterface object to a list of electrodes, which includes all possible electrodes
         /// </summary>
-        /// <param name="channelConfiguration">A <see cref="NeuropixelsV2eProbeGroup"/> object</param>
+        /// <param name="probeGroup">A <see cref="NeuropixelsV2eProbeGroup"/> object</param>
         /// <returns>List of <see cref="NeuropixelsV2QuadShankElectrode"/> electrodes</returns>
-        public static List<NeuropixelsV2QuadShankElectrode> ToElectrodes(NeuropixelsV2eProbeGroup channelConfiguration)
+        public static List<NeuropixelsV2QuadShankElectrode> ToElectrodes(NeuropixelsV2eProbeGroup probeGroup)
         {
             List<NeuropixelsV2QuadShankElectrode> electrodes = new();
 
-            foreach (var c in channelConfiguration.GetContacts())
+            foreach (var c in probeGroup.GetContacts())
             {
                 electrodes.Add(new NeuropixelsV2QuadShankElectrode(c.Index));
             }
@@ -238,12 +238,12 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Convert a <see cref="NeuropixelsV2eProbeGroup"/> object to a list of electrodes, which only includes currently enabled electrodes
         /// </summary>
-        /// <param name="channelConfiguration">A <see cref="NeuropixelsV2eProbeGroup"/> object</param>
+        /// <param name="probeGroup">A <see cref="NeuropixelsV2eProbeGroup"/> object</param>
         /// <returns>List of <see cref="NeuropixelsV2QuadShankElectrode"/> electrodes that are enabled</returns>
-        public static NeuropixelsV2QuadShankElectrode[] ToChannelMap(NeuropixelsV2eProbeGroup channelConfiguration)
+        public static NeuropixelsV2QuadShankElectrode[] ToChannelMap(NeuropixelsV2eProbeGroup probeGroup)
         {
 
-            var enabledContacts = channelConfiguration.GetContacts().Where(c => c.DeviceId != -1);
+            var enabledContacts = probeGroup.GetContacts().Where(c => c.DeviceId != -1);
 
             if (enabledContacts.Count() != NeuropixelsV2.ChannelCount)
             {


### PR DESCRIPTION
This PR is a simple rename of most instances of `ChannelConfiguration` to `ProbeGroup`. This name change is to line up with the underlying `ProbeInterface` specification we are using, and to better describe what the variable actually contains. Now, any instance of `ChannelConfiguration` is a dialog that uses an underlying `ProbeGroup` variable to draw the electrodes and their locations, allowing the user to select which channels to configure.

- Fixes #321 