### PR TITLE
Remove ADC_CONFIG register write in ConfigureNeuropixelsV2e

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.6.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -317,10 +317,6 @@ namespace OpenEphys.Onix1
 
             // Activate recording mode on NP
             i2cNP.WriteByte(NeuropixelsV2e.OP_MODE, 0b0100_0000);
-
-            // Set global ADC settings
-            // TODO: Undocumented
-            i2cNP.WriteByte(NeuropixelsV2e.ADC_CONFIG, 0b0000_1000);
         }
     }
 


### PR DESCRIPTION
- This register is reserved and appears to only have been necessary in the beta test variant of the probe
- Fixes #469 