### PR TITLE
Update StartPosition to CenterParent

### DIFF
--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
@@ -51,7 +51,7 @@
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
             this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 30);
+            this.splitContainer1.Location = new System.Drawing.Point(0, 24);
             this.splitContainer1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
@@ -64,8 +64,8 @@
             // 
             this.splitContainer1.Panel2.Controls.Add(this.buttonCancel);
             this.splitContainer1.Panel2.Controls.Add(this.buttonOK);
-            this.splitContainer1.Size = new System.Drawing.Size(609, 544);
-            this.splitContainer1.SplitterDistance = 507;
+            this.splitContainer1.Size = new System.Drawing.Size(609, 550);
+            this.splitContainer1.SplitterDistance = 513;
             this.splitContainer1.TabIndex = 0;
             // 
             // zedGraphChannels
@@ -82,7 +82,7 @@
             this.zedGraphChannels.ScrollMinX = 0D;
             this.zedGraphChannels.ScrollMinY = 0D;
             this.zedGraphChannels.ScrollMinY2 = 0D;
-            this.zedGraphChannels.Size = new System.Drawing.Size(609, 507);
+            this.zedGraphChannels.Size = new System.Drawing.Size(609, 513);
             this.zedGraphChannels.TabIndex = 4;
             this.zedGraphChannels.UseExtendedPrintDialog = true;
             this.zedGraphChannels.ZoomEvent += new ZedGraph.ZedGraphControl.ZoomEventHandler(this.ZoomEvent);
@@ -119,7 +119,7 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(609, 30);
+            this.menuStrip.Size = new System.Drawing.Size(609, 24);
             this.menuStrip.TabIndex = 5;
             this.menuStrip.Text = "menuStripChannelConfiguration";
             // 
@@ -130,27 +130,27 @@
             this.dropDownSaveFile,
             this.dropDownLoadDefault});
             this.fileMenuItem.Name = "fileMenuItem";
-            this.fileMenuItem.Size = new System.Drawing.Size(46, 28);
+            this.fileMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileMenuItem.Text = "File";
             // 
             // dropDownOpenFile
             // 
             this.dropDownOpenFile.Name = "dropDownOpenFile";
-            this.dropDownOpenFile.Size = new System.Drawing.Size(330, 26);
+            this.dropDownOpenFile.Size = new System.Drawing.Size(265, 22);
             this.dropDownOpenFile.Text = "Open Channel Configuration";
             this.dropDownOpenFile.Click += new System.EventHandler(this.MenuItemOpenFile);
             // 
             // dropDownSaveFile
             // 
             this.dropDownSaveFile.Name = "dropDownSaveFile";
-            this.dropDownSaveFile.Size = new System.Drawing.Size(330, 26);
+            this.dropDownSaveFile.Size = new System.Drawing.Size(265, 22);
             this.dropDownSaveFile.Text = "Save Channel Configuration";
             this.dropDownSaveFile.Click += new System.EventHandler(this.MenuItemSaveFile);
             // 
             // dropDownLoadDefault
             // 
             this.dropDownLoadDefault.Name = "dropDownLoadDefault";
-            this.dropDownLoadDefault.Size = new System.Drawing.Size(330, 26);
+            this.dropDownLoadDefault.Size = new System.Drawing.Size(265, 22);
             this.dropDownLoadDefault.Text = "Load Default Channel Configuration";
             this.dropDownLoadDefault.Click += new System.EventHandler(this.MenuItemLoadDefaultConfig);
             // 
@@ -165,6 +165,7 @@
             this.MainMenuStrip = this.menuStrip;
             this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "ChannelConfigurationDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Channel Configuration";
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.Designer.cs
@@ -100,9 +100,10 @@
             // 
             label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(14, 545);
+            label1.Location = new System.Drawing.Point(19, 671);
+            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(32, 13);
+            label1.Size = new System.Drawing.Size(39, 16);
             label1.TabIndex = 31;
             label1.Text = "0 mm";
             // 
@@ -110,111 +111,102 @@
             // 
             label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             label3.AutoSize = true;
-            label3.Location = new System.Drawing.Point(11, 0);
+            label3.Location = new System.Drawing.Point(15, 0);
+            label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label3.Name = "label3";
-            label3.Size = new System.Drawing.Size(38, 13);
+            label3.Size = new System.Drawing.Size(46, 16);
             label3.TabIndex = 32;
             label3.Text = "10 mm";
             // 
             // label4
             // 
             label4.AutoSize = true;
-            label4.Location = new System.Drawing.Point(10, 225);
-            label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label4.Location = new System.Drawing.Point(13, 277);
             label4.Name = "label4";
-            label4.Size = new System.Drawing.Size(58, 13);
+            label4.Size = new System.Drawing.Size(71, 16);
             label4.TabIndex = 40;
             label4.Text = "Correction:";
             // 
             // label2
             // 
             label2.AutoSize = true;
-            label2.Location = new System.Drawing.Point(10, 171);
-            label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label2.Location = new System.Drawing.Point(13, 210);
             label2.Name = "label2";
-            label2.Size = new System.Drawing.Size(58, 13);
+            label2.Size = new System.Drawing.Size(71, 16);
             label2.TabIndex = 38;
             label2.Text = "Correction:";
             // 
             // labelPresets
             // 
             labelPresets.AutoSize = true;
-            labelPresets.Location = new System.Drawing.Point(10, 329);
-            labelPresets.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            labelPresets.Location = new System.Drawing.Point(13, 405);
             labelPresets.Name = "labelPresets";
-            labelPresets.Size = new System.Drawing.Size(46, 26);
+            labelPresets.Size = new System.Drawing.Size(56, 32);
             labelPresets.TabIndex = 25;
             labelPresets.Text = "Channel\r\nPresets:";
             // 
             // adcCalibrationFile
             // 
             adcCalibrationFile.AutoSize = true;
-            adcCalibrationFile.Location = new System.Drawing.Point(10, 9);
-            adcCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            adcCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            adcCalibrationFile.Location = new System.Drawing.Point(13, 11);
+            adcCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             adcCalibrationFile.Name = "adcCalibrationFile";
-            adcCalibrationFile.Size = new System.Drawing.Size(103, 13);
+            adcCalibrationFile.Size = new System.Drawing.Size(130, 16);
             adcCalibrationFile.TabIndex = 11;
             adcCalibrationFile.Text = "ADC Calibration File:";
             // 
             // gainCalibrationFile
             // 
             gainCalibrationFile.AutoSize = true;
-            gainCalibrationFile.Location = new System.Drawing.Point(10, 93);
-            gainCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            gainCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            gainCalibrationFile.Location = new System.Drawing.Point(13, 114);
+            gainCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             gainCalibrationFile.Name = "gainCalibrationFile";
-            gainCalibrationFile.Size = new System.Drawing.Size(103, 13);
+            gainCalibrationFile.Size = new System.Drawing.Size(130, 16);
             gainCalibrationFile.TabIndex = 8;
             gainCalibrationFile.Text = "Gain Calibration File:";
             // 
             // spikeFilter
             // 
             spikeFilter.AutoSize = true;
-            spikeFilter.Location = new System.Drawing.Point(10, 252);
-            spikeFilter.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            spikeFilter.Location = new System.Drawing.Point(13, 310);
             spikeFilter.Name = "spikeFilter";
-            spikeFilter.Size = new System.Drawing.Size(62, 13);
+            spikeFilter.Size = new System.Drawing.Size(77, 16);
             spikeFilter.TabIndex = 6;
             spikeFilter.Text = "Spike Filter:";
             // 
             // Reference
             // 
             Reference.AutoSize = true;
-            Reference.Location = new System.Drawing.Point(10, 307);
-            Reference.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            Reference.Location = new System.Drawing.Point(13, 378);
             Reference.Name = "Reference";
-            Reference.Size = new System.Drawing.Size(60, 13);
+            Reference.Size = new System.Drawing.Size(73, 16);
             Reference.TabIndex = 4;
             Reference.Text = "Reference:";
             // 
             // lfpGain
             // 
             lfpGain.AutoSize = true;
-            lfpGain.Location = new System.Drawing.Point(10, 198);
-            lfpGain.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            lfpGain.Location = new System.Drawing.Point(13, 244);
             lfpGain.Name = "lfpGain";
-            lfpGain.Size = new System.Drawing.Size(54, 13);
+            lfpGain.Size = new System.Drawing.Size(65, 16);
             lfpGain.TabIndex = 2;
             lfpGain.Text = "LFP Gain:";
             // 
             // apGain
             // 
             apGain.AutoSize = true;
-            apGain.Location = new System.Drawing.Point(10, 145);
-            apGain.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            apGain.Location = new System.Drawing.Point(13, 178);
             apGain.Name = "apGain";
-            apGain.Size = new System.Drawing.Size(49, 13);
+            apGain.Size = new System.Drawing.Size(59, 16);
             apGain.TabIndex = 0;
             apGain.Text = "AP Gain:";
             // 
             // invertPolarity
             // 
             invertPolarity.AutoSize = true;
-            invertPolarity.Location = new System.Drawing.Point(10, 270);
-            invertPolarity.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            invertPolarity.Location = new System.Drawing.Point(13, 332);
             invertPolarity.Name = "invertPolarity";
-            invertPolarity.Size = new System.Drawing.Size(44, 26);
+            invertPolarity.Size = new System.Drawing.Size(55, 32);
             invertPolarity.TabIndex = 42;
             invertPolarity.Text = "Invert\r\nPolarity:";
             // 
@@ -244,10 +236,10 @@
             this.toolStripAdcCalSN,
             this.toolStripLabelGainCalibrationSn,
             this.toolStripGainCalSN});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 622);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 771);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 10, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(990, 25);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 13, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1320, 25);
             this.statusStrip1.TabIndex = 35;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -272,8 +264,8 @@
             this.fileToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(990, 24);
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip.Size = new System.Drawing.Size(1320, 24);
             this.menuStrip.TabIndex = 36;
             this.menuStrip.Text = "menuStrip1";
             // 
@@ -293,11 +285,12 @@
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 34F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(990, 598);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1320, 747);
             this.tableLayoutPanel1.TabIndex = 37;
             // 
             // panelProbe
@@ -305,9 +298,10 @@
             this.panelProbe.BackColor = System.Drawing.SystemColors.Control;
             this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(3, 3);
+            this.panelProbe.Location = new System.Drawing.Point(4, 4);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(736, 558);
+            this.panelProbe.Size = new System.Drawing.Size(982, 697);
             this.panelProbe.TabIndex = 0;
             // 
             // panelTrackBar
@@ -316,9 +310,10 @@
             this.panelTrackBar.Controls.Add(label1);
             this.panelTrackBar.Controls.Add(label3);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(687, 0);
+            this.panelTrackBar.Location = new System.Drawing.Point(917, 5);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(46, 557);
+            this.panelTrackBar.Size = new System.Drawing.Size(61, 686);
             this.panelTrackBar.TabIndex = 33;
             // 
             // trackBarProbePosition
@@ -327,12 +322,12 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBarProbePosition.BackColor = System.Drawing.SystemColors.Control;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(3, 7);
-            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(2);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(4, 9);
+            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(45, 544);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(45, 670);
             this.trackBarProbePosition.TabIndex = 30;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
@@ -369,19 +364,19 @@
             this.panelOptions.Controls.Add(this.comboBoxApGain);
             this.panelOptions.Controls.Add(apGain);
             this.panelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelOptions.Location = new System.Drawing.Point(744, 2);
-            this.panelOptions.Margin = new System.Windows.Forms.Padding(2);
+            this.panelOptions.Location = new System.Drawing.Point(993, 2);
+            this.panelOptions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelOptions.Name = "panelOptions";
-            this.panelOptions.Size = new System.Drawing.Size(244, 560);
+            this.panelOptions.Size = new System.Drawing.Size(324, 701);
             this.panelOptions.TabIndex = 2;
             // 
             // checkBoxInvertPolarity
             // 
             this.checkBoxInvertPolarity.AutoSize = true;
-            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(76, 275);
-            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(2);
+            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(101, 338);
+            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
-            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(65, 17);
+            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(77, 20);
             this.checkBoxInvertPolarity.TabIndex = 43;
             this.checkBoxInvertPolarity.Text = "Enabled";
             this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
@@ -390,22 +385,22 @@
             // 
             this.textBoxLfpCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxLfpCorrection.Location = new System.Drawing.Point(76, 223);
-            this.textBoxLfpCorrection.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxLfpCorrection.Location = new System.Drawing.Point(101, 274);
+            this.textBoxLfpCorrection.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxLfpCorrection.Name = "textBoxLfpCorrection";
             this.textBoxLfpCorrection.ReadOnly = true;
-            this.textBoxLfpCorrection.Size = new System.Drawing.Size(159, 20);
+            this.textBoxLfpCorrection.Size = new System.Drawing.Size(210, 22);
             this.textBoxLfpCorrection.TabIndex = 41;
             // 
             // textBoxApCorrection
             // 
             this.textBoxApCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxApCorrection.Location = new System.Drawing.Point(76, 168);
-            this.textBoxApCorrection.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxApCorrection.Location = new System.Drawing.Point(101, 207);
+            this.textBoxApCorrection.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxApCorrection.Name = "textBoxApCorrection";
             this.textBoxApCorrection.ReadOnly = true;
-            this.textBoxApCorrection.Size = new System.Drawing.Size(159, 20);
+            this.textBoxApCorrection.Size = new System.Drawing.Size(210, 22);
             this.textBoxApCorrection.TabIndex = 39;
             // 
             // buttonViewAdcs
@@ -413,10 +408,10 @@
             this.buttonViewAdcs.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonViewAdcs.Enabled = false;
-            this.buttonViewAdcs.Location = new System.Drawing.Point(10, 54);
-            this.buttonViewAdcs.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonViewAdcs.Location = new System.Drawing.Point(13, 66);
+            this.buttonViewAdcs.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonViewAdcs.Name = "buttonViewAdcs";
-            this.buttonViewAdcs.Size = new System.Drawing.Size(225, 31);
+            this.buttonViewAdcs.Size = new System.Drawing.Size(299, 38);
             this.buttonViewAdcs.TabIndex = 37;
             this.buttonViewAdcs.Text = "View ADC Correction Values";
             this.buttonViewAdcs.UseVisualStyleBackColor = true;
@@ -425,10 +420,10 @@
             // buttonChooseAdcCalibrationFile
             // 
             this.buttonChooseAdcCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseAdcCalibrationFile.Location = new System.Drawing.Point(207, 24);
-            this.buttonChooseAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonChooseAdcCalibrationFile.Location = new System.Drawing.Point(275, 30);
+            this.buttonChooseAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseAdcCalibrationFile.Name = "buttonChooseAdcCalibrationFile";
-            this.buttonChooseAdcCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseAdcCalibrationFile.Size = new System.Drawing.Size(37, 25);
             this.buttonChooseAdcCalibrationFile.TabIndex = 36;
             this.buttonChooseAdcCalibrationFile.Text = "...";
             this.buttonChooseAdcCalibrationFile.UseVisualStyleBackColor = true;
@@ -437,10 +432,10 @@
             // buttonChooseGainCalibrationFile
             // 
             this.buttonChooseGainCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseGainCalibrationFile.Location = new System.Drawing.Point(207, 108);
-            this.buttonChooseGainCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonChooseGainCalibrationFile.Location = new System.Drawing.Point(275, 133);
+            this.buttonChooseGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseGainCalibrationFile.Name = "buttonChooseGainCalibrationFile";
-            this.buttonChooseGainCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseGainCalibrationFile.Size = new System.Drawing.Size(37, 25);
             this.buttonChooseGainCalibrationFile.TabIndex = 35;
             this.buttonChooseGainCalibrationFile.Text = "...";
             this.buttonChooseGainCalibrationFile.UseVisualStyleBackColor = true;
@@ -450,10 +445,10 @@
             // 
             this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(10, 377);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonEnableContacts.Location = new System.Drawing.Point(13, 464);
+            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(225, 36);
+            this.buttonEnableContacts.Size = new System.Drawing.Size(299, 44);
             this.buttonEnableContacts.TabIndex = 28;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.buttonEnableContacts.UseVisualStyleBackColor = true;
@@ -463,10 +458,10 @@
             // 
             this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(10, 416);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonClearSelections.Location = new System.Drawing.Point(13, 512);
+            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(225, 36);
+            this.buttonClearSelections.Size = new System.Drawing.Size(299, 44);
             this.buttonClearSelections.TabIndex = 27;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.buttonClearSelections.UseVisualStyleBackColor = true;
@@ -478,20 +473,20 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxChannelPresets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxChannelPresets.FormattingEnabled = true;
-            this.comboBoxChannelPresets.Location = new System.Drawing.Point(76, 334);
-            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxChannelPresets.Location = new System.Drawing.Point(101, 411);
+            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
-            this.comboBoxChannelPresets.Size = new System.Drawing.Size(159, 21);
+            this.comboBoxChannelPresets.Size = new System.Drawing.Size(210, 24);
             this.comboBoxChannelPresets.TabIndex = 26;
             // 
             // buttonResetZoom
             // 
             this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(10, 457);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonResetZoom.Location = new System.Drawing.Point(13, 562);
+            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(225, 36);
+            this.buttonResetZoom.Size = new System.Drawing.Size(299, 44);
             this.buttonResetZoom.TabIndex = 22;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.buttonResetZoom.UseVisualStyleBackColor = true;
@@ -500,10 +495,10 @@
             // checkBoxSpikeFilter
             // 
             this.checkBoxSpikeFilter.AutoSize = true;
-            this.checkBoxSpikeFilter.Location = new System.Drawing.Point(76, 251);
-            this.checkBoxSpikeFilter.Margin = new System.Windows.Forms.Padding(2);
+            this.checkBoxSpikeFilter.Location = new System.Drawing.Point(101, 309);
+            this.checkBoxSpikeFilter.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxSpikeFilter.Name = "checkBoxSpikeFilter";
-            this.checkBoxSpikeFilter.Size = new System.Drawing.Size(65, 17);
+            this.checkBoxSpikeFilter.Size = new System.Drawing.Size(77, 20);
             this.checkBoxSpikeFilter.TabIndex = 14;
             this.checkBoxSpikeFilter.Text = "Enabled";
             this.checkBoxSpikeFilter.UseVisualStyleBackColor = true;
@@ -512,10 +507,10 @@
             // 
             this.textBoxAdcCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxAdcCalibrationFile.Location = new System.Drawing.Point(10, 24);
-            this.textBoxAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxAdcCalibrationFile.Location = new System.Drawing.Point(13, 30);
+            this.textBoxAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxAdcCalibrationFile.Name = "textBoxAdcCalibrationFile";
-            this.textBoxAdcCalibrationFile.Size = new System.Drawing.Size(193, 20);
+            this.textBoxAdcCalibrationFile.Size = new System.Drawing.Size(255, 22);
             this.textBoxAdcCalibrationFile.TabIndex = 12;
             this.textBoxAdcCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.textBoxAdcCalibrationFile.TextChanged += new System.EventHandler(this.AdcCalibrationFileTextChanged);
@@ -524,10 +519,10 @@
             // 
             this.textBoxGainCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxGainCalibrationFile.Location = new System.Drawing.Point(10, 108);
-            this.textBoxGainCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxGainCalibrationFile.Location = new System.Drawing.Point(13, 133);
+            this.textBoxGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxGainCalibrationFile.Name = "textBoxGainCalibrationFile";
-            this.textBoxGainCalibrationFile.Size = new System.Drawing.Size(193, 20);
+            this.textBoxGainCalibrationFile.Size = new System.Drawing.Size(255, 22);
             this.textBoxGainCalibrationFile.TabIndex = 9;
             this.textBoxGainCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.textBoxGainCalibrationFile.TextChanged += new System.EventHandler(this.GainCalibrationFileTextChanged);
@@ -538,10 +533,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxReference.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxReference.FormattingEnabled = true;
-            this.comboBoxReference.Location = new System.Drawing.Point(76, 303);
-            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxReference.Location = new System.Drawing.Point(101, 373);
+            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
-            this.comboBoxReference.Size = new System.Drawing.Size(159, 21);
+            this.comboBoxReference.Size = new System.Drawing.Size(210, 24);
             this.comboBoxReference.TabIndex = 5;
             // 
             // comboBoxLfpGain
@@ -550,10 +545,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxLfpGain.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxLfpGain.FormattingEnabled = true;
-            this.comboBoxLfpGain.Location = new System.Drawing.Point(76, 195);
-            this.comboBoxLfpGain.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxLfpGain.Location = new System.Drawing.Point(101, 240);
+            this.comboBoxLfpGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxLfpGain.Name = "comboBoxLfpGain";
-            this.comboBoxLfpGain.Size = new System.Drawing.Size(159, 21);
+            this.comboBoxLfpGain.Size = new System.Drawing.Size(210, 24);
             this.comboBoxLfpGain.TabIndex = 3;
             // 
             // comboBoxApGain
@@ -562,10 +557,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxApGain.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxApGain.FormattingEnabled = true;
-            this.comboBoxApGain.Location = new System.Drawing.Point(76, 141);
-            this.comboBoxApGain.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxApGain.Location = new System.Drawing.Point(101, 174);
+            this.comboBoxApGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxApGain.Name = "comboBoxApGain";
-            this.comboBoxApGain.Size = new System.Drawing.Size(159, 21);
+            this.comboBoxApGain.Size = new System.Drawing.Size(210, 24);
             this.comboBoxApGain.TabIndex = 1;
             // 
             // flowLayoutPanel1
@@ -575,19 +570,19 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 566);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 707);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(986, 30);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1314, 38);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // buttonCancel
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(901, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonCancel.Location = new System.Drawing.Point(1200, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 28);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -595,25 +590,26 @@
             // buttonOkay
             // 
             this.buttonOkay.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOkay.Location = new System.Drawing.Point(814, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonOkay.Location = new System.Drawing.Point(1083, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 28);
+            this.buttonOkay.Size = new System.Drawing.Size(111, 34);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
             // 
             // NeuropixelsV1ProbeConfigurationDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(990, 647);
+            this.ClientSize = new System.Drawing.Size(1320, 796);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip);
             this.Controls.Add(this.statusStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV1ProbeConfigurationDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV1 Probe Configuration";
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();


### PR DESCRIPTION
This PR fixes the last two dialogs to open up using the `CenterParent` value, which means that the dialog will open up on top of the parent window that called it. This is useful for a number of reasons, including ensuring that the screen resolution is consistent between windows, and also for ease of use by the user.

- Fixes #311  