### PR TITLE
Add msbuild target to copy native libraries

### DIFF
--- a/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
+++ b/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
@@ -42,4 +42,11 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <Target Name="CopyNativeDependencies" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <NativeDlls Include="$(OutputPath)..\..\OpenEphys.Onix1\$(ArtifactsPivots)\*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(NativeDlls)" DestinationFolder="$(OutputPath)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
- Add AfterBuild target that copies OpenEphys.Onix1 dlls into OpenEphys.Onix1.Design build folder after its built.
- Fixes #222 