### PR TITLE
Fix link text for plurals in xml comments

### DIFF
--- a/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
+++ b/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
@@ -9,6 +9,7 @@
     <Platforms>x64</Platforms>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
@@ -48,7 +48,7 @@ namespace OpenEphys.Onix1
         /// </remarks>
         /// <param name="specification">String defining the <see cref="ProbeGroup.Specification"/>.</param>
         /// <param name="version">String defining the <see cref="ProbeGroup.Version"/>.</param>
-        /// <param name="probes">Array of <see cref="Probe"/>s.</param>
+        /// <param name="probes">Array of <see cref="Probe">Probes</see>.</param>
         [JsonConstructor]
         public NeuropixelsV1eProbeGroup(string specification, string version, Probe[] probes)
             : base(specification, version, probes)

--- a/OpenEphys.Onix1/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eData.cs
@@ -46,9 +46,9 @@ namespace OpenEphys.Onix1
         public NeuropixelsV2Probe ProbeIndex { get; set; }
 
         /// <summary>
-        /// Generates a sequence of <see cref="NeuropixelsV2eDataFrame"/>s.
+        /// Generates a sequence of <see cref="NeuropixelsV2eDataFrame">NeuropixelsV2eDataFrames</see>.
         /// </summary>
-        /// <returns>A sequence of <see cref="NeuropixelsV2eDataFrame"/>s.</returns>
+        /// <returns>A sequence of <see cref="NeuropixelsV2eDataFrame">NeuropixelsV2eDataFrames</see>.</returns>
         public unsafe override IObservable<NeuropixelsV2eDataFrame> Generate()
         {
             var bufferSize = BufferSize;

--- a/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
@@ -57,7 +57,7 @@ namespace OpenEphys.Onix1
         /// </remarks>
         /// <param name="specification">String defining the <see cref="ProbeGroup.Specification"/>.</param>
         /// <param name="version">String defining the <see cref="ProbeGroup.Version"/>.</param>
-        /// <param name="probes">Array of <see cref="Probe"/>s.</param>
+        /// <param name="probes">Array of <see cref="Probe">Probes</see>.</param>
         [JsonConstructor]
         public NeuropixelsV2eProbeGroup(string specification, string version, Probe[] probes)
             : base(specification, version, probes)

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>x64</Platforms>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenEphys.Onix1/Rhs2116Data.cs
+++ b/OpenEphys.Onix1/Rhs2116Data.cs
@@ -37,9 +37,9 @@ namespace OpenEphys.Onix1
         public int BufferSize { get; set; } = 30;
 
         /// <summary>
-        /// Generates a sequence of <see cref="Rhs2116DataFrame"/>s.
+        /// Generates a sequence of <see cref="Rhs2116DataFrame">Rhs2116DataFrames</see>.
         /// </summary>
-        /// <returns>A sequence of <see cref="Rhs2116DataFrame"/>s.</returns>
+        /// <returns>A sequence of <see cref="Rhs2116DataFrame">Rhs2116DataFrames</see>.</returns>
         public unsafe override IObservable<Rhs2116DataFrame> Generate()
         {
             var bufferSize = BufferSize;

--- a/OpenEphys.Onix1/Rhs2116PairData.cs
+++ b/OpenEphys.Onix1/Rhs2116PairData.cs
@@ -12,7 +12,6 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Produces a sequence of <see cref="Rhs2116PairDataFrame"/> objects from a synchronized pair of Intan
     /// Rhs2116 bidirectional bioacquisition chips.
-    /// chips.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
@@ -37,9 +36,9 @@ namespace OpenEphys.Onix1
         public int BufferSize { get; set; } = 30;
 
         /// <summary>
-        /// Generates a sequence of <see cref="Rhs2116PairDataFrame"/>s.
+        /// Generates a sequence of <see cref="Rhs2116PairDataFrame">Rhs2116PairDataFrames</see>.
         /// </summary>
-        /// <returns>A sequence of <see cref="Rhs2116PairDataFrame"/>s.</returns>
+        /// <returns>A sequence of <see cref="Rhs2116PairDataFrame">Rhs2116PairDataFrames</see>.</returns>
         public unsafe override IObservable<Rhs2116PairDataFrame> Generate()
         {
             var bufferSize = BufferSize;

--- a/OpenEphys.Onix1/Rhs2116ProbeGroup.cs
+++ b/OpenEphys.Onix1/Rhs2116ProbeGroup.cs
@@ -66,7 +66,7 @@ namespace OpenEphys.Onix1
         /// </remarks>
         /// <param name="specification">String defining the <see cref="ProbeGroup.Specification"/>.</param>
         /// <param name="version">String defining the <see cref="ProbeGroup.Version"/>.</param>
-        /// <param name="probes">Array of <see cref="Probe"/>s.</param>
+        /// <param name="probes">Array of <see cref="Probe">Probes</see>.</param>
         [JsonConstructor]
         public Rhs2116ProbeGroup(string specification, string version, Probe[] probes)
             : base(specification, version, probes)

--- a/OpenEphys.Onix1/Rhs2116TriggerData.cs
+++ b/OpenEphys.Onix1/Rhs2116TriggerData.cs
@@ -24,9 +24,9 @@ namespace OpenEphys.Onix1
         public string DeviceName { get; set; }
 
         /// <summary>
-        /// Generates a sequence of <see cref="Rhs2116TriggerDataFrame"/>s.
+        /// Generates a sequence of <see cref="Rhs2116TriggerDataFrame">Rhs2116TriggerDataFrames</see>.
         /// </summary>
-        /// <returns>A sequence of <see cref="Rhs2116TriggerDataFrame"/>s.</returns>
+        /// <returns>A sequence of <see cref="Rhs2116TriggerDataFrame">Rhs2116TriggerDataFrames</see>.</returns>
         public override IObservable<Rhs2116TriggerDataFrame> Generate()
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>

--- a/OpenEphys.Onix1/UclaMiniscopeV4CameraData.cs
+++ b/OpenEphys.Onix1/UclaMiniscopeV4CameraData.cs
@@ -10,8 +10,8 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of <see cref="UclaMiniscopeV4CameraFrame"/>s from the Python-480 image sensor on a
-    /// UCLA Miniscope V4.
+    /// Produces a sequence of <see cref="UclaMiniscopeV4CameraFrame">UclaMiniscopeV4CameraFrames</see> from
+    /// the Python-480 image sensor on a UCLA Miniscope V4.
     /// </summary>
     public class UclaMiniscopeV4CameraData : Source<UclaMiniscopeV4CameraFrame>
     {
@@ -38,10 +38,10 @@ namespace OpenEphys.Onix1
         public UclaMiniscopeV4ImageDepth DataType { get; set; } = UclaMiniscopeV4ImageDepth.U8;
 
         /// <summary>
-        /// Generates a sequence of <see cref="UclaMiniscopeV4CameraFrame"/>s at a rate determined by <see
-        /// cref="ConfigureUclaMiniscopeV4Camera.FrameRate"/>.
+        /// Generates a sequence of <see cref="UclaMiniscopeV4CameraFrame">UclaMiniscopeV4CameraFrames</see>
+        /// at a rate determined by <see cref="ConfigureUclaMiniscopeV4Camera.FrameRate"/>.
         /// </summary>
-        /// <returns>A sequence of <see cref="UclaMiniscopeV4CameraFrame"/>s</returns>
+        /// <returns>A sequence of <see cref="UclaMiniscopeV4CameraFrame">UclaMiniscopeV4CameraFrames</see></returns>
         public unsafe override IObservable<UclaMiniscopeV4CameraFrame> Generate()
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>


### PR DESCRIPTION
- For instance, 

`<see cref="Probe"/>s `

is replaced with 

`<see cref="Probe">Probes</see>`

 
since the former looks really bad when rendered