### PR TITLE
Move Probe Interface configuration to be external files

### DIFF
--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
@@ -136,22 +136,22 @@
             // dropDownOpenFile
             // 
             this.dropDownOpenFile.Name = "dropDownOpenFile";
-            this.dropDownOpenFile.Size = new System.Drawing.Size(265, 22);
-            this.dropDownOpenFile.Text = "Open Channel Configuration";
+            this.dropDownOpenFile.Size = new System.Drawing.Size(211, 22);
+            this.dropDownOpenFile.Text = "Open Probe Group";
             this.dropDownOpenFile.Click += new System.EventHandler(this.MenuItemOpenFile);
             // 
             // dropDownSaveFile
             // 
             this.dropDownSaveFile.Name = "dropDownSaveFile";
-            this.dropDownSaveFile.Size = new System.Drawing.Size(265, 22);
-            this.dropDownSaveFile.Text = "Save Channel Configuration";
+            this.dropDownSaveFile.Size = new System.Drawing.Size(211, 22);
+            this.dropDownSaveFile.Text = "Save Probe Group";
             this.dropDownSaveFile.Click += new System.EventHandler(this.MenuItemSaveFile);
             // 
             // dropDownLoadDefault
             // 
             this.dropDownLoadDefault.Name = "dropDownLoadDefault";
-            this.dropDownLoadDefault.Size = new System.Drawing.Size(265, 22);
-            this.dropDownLoadDefault.Text = "Load Default Channel Configuration";
+            this.dropDownLoadDefault.Size = new System.Drawing.Size(211, 22);
+            this.dropDownLoadDefault.Text = "Load Default Probe Group";
             this.dropDownLoadDefault.Click += new System.EventHandler(this.MenuItemLoadDefaultConfig);
             // 
             // ChannelConfigurationDialog
@@ -165,7 +165,7 @@
             this.MainMenuStrip = this.menuStrip;
             this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "ChannelConfigurationDialog";
-            this.Text = "Channel Configuration";
+            this.Text = "Probe Group Configuration";
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
@@ -51,7 +51,7 @@
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
             this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 30);
+            this.splitContainer1.Location = new System.Drawing.Point(0, 24);
             this.splitContainer1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
@@ -64,8 +64,8 @@
             // 
             this.splitContainer1.Panel2.Controls.Add(this.buttonCancel);
             this.splitContainer1.Panel2.Controls.Add(this.buttonOK);
-            this.splitContainer1.Size = new System.Drawing.Size(609, 544);
-            this.splitContainer1.SplitterDistance = 507;
+            this.splitContainer1.Size = new System.Drawing.Size(609, 550);
+            this.splitContainer1.SplitterDistance = 513;
             this.splitContainer1.TabIndex = 0;
             // 
             // zedGraphChannels
@@ -82,7 +82,7 @@
             this.zedGraphChannels.ScrollMinX = 0D;
             this.zedGraphChannels.ScrollMinY = 0D;
             this.zedGraphChannels.ScrollMinY2 = 0D;
-            this.zedGraphChannels.Size = new System.Drawing.Size(609, 507);
+            this.zedGraphChannels.Size = new System.Drawing.Size(609, 513);
             this.zedGraphChannels.TabIndex = 4;
             this.zedGraphChannels.UseExtendedPrintDialog = true;
             this.zedGraphChannels.ZoomEvent += new ZedGraph.ZedGraphControl.ZoomEventHandler(this.ZoomEvent);
@@ -119,7 +119,7 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(609, 30);
+            this.menuStrip.Size = new System.Drawing.Size(609, 24);
             this.menuStrip.TabIndex = 5;
             this.menuStrip.Text = "menuStripChannelConfiguration";
             // 
@@ -130,27 +130,27 @@
             this.dropDownSaveFile,
             this.dropDownLoadDefault});
             this.fileMenuItem.Name = "fileMenuItem";
-            this.fileMenuItem.Size = new System.Drawing.Size(46, 28);
+            this.fileMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileMenuItem.Text = "File";
             // 
             // dropDownOpenFile
             // 
             this.dropDownOpenFile.Name = "dropDownOpenFile";
-            this.dropDownOpenFile.Size = new System.Drawing.Size(330, 26);
+            this.dropDownOpenFile.Size = new System.Drawing.Size(265, 22);
             this.dropDownOpenFile.Text = "Open Channel Configuration";
             this.dropDownOpenFile.Click += new System.EventHandler(this.MenuItemOpenFile);
             // 
             // dropDownSaveFile
             // 
             this.dropDownSaveFile.Name = "dropDownSaveFile";
-            this.dropDownSaveFile.Size = new System.Drawing.Size(330, 26);
+            this.dropDownSaveFile.Size = new System.Drawing.Size(265, 22);
             this.dropDownSaveFile.Text = "Save Channel Configuration";
             this.dropDownSaveFile.Click += new System.EventHandler(this.MenuItemSaveFile);
             // 
             // dropDownLoadDefault
             // 
             this.dropDownLoadDefault.Name = "dropDownLoadDefault";
-            this.dropDownLoadDefault.Size = new System.Drawing.Size(330, 26);
+            this.dropDownLoadDefault.Size = new System.Drawing.Size(265, 22);
             this.dropDownLoadDefault.Text = "Load Default Channel Configuration";
             this.dropDownLoadDefault.Click += new System.EventHandler(this.MenuItemLoadDefaultConfig);
             // 

--- a/OpenEphys.Onix1.Design/DesignHelper.cs
+++ b/OpenEphys.Onix1.Design/DesignHelper.cs
@@ -18,46 +18,13 @@ namespace OpenEphys.Onix1.Design
         #nullable enable
         public static T? DeserializeString<T>(string jsonString)
         {
-            var errors = new List<string>();
-
-            var serializerSettings = new JsonSerializerSettings()
-            {
-                Error = delegate(object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
-                {
-                    errors.Add(args.ErrorContext.Error.Message);
-                    args.ErrorContext.Handled = true;
-                }
-            };
-
-            var obj = JsonConvert.DeserializeObject<T>(jsonString, serializerSettings);
-
-            if (errors.Count > 0)
-            {
-                MessageBox.Show($"There were errors encountered while parsing a JSON string. Check the console " +
-                    $"for an error log.", "JSON Parse Error");
-
-                foreach (var e in errors)
-                {
-                    Console.Error.WriteLine(e);
-                }
-
-                return default;
-            }
-
-            return obj;
+            return ProbeGroupHelper.DeserializeString<T>(jsonString);
         }
         #nullable disable
 
         public static void SerializeObject(object _object, string filepath)
         {
-            var serializerSettings = new JsonSerializerSettings()
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-            };
-
-            var stringJson = JsonConvert.SerializeObject(_object, Formatting.Indented, serializerSettings);
-
-            File.WriteAllText(filepath, stringJson);
+            ProbeGroupHelper.SerializeObject(_object, filepath);
         }
 
         public static IEnumerable<Control> GetAllControls(this Control root)

--- a/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.Designer.cs
@@ -53,7 +53,7 @@
             this.tabControl.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl.Name = "tabControl";
             this.tabControl.SelectedIndex = 0;
-            this.tabControl.Size = new System.Drawing.Size(1588, 740);
+            this.tabControl.Size = new System.Drawing.Size(1588, 746);
             this.tabControl.TabIndex = 0;
             // 
             // tabPageStimulusSequence
@@ -62,7 +62,7 @@
             this.tabPageStimulusSequence.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageStimulusSequence.Name = "tabPageStimulusSequence";
             this.tabPageStimulusSequence.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageStimulusSequence.Size = new System.Drawing.Size(1580, 711);
+            this.tabPageStimulusSequence.Size = new System.Drawing.Size(1580, 717);
             this.tabPageStimulusSequence.TabIndex = 1;
             this.tabPageStimulusSequence.Text = "Stimulus Sequence";
             this.tabPageStimulusSequence.UseVisualStyleBackColor = true;
@@ -109,14 +109,14 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 2, 0, 2);
-            this.menuStrip.Size = new System.Drawing.Size(1594, 30);
+            this.menuStrip.Size = new System.Drawing.Size(1594, 24);
             this.menuStrip.TabIndex = 3;
             this.menuStrip.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 26);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -126,12 +126,12 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 30);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1594, 786);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1594, 792);
             this.tableLayoutPanel1.TabIndex = 4;
             // 
             // flowLayoutPanel1
@@ -140,7 +140,7 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 747);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 753);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1588, 36);
             this.flowLayoutPanel1.TabIndex = 1;
@@ -158,6 +158,7 @@
             this.Name = "HeadstageRhs2116Dialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "HeadstageRhs2116Dialog";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.HeadstageRhs2116Dialog_FormClosing);
             this.tabControl.ResumeLayout(false);
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();

--- a/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.cs
+++ b/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using OpenEphys.ProbeInterface.NET;
 
 namespace OpenEphys.Onix1.Design
 {
@@ -15,22 +16,30 @@ namespace OpenEphys.Onix1.Design
         internal readonly Rhs2116StimulusSequenceDialog StimulusSequenceDialog;
         internal readonly Rhs2116Dialog Rhs2116Dialog;
 
-        internal Rhs2116ProbeGroup ProbeGroup;
-
         /// <summary>
         /// Initializes a new instance of a <see cref="HeadstageRhs2116Dialog"/>.
         /// </summary>
         /// <param name="probeGroup">Current channel configuration settings for a <see cref="Rhs2116ProbeGroup"/>.</param>
         /// <param name="sequence">Current stimulus sequence for a <see cref="Rhs2116StimulusSequencePair"/>.</param>
         /// <param name="rhs2116">Current configuration settings for a single <see cref="ConfigureRhs2116"/>.</param>
+        [Obsolete("This constructor is now deprecated, as Probe Groups are now held in externalized files.")]
         public HeadstageRhs2116Dialog(Rhs2116ProbeGroup probeGroup, Rhs2116StimulusSequencePair sequence,
+            ConfigureRhs2116Pair rhs2116) : this("", sequence, rhs2116)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="HeadstageRhs2116Dialog"/>.
+        /// </summary>
+        /// <param name="probeInterfaceFile">Filepath to the location where the Probe Interface file is saved.</param>
+        /// <param name="sequence">Stimulus sequence object containing all stimulation parameters.</param>
+        /// <param name="rhs2116">Current configuration settings for the Rhs2116 device.</param>
+        public HeadstageRhs2116Dialog(string probeInterfaceFile, Rhs2116StimulusSequencePair sequence,
             ConfigureRhs2116Pair rhs2116)
         {
             InitializeComponent();
 
-            ProbeGroup = new Rhs2116ProbeGroup(probeGroup);
-
-            StimulusSequenceDialog = new Rhs2116StimulusSequenceDialog(sequence, ProbeGroup)
+            StimulusSequenceDialog = new Rhs2116StimulusSequenceDialog(sequence, probeInterfaceFile)
             {
                 TopLevel = false,
                 FormBorderStyle = FormBorderStyle.None,
@@ -62,6 +71,11 @@ namespace OpenEphys.Onix1.Design
                 DialogResult = result;
                 Close();
             }
+        }
+
+        private void HeadstageRhs2116Dialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            ChannelConfigurationDialog.TryRemoveEmptyFile(StimulusSequenceDialog.ChannelDialog.ProbeInterfaceFile);
         }
     }
 }

--- a/OpenEphys.Onix1.Design/HeadstageRhs2116Editor.cs
+++ b/OpenEphys.Onix1.Design/HeadstageRhs2116Editor.cs
@@ -18,14 +18,16 @@ namespace OpenEphys.Onix1.Design
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
                 if (editorState != null && !editorState.WorkflowRunning && component is ConfigureHeadstageRhs2116 configureNode)
                 {
-                    using var editorDialog = new HeadstageRhs2116Dialog(configureNode.StimulusTrigger.ProbeGroup,
+                    using var editorDialog = new HeadstageRhs2116Dialog(configureNode.StimulusTrigger.ProbeInterfaceFile,
                         configureNode.StimulusTrigger.StimulusSequence, configureNode.Rhs2116Pair);
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
                         configureNode.StimulusTrigger.StimulusSequence = editorDialog.StimulusSequenceDialog.Sequence;
-                        configureNode.StimulusTrigger.ProbeGroup = (Rhs2116ProbeGroup)editorDialog.StimulusSequenceDialog.ChannelDialog.ProbeGroup;
+                        configureNode.StimulusTrigger.ProbeInterfaceFile = editorDialog.StimulusSequenceDialog.ChannelDialog.ProbeInterfaceFile;
                         configureNode.Rhs2116Pair = editorDialog.Rhs2116Dialog.ConfigureNode;
+
+                        ProbeGroupHelper.SaveExternalProbeConfigurationFile(editorDialog.StimulusSequenceDialog.ChannelDialog.ProbeGroup, configureNode.StimulusTrigger.ProbeInterfaceFile);
 
                         return true;
                     }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.Designer.cs
@@ -49,14 +49,14 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(1312, 26);
+            this.menuStrip.Size = new System.Drawing.Size(1312, 24);
             this.menuStrip.TabIndex = 1;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -66,13 +66,13 @@
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.panelProbe, 0, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 49F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1312, 757);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1312, 759);
             this.tableLayoutPanel1.TabIndex = 4;
             // 
             // flowLayoutPanel1
@@ -81,7 +81,7 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 712);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 714);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1304, 41);
@@ -115,10 +115,10 @@
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelProbe.Location = new System.Drawing.Point(3, 3);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(1306, 702);
+            this.panelProbe.Size = new System.Drawing.Size(1306, 704);
             this.panelProbe.TabIndex = 3;
             // 
-            // NeuropixelsV1eDialog
+            // NeuropixelsV1Dialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -128,9 +128,10 @@
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.Name = "NeuropixelsV1eDialog";
+            this.Name = "NeuropixelsV1Dialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV1 Configuration";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.NeuropixelsV1Dialog_FormClosing);
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.cs
@@ -76,5 +76,20 @@ namespace OpenEphys.Onix1.Design
 
             ConfigureNode.InvertPolarity = ProbeConfigurationDialog.InvertPolarity;
         }
+
+        internal NeuropixelsV1eProbeGroup GetProbeGroup()
+        {
+            return ProbeConfigurationDialog.GetProbeGroup();
+        }
+
+        internal string GetProbeInterfaceFile()
+        {
+            return ProbeConfigurationDialog.ProbeConfiguration.ProbeInterfaceFile;
+        }
+
+        private void NeuropixelsV1Dialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            ChannelConfigurationDialog.TryRemoveEmptyFile(ProbeConfigurationDialog.ProbeConfiguration.ProbeInterfaceFile);
+        }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1Editor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1Editor.cs
@@ -28,6 +28,8 @@ namespace OpenEphys.Onix1.Design
                         configureNeuropixelsV1.ProbeConfiguration = editorDialog.ConfigureNode.ProbeConfiguration;
                         configureNeuropixelsV1.InvertPolarity = editorDialog.ConfigureNode.InvertPolarity;
 
+                        ProbeGroupHelper.SaveExternalProbeConfigurationFile(editorDialog.GetProbeGroup(), configureNeuropixelsV1.ProbeConfiguration.ProbeInterfaceFile);
+
                         return true;
                     }
                 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -169,32 +169,32 @@ namespace OpenEphys.Onix1.Design
 
         private void SetChannelPreset(ChannelPreset preset)
         {
-            var probeConfiguration = ChannelConfiguration.ProbeConfiguration;
-            var electrodes = NeuropixelsV1eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup);
+            var probeGroup = (NeuropixelsV1eProbeGroup)ChannelConfiguration.ProbeGroup;
+            var electrodes = probeGroup.ToElectrodes();
 
             switch (preset)
             {
                 case ChannelPreset.BankA:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV1Bank.A).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV1Bank.A).ToArray());
                     break;
 
                 case ChannelPreset.BankB:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV1Bank.B).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV1Bank.B).ToArray());
                     break;
 
                 case ChannelPreset.BankC:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV1Bank.C ||
-                                                                             (e.Bank == NeuropixelsV1Bank.B && e.Index >= 576)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV1Bank.C ||
+                                                (e.Bank == NeuropixelsV1Bank.B && e.Index >= 576)).ToArray());
                     break;
 
                 case ChannelPreset.SingleColumn:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Index % 2 == 0 && e.Bank == NeuropixelsV1Bank.A) ||
-                                                                              (e.Index % 2 == 1 && e.Bank == NeuropixelsV1Bank.B)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Index % 2 == 0 && e.Bank == NeuropixelsV1Bank.A) ||
+                                                (e.Index % 2 == 1 && e.Bank == NeuropixelsV1Bank.B)).ToArray());
                     break;
 
                 case ChannelPreset.Tetrodes:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Index % 8 < 4 && e.Bank == NeuropixelsV1Bank.A) ||
-                                                                              (e.Index % 8 > 3 && e.Bank == NeuropixelsV1Bank.B)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Index % 8 < 4 && e.Bank == NeuropixelsV1Bank.A) ||
+                                                (e.Index % 8 > 3 && e.Bank == NeuropixelsV1Bank.B)).ToArray());
                     break;
             }
 
@@ -206,7 +206,7 @@ namespace OpenEphys.Onix1.Design
 
         private void CheckForExistingChannelPreset()
         {
-            var channelMap = ChannelConfiguration.ProbeConfiguration.ChannelMap;
+            var channelMap = ((NeuropixelsV1eProbeGroup)ChannelConfiguration.ProbeGroup).ToChannelMap();
 
             if (channelMap.All(e => e.Bank == NeuropixelsV1Bank.A))
             {
@@ -239,8 +239,6 @@ namespace OpenEphys.Onix1.Design
 
         private void OnFileLoadEvent(object sender, EventArgs e)
         {
-            // NB: Ensure that the newly loaded ProbeConfiguration in the ChannelConfigurationDialog is reflected here.
-            ProbeConfiguration = ChannelConfiguration.ProbeConfiguration;
             CheckForExistingChannelPreset();
         }
 
@@ -317,22 +315,22 @@ namespace OpenEphys.Onix1.Design
 
             panelProbe.Visible = adcCalibration.HasValue && gainCorrection.HasValue;
 
-            if (toolStripAdcCalSN.Text == NoFileSelected) 
+            if (toolStripAdcCalSN.Text == NoFileSelected)
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusWarningImage;
-            else if (toolStripAdcCalSN.Text == InvalidFile) 
+            else if (toolStripAdcCalSN.Text == InvalidFile)
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusCriticalImage;
             else if (toolStripGainCalSN.Text != NoFileSelected && toolStripGainCalSN.Text != InvalidFile && toolStripAdcCalSN.Text != toolStripGainCalSN.Text)
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusBlockedImage;
-            else 
+            else
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusReadyImage;
 
-            if (toolStripGainCalSN.Text == NoFileSelected) 
+            if (toolStripGainCalSN.Text == NoFileSelected)
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusWarningImage;
-            else if (toolStripGainCalSN.Text == InvalidFile) 
+            else if (toolStripGainCalSN.Text == InvalidFile)
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusCriticalImage;
             else if (toolStripAdcCalSN.Text != NoFileSelected && toolStripAdcCalSN.Text != InvalidFile && toolStripAdcCalSN.Text != toolStripGainCalSN.Text)
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusBlockedImage;
-            else 
+            else
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusReadyImage;
         }
 
@@ -432,7 +430,7 @@ namespace OpenEphys.Onix1.Design
 
         private void EnableSelectedContacts()
         {
-            var electrodes = NeuropixelsV1eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup);
+            var electrodes = ((NeuropixelsV1eProbeGroup)ChannelConfiguration.ProbeGroup).ToElectrodes();
 
             var selectedElectrodes = electrodes.Where((e, ind) => ChannelConfiguration.SelectedContacts[ind])
                                                .ToArray();
@@ -472,6 +470,11 @@ namespace OpenEphys.Onix1.Design
         private void UpdateTrackBarLocation(object sender, EventArgs e)
         {
             trackBarProbePosition.Value = (int)(ChannelConfiguration.GetRelativeVerticalPosition() * 100);
+        }
+
+        internal NeuropixelsV1eProbeGroup GetProbeGroup()
+        {
+            return (NeuropixelsV1eProbeGroup)ChannelConfiguration.ProbeGroup;
         }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
@@ -57,7 +57,7 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1350, 732);
+            this.tabControl1.Size = new System.Drawing.Size(1350, 734);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV1e
@@ -67,7 +67,7 @@
             this.tabPageNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageNeuropixelsV1e.Name = "tabPageNeuropixelsV1e";
             this.tabPageNeuropixelsV1e.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageNeuropixelsV1e.Size = new System.Drawing.Size(1342, 703);
+            this.tabPageNeuropixelsV1e.Size = new System.Drawing.Size(1342, 705);
             this.tabPageNeuropixelsV1e.TabIndex = 0;
             this.tabPageNeuropixelsV1e.Text = "NeuropixelsV1e";
             this.tabPageNeuropixelsV1e.UseVisualStyleBackColor = true;
@@ -79,7 +79,7 @@
             this.panelNeuropixelsV1e.Location = new System.Drawing.Point(3, 2);
             this.panelNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV1e.Name = "panelNeuropixelsV1e";
-            this.panelNeuropixelsV1e.Size = new System.Drawing.Size(1336, 699);
+            this.panelNeuropixelsV1e.Size = new System.Drawing.Size(1336, 701);
             this.panelNeuropixelsV1e.TabIndex = 0;
             // 
             // tabPageBno055
@@ -134,14 +134,14 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1356, 26);
+            this.menuStrip1.Size = new System.Drawing.Size(1356, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -151,13 +151,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1356, 778);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1356, 780);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -166,7 +166,7 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 738);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 740);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1352, 38);
@@ -186,6 +186,7 @@
             this.Name = "NeuropixelsV1eHeadstageDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV1e Headstage Configuration";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.NeuropixelsV1eHeadstageDialog_FormClosing);
             this.tabControl1.ResumeLayout(false);
             this.tabPageNeuropixelsV1e.ResumeLayout(false);
             this.tabPageNeuropixelsV1e.PerformLayout();

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
@@ -61,5 +61,10 @@ namespace OpenEphys.Onix1.Design
 
             DialogResult = DialogResult.OK;
         }
+
+        private void NeuropixelsV1eHeadstageDialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            ChannelConfigurationDialog.TryRemoveEmptyFile(DialogNeuropixelsV1e.GetProbeInterfaceFile());
+        }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.Designer.cs
@@ -32,6 +32,8 @@
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPageNeuropixelsV1A = new System.Windows.Forms.TabPage();
             this.panelNeuropixelsV1A = new System.Windows.Forms.Panel();
+            this.tabPageNeuropixelsV1B = new System.Windows.Forms.TabPage();
+            this.panelNeuropixelsV1B = new System.Windows.Forms.Panel();
             this.tabPageBno055 = new System.Windows.Forms.TabPage();
             this.panelBno055 = new System.Windows.Forms.Panel();
             this.buttonCancel = new System.Windows.Forms.Button();
@@ -40,15 +42,13 @@
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.tabPageNeuropixelsV1B = new System.Windows.Forms.TabPage();
-            this.panelNeuropixelsV1B = new System.Windows.Forms.Panel();
             this.tabControl1.SuspendLayout();
             this.tabPageNeuropixelsV1A.SuspendLayout();
+            this.tabPageNeuropixelsV1B.SuspendLayout();
             this.tabPageBno055.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
-            this.tabPageNeuropixelsV1B.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControl1
@@ -61,7 +61,7 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1350, 732);
+            this.tabControl1.Size = new System.Drawing.Size(1350, 734);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV1A
@@ -69,7 +69,7 @@
             this.tabPageNeuropixelsV1A.Controls.Add(this.panelNeuropixelsV1A);
             this.tabPageNeuropixelsV1A.Location = new System.Drawing.Point(4, 25);
             this.tabPageNeuropixelsV1A.Name = "tabPageNeuropixelsV1A";
-            this.tabPageNeuropixelsV1A.Size = new System.Drawing.Size(1342, 703);
+            this.tabPageNeuropixelsV1A.Size = new System.Drawing.Size(1342, 705);
             this.tabPageNeuropixelsV1A.TabIndex = 0;
             this.tabPageNeuropixelsV1A.Text = "NeuropixelsV1A";
             this.tabPageNeuropixelsV1A.UseVisualStyleBackColor = true;
@@ -80,8 +80,28 @@
             this.panelNeuropixelsV1A.Location = new System.Drawing.Point(0, 0);
             this.panelNeuropixelsV1A.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV1A.Name = "panelNeuropixelsV1A";
-            this.panelNeuropixelsV1A.Size = new System.Drawing.Size(1342, 703);
+            this.panelNeuropixelsV1A.Size = new System.Drawing.Size(1342, 705);
             this.panelNeuropixelsV1A.TabIndex = 0;
+            // 
+            // tabPageNeuropixelsV1B
+            // 
+            this.tabPageNeuropixelsV1B.Controls.Add(this.panelNeuropixelsV1B);
+            this.tabPageNeuropixelsV1B.Location = new System.Drawing.Point(4, 25);
+            this.tabPageNeuropixelsV1B.Name = "tabPageNeuropixelsV1B";
+            this.tabPageNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
+            this.tabPageNeuropixelsV1B.TabIndex = 2;
+            this.tabPageNeuropixelsV1B.Text = "NeuropixelsV1B";
+            this.tabPageNeuropixelsV1B.UseVisualStyleBackColor = true;
+            // 
+            // panelNeuropixelsV1B
+            // 
+            this.panelNeuropixelsV1B.AutoSize = true;
+            this.panelNeuropixelsV1B.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelNeuropixelsV1B.Location = new System.Drawing.Point(0, 0);
+            this.panelNeuropixelsV1B.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.panelNeuropixelsV1B.Name = "panelNeuropixelsV1B";
+            this.panelNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
+            this.panelNeuropixelsV1B.TabIndex = 1;
             // 
             // tabPageBno055
             // 
@@ -135,14 +155,14 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1356, 26);
+            this.menuStrip1.Size = new System.Drawing.Size(1356, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -152,13 +172,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1356, 778);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1356, 780);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -167,31 +187,11 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 738);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 740);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1352, 38);
             this.flowLayoutPanel1.TabIndex = 0;
-            // 
-            // tabPageNeuropixelsV1B
-            // 
-            this.tabPageNeuropixelsV1B.Controls.Add(this.panelNeuropixelsV1B);
-            this.tabPageNeuropixelsV1B.Location = new System.Drawing.Point(4, 25);
-            this.tabPageNeuropixelsV1B.Name = "tabPageNeuropixelsV1B";
-            this.tabPageNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
-            this.tabPageNeuropixelsV1B.TabIndex = 2;
-            this.tabPageNeuropixelsV1B.Text = "NeuropixelsV1B";
-            this.tabPageNeuropixelsV1B.UseVisualStyleBackColor = true;
-            // 
-            // panelNeuropixelsV1B
-            // 
-            this.panelNeuropixelsV1B.AutoSize = true;
-            this.panelNeuropixelsV1B.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelNeuropixelsV1B.Location = new System.Drawing.Point(0, 0);
-            this.panelNeuropixelsV1B.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.panelNeuropixelsV1B.Name = "panelNeuropixelsV1B";
-            this.panelNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
-            this.panelNeuropixelsV1B.TabIndex = 1;
             // 
             // NeuropixelsV1fHeadstageDialog
             // 
@@ -207,15 +207,16 @@
             this.Name = "NeuropixelsV1fHeadstageDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV1f Headstage Configuration";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.NeuropixelsV1fHeadstageDialog_FormClosing);
             this.tabControl1.ResumeLayout(false);
             this.tabPageNeuropixelsV1A.ResumeLayout(false);
+            this.tabPageNeuropixelsV1B.ResumeLayout(false);
+            this.tabPageNeuropixelsV1B.PerformLayout();
             this.tabPageBno055.ResumeLayout(false);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.ResumeLayout(false);
-            this.tabPageNeuropixelsV1B.ResumeLayout(false);
-            this.tabPageNeuropixelsV1B.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
@@ -82,5 +82,11 @@ namespace OpenEphys.Onix1.Design
 
             DialogResult = DialogResult.OK;
         }
+
+        private void NeuropixelsV1fHeadstageDialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            ChannelConfigurationDialog.TryRemoveEmptyFile(DialogNeuropixelsV1A.GetProbeInterfaceFile());
+            ChannelConfigurationDialog.TryRemoveEmptyFile(DialogNeuropixelsV1B.GetProbeInterfaceFile());
+        }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageEditor.cs
@@ -31,11 +31,17 @@ namespace OpenEphys.Onix1.Design
                         configureHeadstage.NeuropixelsV1A.ProbeConfiguration = editorDialog.DialogNeuropixelsV1A.ConfigureNode.ProbeConfiguration;
                         configureHeadstage.NeuropixelsV1A.InvertPolarity = editorDialog.DialogNeuropixelsV1A.ConfigureNode.InvertPolarity;
 
+                        ProbeGroupHelper.SaveExternalProbeConfigurationFile(editorDialog.DialogNeuropixelsV1A.GetProbeGroup(),
+                            configureHeadstage.NeuropixelsV1A.ProbeConfiguration.ProbeInterfaceFile);
+
                         configureHeadstage.NeuropixelsV1B.AdcCalibrationFile = editorDialog.DialogNeuropixelsV1B.ConfigureNode.AdcCalibrationFile;
                         configureHeadstage.NeuropixelsV1B.GainCalibrationFile = editorDialog.DialogNeuropixelsV1B.ConfigureNode.GainCalibrationFile;
                         configureHeadstage.NeuropixelsV1B.Enable = editorDialog.DialogNeuropixelsV1B.ConfigureNode.Enable;
                         configureHeadstage.NeuropixelsV1B.ProbeConfiguration = editorDialog.DialogNeuropixelsV1B.ConfigureNode.ProbeConfiguration;
                         configureHeadstage.NeuropixelsV1B.InvertPolarity = editorDialog.DialogNeuropixelsV1B.ConfigureNode.InvertPolarity;
+
+                        ProbeGroupHelper.SaveExternalProbeConfigurationFile(editorDialog.DialogNeuropixelsV1B.GetProbeGroup(),
+                            configureHeadstage.NeuropixelsV1B.ProbeConfiguration.ProbeInterfaceFile);
 
                         return true;
                     }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
@@ -49,14 +49,14 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(1139, 26);
+            this.menuStrip.Size = new System.Drawing.Size(1139, 24);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tabControlProbe
@@ -66,7 +66,7 @@
             this.tabControlProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControlProbe.Name = "tabControlProbe";
             this.tabControlProbe.SelectedIndex = 0;
-            this.tabControlProbe.Size = new System.Drawing.Size(1133, 632);
+            this.tabControlProbe.Size = new System.Drawing.Size(1133, 634);
             this.tabControlProbe.TabIndex = 1;
             // 
             // buttonCancel
@@ -99,13 +99,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControlProbe, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 49F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1139, 685);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1139, 687);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -114,8 +114,8 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 640);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 642);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1131, 41);
             this.flowLayoutPanel1.TabIndex = 2;
@@ -134,6 +134,7 @@
             this.Name = "NeuropixelsV2eDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Configuration";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.NeuropixelsV2eDialog_FormClosing);
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -36,6 +36,14 @@ namespace OpenEphys.Onix1.Design
                 ConfigureNode = new ConfigureNeuropixelsV2e(configureV2e);
             }
 
+            if (ProbeGroupHelper.CompareFilePaths(ConfigureNode.ProbeConfigurationA.ProbeInterfaceFile, ConfigureNode.ProbeConfigurationB.ProbeInterfaceFile))
+            {
+                MessageBox.Show("Both probes are pointing to the same Probe Interface file. \n\nAny changes made in " +
+                    "Probe A will be ignored, and any changes made in Probe B will be applied to both probes.\n\nIf this is not desired, " +
+                    "close this GUI and update the ProbeInterfaceFile property in ProbeConfigurationA/B to point to unique files.",
+                    "Probe Interface File Not Unique", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+
             ProbeConfigurations = new List<NeuropixelsV2eProbeConfigurationDialog>
             {
                 new(ConfigureNode.ProbeConfigurationA, ConfigureNode.GainCalibrationFileA, ConfigureNode.InvertPolarity)
@@ -127,6 +135,31 @@ namespace OpenEphys.Onix1.Design
             ConfigureNode.GainCalibrationFileB = ProbeConfigurations[GetProbeIndex(NeuropixelsV2Probe.ProbeB)].textBoxProbeCalibrationFile.Text;
 
             ConfigureNode.InvertPolarity = ProbeConfigurations[GetProbeIndex(NeuropixelsV2Probe.ProbeA)].InvertPolarity;
+        }
+
+        internal NeuropixelsV2eProbeGroup[] GetProbeGroups()
+        {
+            NeuropixelsV2eProbeGroup[] probeGroups = new NeuropixelsV2eProbeGroup[ProbeConfigurations.Count];
+
+            for (int i = 0; i < ProbeConfigurations.Count; i++)
+            {
+                probeGroups[i] = ProbeConfigurations[i].GetProbeGroup();
+            }
+
+            return probeGroups;
+        }
+
+        internal void TryRemoveEmptyFiles()
+        {
+            foreach (var probeConfiguration in ProbeConfigurations)
+            {
+                ChannelConfigurationDialog.TryRemoveEmptyFile(probeConfiguration.ProbeConfiguration.ProbeInterfaceFile);
+            }
+        }
+
+        private void NeuropixelsV2eDialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            TryRemoveEmptyFiles();
         }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eEditor.cs
@@ -29,6 +29,14 @@ namespace OpenEphys.Onix1.Design
                         configureNeuropixelsV2e.ProbeConfigurationB = editorDialog.ConfigureNode.ProbeConfigurationB;
                         configureNeuropixelsV2e.InvertPolarity = editorDialog.ConfigureNode.InvertPolarity;
 
+                        var probeGroups = editorDialog.GetProbeGroups();
+
+                        if (probeGroups.Length != 2)
+                            throw new ArgumentOutOfRangeException("Invalid number of probe groups returned.");
+
+                        ProbeGroupHelper.SaveExternalProbeConfigurationFile(probeGroups[0], configureNeuropixelsV2e.ProbeConfigurationA.ProbeInterfaceFile);
+                        ProbeGroupHelper.SaveExternalProbeConfigurationFile(probeGroups[1], configureNeuropixelsV2e.ProbeConfigurationB.ProbeInterfaceFile);
+
                         return true;
                     }
                 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
@@ -80,14 +80,14 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1151, 26);
+            this.menuStrip1.Size = new System.Drawing.Size(1151, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -97,13 +97,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1151, 623);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1151, 625);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // tabControl1
@@ -115,7 +115,7 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1145, 577);
+            this.tabControl1.Size = new System.Drawing.Size(1145, 579);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV2e
@@ -125,7 +125,7 @@
             this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageNeuropixelsV2e.Name = "tabPageNeuropixelsV2e";
             this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(1137, 548);
+            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(1137, 550);
             this.tabPageNeuropixelsV2e.TabIndex = 0;
             this.tabPageNeuropixelsV2e.Text = "NeuropixelsV2e";
             this.tabPageNeuropixelsV2e.UseVisualStyleBackColor = true;
@@ -136,7 +136,7 @@
             this.panelNeuropixelsV2e.Location = new System.Drawing.Point(3, 2);
             this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV2e.Name = "panelNeuropixelsV2e";
-            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(1131, 544);
+            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(1131, 546);
             this.panelNeuropixelsV2e.TabIndex = 0;
             // 
             // tabPageBno055
@@ -146,7 +146,7 @@
             this.tabPageBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageBno055.Name = "tabPageBno055";
             this.tabPageBno055.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageBno055.Size = new System.Drawing.Size(1137, 541);
+            this.tabPageBno055.Size = new System.Drawing.Size(1137, 548);
             this.tabPageBno055.TabIndex = 1;
             this.tabPageBno055.Text = "Bno055";
             this.tabPageBno055.UseVisualStyleBackColor = true;
@@ -158,7 +158,7 @@
             this.panelBno055.Location = new System.Drawing.Point(3, 2);
             this.panelBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(1131, 537);
+            this.panelBno055.Size = new System.Drawing.Size(1131, 544);
             this.panelBno055.TabIndex = 0;
             // 
             // flowLayoutPanel1
@@ -169,8 +169,8 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 585);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 587);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1143, 34);
             this.flowLayoutPanel1.TabIndex = 1;
@@ -189,6 +189,7 @@
             this.Name = "NeuropixelsV2eHeadstageDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Headstage Configuration";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.NeuropixelsV2eHeadstageDialog_FormClosing);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
@@ -68,5 +68,10 @@ namespace OpenEphys.Onix1.Design
 
             DialogResult = DialogResult.OK;
         }
+
+        private void NeuropixelsV2eHeadstageDialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            DialogNeuropixelsV2e.TryRemoveEmptyFiles();
+        }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
@@ -49,6 +49,7 @@
             this.panelTrackBar = new System.Windows.Forms.Panel();
             this.trackBarProbePosition = new System.Windows.Forms.TrackBar();
             this.panelChannelOptions = new System.Windows.Forms.Panel();
+            this.checkBoxInvertPolarity = new System.Windows.Forms.CheckBox();
             this.textBoxGainCorrection = new System.Windows.Forms.TextBox();
             this.textBoxProbeCalibrationFile = new System.Windows.Forms.TextBox();
             this.comboBoxReference = new System.Windows.Forms.ComboBox();
@@ -59,7 +60,6 @@
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripGainCalSN = new System.Windows.Forms.ToolStripStatusLabel();
-            this.checkBoxInvertPolarity = new System.Windows.Forms.CheckBox();
             label6 = new System.Windows.Forms.Label();
             label7 = new System.Windows.Forms.Label();
             probeCalibrationFile = new System.Windows.Forms.Label();
@@ -81,10 +81,9 @@
             // 
             label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             label6.AutoSize = true;
-            label6.Location = new System.Drawing.Point(0, 440);
-            label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label6.Location = new System.Drawing.Point(0, 542);
             label6.Name = "label6";
-            label6.Size = new System.Drawing.Size(32, 13);
+            label6.Size = new System.Drawing.Size(39, 16);
             label6.TabIndex = 28;
             label6.Text = "0 mm";
             // 
@@ -93,9 +92,8 @@
             label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             label7.AutoSize = true;
             label7.Location = new System.Drawing.Point(0, 0);
-            label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             label7.Name = "label7";
-            label7.Size = new System.Drawing.Size(38, 13);
+            label7.Size = new System.Drawing.Size(46, 16);
             label7.TabIndex = 29;
             label7.Text = "10 mm";
             label7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -103,43 +101,48 @@
             // probeCalibrationFile
             // 
             probeCalibrationFile.AutoSize = true;
-            probeCalibrationFile.Location = new System.Drawing.Point(11, 9);
-            probeCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            probeCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            probeCalibrationFile.Location = new System.Drawing.Point(15, 11);
+            probeCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             probeCalibrationFile.Name = "probeCalibrationFile";
-            probeCalibrationFile.Size = new System.Drawing.Size(109, 13);
+            probeCalibrationFile.Size = new System.Drawing.Size(139, 16);
             probeCalibrationFile.TabIndex = 32;
             probeCalibrationFile.Text = "Probe Calibration File:";
             // 
             // Reference
             // 
             Reference.AutoSize = true;
-            Reference.Location = new System.Drawing.Point(11, 93);
-            Reference.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            Reference.Location = new System.Drawing.Point(15, 114);
             Reference.Name = "Reference";
-            Reference.Size = new System.Drawing.Size(60, 13);
+            Reference.Size = new System.Drawing.Size(73, 16);
             Reference.TabIndex = 30;
             Reference.Text = "Reference:";
             // 
             // labelPresets
             // 
             labelPresets.AutoSize = true;
-            labelPresets.Location = new System.Drawing.Point(11, 119);
-            labelPresets.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            labelPresets.Location = new System.Drawing.Point(15, 146);
             labelPresets.Name = "labelPresets";
-            labelPresets.Size = new System.Drawing.Size(49, 26);
+            labelPresets.Size = new System.Drawing.Size(59, 32);
             labelPresets.TabIndex = 23;
             labelPresets.Text = "Channel \nPresets:";
             // 
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(11, 51);
-            label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label1.Location = new System.Drawing.Point(15, 63);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(58, 26);
+            label1.Size = new System.Drawing.Size(71, 32);
             label1.TabIndex = 35;
             label1.Text = "Gain\r\nCorrection:";
+            // 
+            // invertPolarity
+            // 
+            invertPolarity.AutoSize = true;
+            invertPolarity.Location = new System.Drawing.Point(15, 187);
+            invertPolarity.Name = "invertPolarity";
+            invertPolarity.Size = new System.Drawing.Size(55, 32);
+            invertPolarity.TabIndex = 44;
+            invertPolarity.Text = "Invert\r\nPolarity:";
             // 
             // toolStripLabelGainCalibrationSN
             // 
@@ -157,8 +160,8 @@
             this.fileToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(834, 24);
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip.Size = new System.Drawing.Size(1112, 24);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
@@ -172,10 +175,10 @@
             // 
             this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(11, 184);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonEnableContacts.Location = new System.Drawing.Point(15, 226);
+            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(183, 36);
+            this.buttonEnableContacts.Size = new System.Drawing.Size(243, 44);
             this.buttonEnableContacts.TabIndex = 20;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select electrodes in the probe view. \r\nPress this button to ena" +
@@ -187,10 +190,10 @@
             // 
             this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(11, 224);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonClearSelections.Location = new System.Drawing.Point(15, 276);
+            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(183, 36);
+            this.buttonClearSelections.Size = new System.Drawing.Size(243, 44);
             this.buttonClearSelections.TabIndex = 19;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.toolTip.SetToolTip(this.buttonClearSelections, "Deselect all electrodes in the probe view. \r\nNote that this does not disable elec" +
@@ -202,10 +205,10 @@
             // 
             this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(11, 264);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonResetZoom.Location = new System.Drawing.Point(15, 325);
+            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(183, 36);
+            this.buttonResetZoom.Size = new System.Drawing.Size(243, 44);
             this.buttonResetZoom.TabIndex = 4;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.");
@@ -215,10 +218,10 @@
             // buttonChooseCalibrationFile
             // 
             this.buttonChooseCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(166, 24);
-            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(220, 30);
+            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseCalibrationFile.Name = "buttonChooseCalibrationFile";
-            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(37, 25);
             this.buttonChooseCalibrationFile.TabIndex = 34;
             this.buttonChooseCalibrationFile.Text = "...";
             this.toolTip.SetToolTip(this.buttonChooseCalibrationFile, "Browse for a gain calibration file.");
@@ -230,10 +233,10 @@
             this.panelProbe.AutoSize = true;
             this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(2, 2);
-            this.panelProbe.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelProbe.Location = new System.Drawing.Point(3, 2);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(621, 443);
+            this.panelProbe.Size = new System.Drawing.Size(828, 557);
             this.panelProbe.TabIndex = 1;
             // 
             // panelTrackBar
@@ -242,9 +245,10 @@
             this.panelTrackBar.Controls.Add(label6);
             this.panelTrackBar.Controls.Add(label7);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(581, -5);
+            this.panelTrackBar.Location = new System.Drawing.Point(775, 0);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(37, 454);
+            this.panelTrackBar.Size = new System.Drawing.Size(49, 559);
             this.panelTrackBar.TabIndex = 30;
             // 
             // trackBarProbePosition
@@ -252,12 +256,12 @@
             this.trackBarProbePosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBarProbePosition.AutoSize = false;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(-6, 9);
-            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(-8, 11);
+            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(37, 435);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(49, 535);
             this.trackBarProbePosition.TabIndex = 22;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
@@ -284,21 +288,32 @@
             this.panelChannelOptions.Controls.Add(this.buttonClearSelections);
             this.panelChannelOptions.Controls.Add(this.buttonResetZoom);
             this.panelChannelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelChannelOptions.Location = new System.Drawing.Point(627, 2);
-            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelChannelOptions.Location = new System.Drawing.Point(837, 2);
+            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelChannelOptions.Name = "panelChannelOptions";
-            this.panelChannelOptions.Size = new System.Drawing.Size(205, 443);
+            this.panelChannelOptions.Size = new System.Drawing.Size(272, 557);
             this.panelChannelOptions.TabIndex = 1;
+            // 
+            // checkBoxInvertPolarity
+            // 
+            this.checkBoxInvertPolarity.AutoSize = true;
+            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(107, 193);
+            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
+            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(77, 20);
+            this.checkBoxInvertPolarity.TabIndex = 45;
+            this.checkBoxInvertPolarity.Text = "Enabled";
+            this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
             // 
             // textBoxGainCorrection
             // 
             this.textBoxGainCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxGainCorrection.Location = new System.Drawing.Point(80, 55);
-            this.textBoxGainCorrection.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxGainCorrection.Location = new System.Drawing.Point(107, 68);
+            this.textBoxGainCorrection.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxGainCorrection.Name = "textBoxGainCorrection";
             this.textBoxGainCorrection.ReadOnly = true;
-            this.textBoxGainCorrection.Size = new System.Drawing.Size(115, 20);
+            this.textBoxGainCorrection.Size = new System.Drawing.Size(151, 22);
             this.textBoxGainCorrection.TabIndex = 36;
             this.textBoxGainCorrection.TabStop = false;
             // 
@@ -306,10 +321,10 @@
             // 
             this.textBoxProbeCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(11, 24);
-            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(15, 30);
+            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxProbeCalibrationFile.Name = "textBoxProbeCalibrationFile";
-            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(150, 20);
+            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(198, 22);
             this.textBoxProbeCalibrationFile.TabIndex = 33;
             this.textBoxProbeCalibrationFile.TextChanged += new System.EventHandler(this.FileTextChanged);
             // 
@@ -319,10 +334,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxReference.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxReference.FormattingEnabled = true;
-            this.comboBoxReference.Location = new System.Drawing.Point(80, 89);
-            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.comboBoxReference.Location = new System.Drawing.Point(107, 110);
+            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
-            this.comboBoxReference.Size = new System.Drawing.Size(115, 21);
+            this.comboBoxReference.Size = new System.Drawing.Size(151, 24);
             this.comboBoxReference.TabIndex = 31;
             // 
             // comboBoxChannelPresets
@@ -331,10 +346,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxChannelPresets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxChannelPresets.FormattingEnabled = true;
-            this.comboBoxChannelPresets.Location = new System.Drawing.Point(80, 122);
-            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.comboBoxChannelPresets.Location = new System.Drawing.Point(107, 150);
+            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
-            this.comboBoxChannelPresets.Size = new System.Drawing.Size(115, 21);
+            this.comboBoxChannelPresets.Size = new System.Drawing.Size(151, 24);
             this.comboBoxChannelPresets.TabIndex = 24;
             // 
             // buttonCancel
@@ -342,10 +357,10 @@
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(743, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(990, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 28);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -355,10 +370,10 @@
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonOkay.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOkay.Location = new System.Drawing.Point(656, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonOkay.Location = new System.Drawing.Point(873, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 28);
+            this.buttonOkay.Size = new System.Drawing.Size(111, 34);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
@@ -375,12 +390,13 @@
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 16F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(834, 484);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 46F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1112, 607);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -390,9 +406,10 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 450);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 565);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(828, 31);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1104, 38);
             this.flowLayoutPanel1.TabIndex = 2;
             // 
             // statusStrip1
@@ -401,10 +418,10 @@
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabelGainCalibrationSN,
             this.toolStripGainCalSN});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 508);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 631);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 10, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(834, 25);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 13, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1112, 25);
             this.statusStrip1.TabIndex = 3;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -415,42 +432,22 @@
             this.toolStripGainCalSN.Text = "No file selected.";
             this.toolStripGainCalSN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // checkBoxInvertPolarity
-            // 
-            this.checkBoxInvertPolarity.AutoSize = true;
-            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(80, 157);
-            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(2);
-            this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
-            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(65, 17);
-            this.checkBoxInvertPolarity.TabIndex = 45;
-            this.checkBoxInvertPolarity.Text = "Enabled";
-            this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
-            // 
-            // invertPolarity
-            // 
-            invertPolarity.AutoSize = true;
-            invertPolarity.Location = new System.Drawing.Point(11, 152);
-            invertPolarity.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            invertPolarity.Name = "invertPolarity";
-            invertPolarity.Size = new System.Drawing.Size(44, 26);
-            invertPolarity.TabIndex = 44;
-            invertPolarity.Text = "Invert\r\nPolarity:";
-            // 
             // NeuropixelsV2eProbeConfigurationDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(834, 533);
+            this.ClientSize = new System.Drawing.Size(1112, 656);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.menuStrip);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip;
-            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV2eProbeConfigurationDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Probe Configuration";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.NeuropixelsV2eProbeConfigurationDialog_FormClosing);
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
             this.panelProbe.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -81,6 +81,8 @@ namespace OpenEphys.Onix1.Design
                 Parent = this
             };
 
+            ProbeConfiguration.ProbeInterfaceFile = ChannelConfiguration.ProbeInterfaceFile;
+
             InvertPolarity = invertPolarity;
 
             panelProbe.Controls.Add(ChannelConfiguration);
@@ -167,184 +169,184 @@ namespace OpenEphys.Onix1.Design
 
         private void SetChannelPreset(ChannelPreset preset)
         {
-            var probeConfiguration = ChannelConfiguration.ProbeConfiguration;
-            var electrodes = NeuropixelsV2eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup);
+            var probeGroup = (NeuropixelsV2eProbeGroup)ChannelConfiguration.ProbeGroup;
+            var electrodes = probeGroup.ToElectrodes();
 
             switch (preset)
             {
                 case ChannelPreset.Shank0BankA:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
-                                                                              e.Shank == 0).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
+                                                                      e.Shank == 0).ToArray());
                     break;
 
                 case ChannelPreset.Shank0BankB:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
-                                                                              e.Shank == 0).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
+                                                                      e.Shank == 0).ToArray());
                     break;
 
                 case ChannelPreset.Shank0BankC:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
-                                                                              e.Shank == 0).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
+                                                                      e.Shank == 0).ToArray());
                     break;
 
                 case ChannelPreset.Shank0BankD:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
-                                                                              (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
-                                                                               e.Shank == 0).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
+                                                                      (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
+                                                                       e.Shank == 0).ToArray());
                     break;
 
                 case ChannelPreset.Shank1BankA:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
-                                                                              e.Shank == 1).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
+                                                                      e.Shank == 1).ToArray());
                     break;
 
                 case ChannelPreset.Shank1BankB:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
                                                                       e.Shank == 1).ToArray());
                     break;
 
                 case ChannelPreset.Shank1BankC:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
-                                                                              e.Shank == 1).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
+                                                                      e.Shank == 1).ToArray());
                     break;
 
                 case ChannelPreset.Shank1BankD:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
-                                                                              (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
-                                                                               e.Shank == 1).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
+                                                                      (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
+                                                                       e.Shank == 1).ToArray());
                     break;
 
                 case ChannelPreset.Shank2BankA:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
-                                                                              e.Shank == 2).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
+                                                                      e.Shank == 2).ToArray());
                     break;
 
                 case ChannelPreset.Shank2BankB:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
-                                                                              e.Shank == 2).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
+                                                                      e.Shank == 2).ToArray());
                     break;
 
                 case ChannelPreset.Shank2BankC:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
-                                                                              e.Shank == 2).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
+                                                                      e.Shank == 2).ToArray());
                     break;
 
                 case ChannelPreset.Shank2BankD:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
-                                                                              (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
-                                                                               e.Shank == 2).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
+                                                                       (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
+                                                                        e.Shank == 2).ToArray());
                     break;
 
                 case ChannelPreset.Shank3BankA:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
-                                                                              e.Shank == 3).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
+                                                                      e.Shank == 3).ToArray());
                     break;
 
                 case ChannelPreset.Shank3BankB:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
-                                                                              e.Shank == 3).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.B &&
+                                                                      e.Shank == 3).ToArray());
                     break;
 
                 case ChannelPreset.Shank3BankC:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
-                                                                              e.Shank == 3).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => e.Bank == NeuropixelsV2QuadShankBank.C &&
+                                                                      e.Shank == 3).ToArray());
                     break;
 
                 case ChannelPreset.Shank3BankD:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
-                                                                              (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
-                                                                               e.Shank == 3).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Bank == NeuropixelsV2QuadShankBank.D ||
+                                                                       (e.Bank == NeuropixelsV2QuadShankBank.C && e.Index >= 896)) &&
+                                                                        e.Shank == 3).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks0_95:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 0 && e.IntraShankElectrodeIndex <= 95)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks96_191:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 96 && e.IntraShankElectrodeIndex <= 191)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks192_287:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 192 && e.IntraShankElectrodeIndex <= 287)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks288_383:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 288 && e.IntraShankElectrodeIndex <= 383)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks384_479:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 384 && e.IntraShankElectrodeIndex <= 479)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks480_575:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 480 && e.IntraShankElectrodeIndex <= 575)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks576_671:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 576 && e.IntraShankElectrodeIndex <= 671)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks672_767:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 672 && e.IntraShankElectrodeIndex <= 767)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks768_863:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 768 && e.IntraShankElectrodeIndex <= 863)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks864_959:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 864 && e.IntraShankElectrodeIndex <= 959)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks960_1055:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 960 && e.IntraShankElectrodeIndex <= 1055)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks1056_1151:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 1056 && e.IntraShankElectrodeIndex <= 1151)).ToArray());
                     break;
 
                 case ChannelPreset.AllShanks1152_1247:
-                    probeConfiguration.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247) ||
-                                                                              (e.Shank == 1 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247) ||
-                                                                              (e.Shank == 2 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247) ||
-                                                                              (e.Shank == 3 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247)).ToArray());
+                    probeGroup.SelectElectrodes(electrodes.Where(e => (e.Shank == 0 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247) ||
+                                                                       (e.Shank == 1 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247) ||
+                                                                       (e.Shank == 2 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247) ||
+                                                                       (e.Shank == 3 && e.IntraShankElectrodeIndex >= 1152 && e.IntraShankElectrodeIndex <= 1247)).ToArray());
                     break;
             }
 
@@ -356,7 +358,7 @@ namespace OpenEphys.Onix1.Design
 
         private void CheckForExistingChannelPreset()
         {
-            var channelMap = ChannelConfiguration.ProbeConfiguration.ChannelMap;
+            var channelMap = ((NeuropixelsV2eProbeGroup)ChannelConfiguration.ProbeGroup).ToChannelMap();
 
             if (channelMap.All(e => e.Bank == NeuropixelsV2QuadShankBank.A &&
                                     e.Shank == 0))
@@ -622,9 +624,9 @@ namespace OpenEphys.Onix1.Design
 
         private void EnableSelectedContacts()
         {
-            var selected = NeuropixelsV2eProbeGroup.ToElectrodes(ChannelConfiguration.ProbeConfiguration.ProbeGroup)
-                                                   .Where((e, ind) => ChannelConfiguration.SelectedContacts[ind])
-                                                   .ToArray();
+            var selected = ((NeuropixelsV2eProbeGroup)ChannelConfiguration.ProbeGroup).ToElectrodes()
+                                                                                      .Where((e, ind) => ChannelConfiguration.SelectedContacts[ind])
+                                                                                      .ToArray();
 
             ChannelConfiguration.EnableElectrodes(selected);
 
@@ -662,6 +664,16 @@ namespace OpenEphys.Onix1.Design
         private void UpdateTrackBarLocation(object sender, EventArgs e)
         {
             trackBarProbePosition.Value = (int)(ChannelConfiguration.GetRelativeVerticalPosition() * trackBarProbePosition.Maximum);
+        }
+
+        internal NeuropixelsV2eProbeGroup GetProbeGroup()
+        {
+            return (NeuropixelsV2eProbeGroup)ChannelConfiguration.ProbeGroup;
+        }
+
+        private void NeuropixelsV2eProbeConfigurationDialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            ChannelConfigurationDialog.TryRemoveEmptyFile(ChannelConfiguration.ProbeInterfaceFile);
         }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.resx
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.resx
@@ -135,14 +135,14 @@
   <metadata name="label1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
+  <metadata name="invertPolarity.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>274, 17</value>
-  </metadata>
-  <metadata name="invertPolarity.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
   </metadata>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>382, 17</value>

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationEditor.cs
@@ -45,10 +45,14 @@ namespace OpenEphys.Onix1.Design
                         if (configuration.Probe == NeuropixelsV2Probe.ProbeA)
                         {
                             instance.GainCalibrationFileA = editorDialog.textBoxProbeCalibrationFile.Text;
+                            instance.ProbeConfigurationA.ProbeInterfaceFile = editorDialog.ProbeConfiguration.ProbeInterfaceFile;
+                            ProbeGroupHelper.SaveExternalProbeConfigurationFile(editorDialog.GetProbeGroup(), instance.ProbeConfigurationA.ProbeInterfaceFile);
                         }
                         else
                         {
                             instance.GainCalibrationFileB = editorDialog.textBoxProbeCalibrationFile.Text;
+                            instance.ProbeConfigurationB.ProbeInterfaceFile = editorDialog.ProbeConfiguration.ProbeInterfaceFile;
+                            ProbeGroupHelper.SaveExternalProbeConfigurationFile(editorDialog.GetProbeGroup(), instance.ProbeConfigurationB.ProbeInterfaceFile);
                         }
 
                         instance.InvertPolarity = editorDialog.InvertPolarity;

--- a/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
@@ -18,12 +18,10 @@ namespace OpenEphys.Onix1.Design
         /// <summary>
         /// Initializes a new instance of <see cref="Rhs2116ChannelConfigurationDialog"/>.
         /// </summary>
-        /// <param name="probeGroup">Channel configuration settings for a <see cref="Rhs2116ProbeGroup"/>.</param>
-        public Rhs2116ChannelConfigurationDialog(Rhs2116ProbeGroup probeGroup)
-            : base(probeGroup)
+        public Rhs2116ChannelConfigurationDialog(string probeInterfaceFile)
+            : base(probeInterfaceFile)
         {
             InitializeComponent();
-            ProbeGroup = probeGroup;
 
             zedGraphChannels.ZoomButtons = MouseButtons.None;
             zedGraphChannels.ZoomButtons2 = MouseButtons.None;
@@ -39,6 +37,19 @@ namespace OpenEphys.Onix1.Design
         internal override ProbeGroup DefaultChannelLayout()
         {
             return new Rhs2116ProbeGroup();
+        }
+
+        internal override void LoadExternalProbeInterfaceFile()
+        {
+            var probeGroup = ProbeGroupHelper.LoadExternalProbeConfigurationFile<Rhs2116ProbeGroup>(ProbeInterfaceFile);
+
+            if (probeGroup.NumberOfContacts != ProbeGroup.NumberOfContacts)
+                throw new InvalidOperationException("The Probe Interface file has the wrong number of contacts. " +
+                    $"Expected {ProbeGroup.NumberOfContacts} to exist, but there were {probeGroup.NumberOfContacts} found. " +
+                    $"\n\nDouble check that the correct filepath is given for this device. " +
+                    $"\nFilepath: {ProbeInterfaceFile}");
+
+            ProbeGroup = probeGroup;
         }
 
         internal override bool OpenFile<T>()

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.Designer.cs
@@ -38,11 +38,13 @@
             this.panelParameters = new System.Windows.Forms.Panel();
             this.textBoxStepSize = new System.Windows.Forms.TextBox();
             this.groupBoxCathode = new System.Windows.Forms.GroupBox();
+            this.textboxAmplitudeCathodic = new System.Windows.Forms.TextBox();
             this.labelAmplitudeCathodic = new System.Windows.Forms.Label();
             this.labelPulseWidthCathodic = new System.Windows.Forms.Label();
             this.textboxPulseWidthCathodic = new System.Windows.Forms.TextBox();
             this.textboxAmplitudeCathodicRequested = new System.Windows.Forms.TextBox();
             this.groupBoxAnode = new System.Windows.Forms.GroupBox();
+            this.textboxAmplitudeAnodic = new System.Windows.Forms.TextBox();
             this.labelAmplitudeAnodic = new System.Windows.Forms.Label();
             this.labelPulseWidthAnodic = new System.Windows.Forms.Label();
             this.textboxPulseWidthAnodic = new System.Windows.Forms.TextBox();
@@ -76,8 +78,6 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.textboxAmplitudeAnodic = new System.Windows.Forms.TextBox();
-            this.textboxAmplitudeCathodic = new System.Windows.Forms.TextBox();
             this.statusStrip.SuspendLayout();
             this.panelParameters.SuspendLayout();
             this.groupBoxCathode.SuspendLayout();
@@ -126,14 +126,14 @@
             this.toolStripStatusIsValid.Image = global::OpenEphys.Onix1.Design.Properties.Resources.StatusReadyImage;
             this.toolStripStatusIsValid.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.toolStripStatusIsValid.Name = "toolStripStatusIsValid";
-            this.toolStripStatusIsValid.Size = new System.Drawing.Size(186, 20);
+            this.toolStripStatusIsValid.Size = new System.Drawing.Size(153, 21);
             this.toolStripStatusIsValid.Text = "Valid stimulus sequence";
             this.toolStripStatusIsValid.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // toolStripStatusSlotsUsed
             // 
             this.toolStripStatusSlotsUsed.Name = "toolStripStatusSlotsUsed";
-            this.toolStripStatusSlotsUsed.Size = new System.Drawing.Size(132, 20);
+            this.toolStripStatusSlotsUsed.Size = new System.Drawing.Size(104, 21);
             this.toolStripStatusSlotsUsed.Text = "100% of slots used";
             this.toolStripStatusSlotsUsed.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -204,6 +204,15 @@
             this.groupBoxCathode.Text = "Cathode";
             this.groupBoxCathode.Visible = false;
             // 
+            // textboxAmplitudeCathodic
+            // 
+            this.textboxAmplitudeCathodic.Location = new System.Drawing.Point(132, 39);
+            this.textboxAmplitudeCathodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.textboxAmplitudeCathodic.Name = "textboxAmplitudeCathodic";
+            this.textboxAmplitudeCathodic.ReadOnly = true;
+            this.textboxAmplitudeCathodic.Size = new System.Drawing.Size(55, 22);
+            this.textboxAmplitudeCathodic.TabIndex = 9;
+            // 
             // labelAmplitudeCathodic
             // 
             this.labelAmplitudeCathodic.AutoSize = true;
@@ -256,6 +265,15 @@
             this.groupBoxAnode.TabIndex = 2;
             this.groupBoxAnode.TabStop = false;
             this.groupBoxAnode.Text = "Anode";
+            // 
+            // textboxAmplitudeAnodic
+            // 
+            this.textboxAmplitudeAnodic.Location = new System.Drawing.Point(129, 39);
+            this.textboxAmplitudeAnodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.textboxAmplitudeAnodic.Name = "textboxAmplitudeAnodic";
+            this.textboxAmplitudeAnodic.ReadOnly = true;
+            this.textboxAmplitudeAnodic.Size = new System.Drawing.Size(55, 22);
+            this.textboxAmplitudeAnodic.TabIndex = 8;
             // 
             // labelAmplitudeAnodic
             // 
@@ -362,7 +380,7 @@
             this.checkBoxAnodicFirst.Location = new System.Drawing.Point(91, 33);
             this.checkBoxAnodicFirst.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxAnodicFirst.Name = "checkBoxAnodicFirst";
-            this.checkBoxAnodicFirst.Size = new System.Drawing.Size(99, 20);
+            this.checkBoxAnodicFirst.Size = new System.Drawing.Size(96, 20);
             this.checkBoxAnodicFirst.TabIndex = 16;
             this.checkBoxAnodicFirst.TabStop = false;
             this.checkBoxAnodicFirst.Text = "Anodic First";
@@ -428,7 +446,7 @@
             this.checkboxBiphasicSymmetrical.Location = new System.Drawing.Point(43, 14);
             this.checkboxBiphasicSymmetrical.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkboxBiphasicSymmetrical.Name = "checkboxBiphasicSymmetrical";
-            this.checkboxBiphasicSymmetrical.Size = new System.Drawing.Size(147, 20);
+            this.checkboxBiphasicSymmetrical.Size = new System.Drawing.Size(144, 20);
             this.checkboxBiphasicSymmetrical.TabIndex = 5;
             this.checkboxBiphasicSymmetrical.TabStop = false;
             this.checkboxBiphasicSymmetrical.Text = "Biphasic Symmetric";
@@ -464,7 +482,7 @@
             this.tabControlVisualization.Name = "tabControlVisualization";
             this.tableLayoutPanel1.SetRowSpan(this.tabControlVisualization, 2);
             this.tabControlVisualization.SelectedIndex = 0;
-            this.tabControlVisualization.Size = new System.Drawing.Size(1090, 675);
+            this.tabControlVisualization.Size = new System.Drawing.Size(1090, 679);
             this.tabControlVisualization.TabIndex = 6;
             // 
             // tabPageWaveform
@@ -474,7 +492,7 @@
             this.tabPageWaveform.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageWaveform.Name = "tabPageWaveform";
             this.tabPageWaveform.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageWaveform.Size = new System.Drawing.Size(1082, 646);
+            this.tabPageWaveform.Size = new System.Drawing.Size(1082, 650);
             this.tabPageWaveform.TabIndex = 0;
             this.tabPageWaveform.Text = "Stimulus Waveform";
             this.tabPageWaveform.UseVisualStyleBackColor = true;
@@ -492,7 +510,7 @@
             this.zedGraphWaveform.ScrollMinX = 0D;
             this.zedGraphWaveform.ScrollMinY = 0D;
             this.zedGraphWaveform.ScrollMinY2 = 0D;
-            this.zedGraphWaveform.Size = new System.Drawing.Size(1076, 642);
+            this.zedGraphWaveform.Size = new System.Drawing.Size(1076, 646);
             this.zedGraphWaveform.TabIndex = 4;
             this.zedGraphWaveform.UseExtendedPrintDialog = true;
             // 
@@ -503,7 +521,7 @@
             this.tabPageTable.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageTable.Name = "tabPageTable";
             this.tabPageTable.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageTable.Size = new System.Drawing.Size(1082, 644);
+            this.tabPageTable.Size = new System.Drawing.Size(1082, 646);
             this.tabPageTable.TabIndex = 1;
             this.tabPageTable.Text = "Table";
             this.tabPageTable.UseVisualStyleBackColor = true;
@@ -521,7 +539,7 @@
             this.dataGridViewStimulusTable.Name = "dataGridViewStimulusTable";
             this.dataGridViewStimulusTable.RowHeadersWidth = 62;
             this.dataGridViewStimulusTable.RowTemplate.Height = 28;
-            this.dataGridViewStimulusTable.Size = new System.Drawing.Size(1076, 640);
+            this.dataGridViewStimulusTable.Size = new System.Drawing.Size(1076, 642);
             this.dataGridViewStimulusTable.TabIndex = 0;
             this.dataGridViewStimulusTable.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.DataGridViewStimulusTable_CellEndEdit);
             this.dataGridViewStimulusTable.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.DataGridViewStimulusTable_DataBindingComplete);
@@ -533,7 +551,7 @@
             this.panelProbe.Location = new System.Drawing.Point(1099, 2);
             this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(445, 367);
+            this.panelProbe.Size = new System.Drawing.Size(445, 371);
             this.panelProbe.TabIndex = 0;
             // 
             // menuStrip
@@ -544,7 +562,7 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 2, 0, 2);
-            this.menuStrip.Size = new System.Drawing.Size(1547, 28);
+            this.menuStrip.Size = new System.Drawing.Size(1547, 24);
             this.menuStrip.TabIndex = 7;
             this.menuStrip.Text = "menuStrip1";
             // 
@@ -553,7 +571,7 @@
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.stimulusWaveformToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // stimulusWaveformToolStripMenuItem
@@ -562,20 +580,20 @@
             this.openFileToolStripMenuItem,
             this.saveFileToolStripMenuItem});
             this.stimulusWaveformToolStripMenuItem.Name = "stimulusWaveformToolStripMenuItem";
-            this.stimulusWaveformToolStripMenuItem.Size = new System.Drawing.Size(220, 26);
+            this.stimulusWaveformToolStripMenuItem.Size = new System.Drawing.Size(178, 22);
             this.stimulusWaveformToolStripMenuItem.Text = "Stimulus Waveform";
             // 
             // openFileToolStripMenuItem
             // 
             this.openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
-            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(155, 26);
+            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(124, 22);
             this.openFileToolStripMenuItem.Text = "Open File";
             this.openFileToolStripMenuItem.Click += new System.EventHandler(this.MenuItemLoadFile_Click);
             // 
             // saveFileToolStripMenuItem
             // 
             this.saveFileToolStripMenuItem.Name = "saveFileToolStripMenuItem";
-            this.saveFileToolStripMenuItem.Size = new System.Drawing.Size(155, 26);
+            this.saveFileToolStripMenuItem.Size = new System.Drawing.Size(124, 22);
             this.saveFileToolStripMenuItem.Text = "Save File";
             this.saveFileToolStripMenuItem.Click += new System.EventHandler(this.MenuItemSaveFile_Click);
             // 
@@ -589,21 +607,21 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControlVisualization, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 28);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 308F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1547, 721);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1547, 725);
             this.tableLayoutPanel1.TabIndex = 8;
             // 
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.panelParameters);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Location = new System.Drawing.Point(1099, 373);
+            this.groupBox1.Location = new System.Drawing.Point(1099, 377);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
@@ -619,29 +637,11 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOk);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 681);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 685);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1541, 38);
             this.flowLayoutPanel1.TabIndex = 7;
-            // 
-            // textboxAmplitudeAnodic
-            // 
-            this.textboxAmplitudeAnodic.Location = new System.Drawing.Point(129, 39);
-            this.textboxAmplitudeAnodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.textboxAmplitudeAnodic.Name = "textboxAmplitudeAnodic";
-            this.textboxAmplitudeAnodic.ReadOnly = true;
-            this.textboxAmplitudeAnodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeAnodic.TabIndex = 8;
-            // 
-            // textboxAmplitudeCathodic
-            // 
-            this.textboxAmplitudeCathodic.Location = new System.Drawing.Point(132, 39);
-            this.textboxAmplitudeCathodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.textboxAmplitudeCathodic.Name = "textboxAmplitudeCathodic";
-            this.textboxAmplitudeCathodic.ReadOnly = true;
-            this.textboxAmplitudeCathodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeCathodic.TabIndex = 9;
             // 
             // Rhs2116StimulusSequenceDialog
             // 
@@ -660,6 +660,7 @@
             this.Name = "Rhs2116StimulusSequenceDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Rhs2116StimulusSequenceDialog";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Rhs2116StimulusSequenceDialog_FormClosing);
             this.statusStrip.ResumeLayout(false);
             this.statusStrip.PerformLayout();
             this.panelParameters.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -29,11 +29,24 @@ namespace OpenEphys.Onix1.Design
         internal readonly Rhs2116ChannelConfigurationDialog ChannelDialog;
 
         /// <summary>
-        /// Opens a dialog allowing for easy changing of stimulus sequence parameters, with visual feedback on what the resulting stimulus sequence looks like.
+        /// Opens a dialog allowing for easy changing of stimulus sequence parameters, 
+        /// with visual feedback on what the resulting stimulus sequence looks like.
         /// </summary>
         /// <param name="sequence"></param>
         /// <param name="probeGroup"></param>
+        [Obsolete("This constructor is now deprecated, as Probe Groups are now held in externalized files.")]
         public Rhs2116StimulusSequenceDialog(Rhs2116StimulusSequencePair sequence, Rhs2116ProbeGroup probeGroup)
+            : this(sequence, "")
+        {
+        }
+
+        /// <summary>
+        /// Opens a dialog allowing for easy changing of stimulus sequence parameters, 
+        /// with visual feedback on what the resulting stimulus sequence looks like.
+        /// </summary>
+        /// <param name="sequence">Stimulus sequence object containing all stimulation parameters.</param>
+        /// <param name="probeInterfaceFile">Filepath to the location where the Probe Interface file is saved.</param>
+        public Rhs2116StimulusSequenceDialog(Rhs2116StimulusSequencePair sequence, string probeInterfaceFile)
         {
             InitializeComponent();
             Shown += FormShown;
@@ -50,7 +63,7 @@ namespace OpenEphys.Onix1.Design
 
             StepSize = Sequence.CurrentStepSize;
 
-            ChannelDialog = new(probeGroup)
+            ChannelDialog = new(probeInterfaceFile)
             {
                 TopLevel = false,
                 FormBorderStyle = FormBorderStyle.None,
@@ -67,11 +80,6 @@ namespace OpenEphys.Onix1.Design
             ChannelDialog.Show();
 
             textBoxStepSize.Text = GetStepSizeStringuA(StepSize);
-
-            if (probeGroup.NumberOfContacts != 32)
-            {
-                throw new ArgumentException($"Probe group is not valid: 32 channels were expected, there are {probeGroup.NumberOfContacts} instead.");
-            }
 
             InitializeZedGraphWaveform();
             DrawStimulusWaveform();
@@ -1062,7 +1070,7 @@ namespace OpenEphys.Onix1.Design
             {
                 StepSize = validStepSizes.First();
                 textBoxStepSize.Text = GetStepSizeStringuA(StepSize);
-                
+
                 return true;
             }
 
@@ -1308,6 +1316,11 @@ namespace OpenEphys.Onix1.Design
                     }
                 }
             }
+        }
+
+        private void Rhs2116StimulusSequenceDialog_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            ChannelConfigurationDialog.TryRemoveEmptyFile(ChannelDialog.ProbeInterfaceFile);
         }
     }
 }

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceEditor.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceEditor.cs
@@ -18,12 +18,14 @@ namespace OpenEphys.Onix1.Design
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
                 if (editorState != null && !editorState.WorkflowRunning && component is ConfigureRhs2116Trigger configureNode)
                 {
-                    using var editorDialog = new Rhs2116StimulusSequenceDialog(configureNode.StimulusSequence, configureNode.ProbeGroup);
+                    using var editorDialog = new Rhs2116StimulusSequenceDialog(configureNode.StimulusSequence, configureNode.ProbeInterfaceFile);
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
                         configureNode.StimulusSequence = editorDialog.Sequence;
-                        configureNode.ProbeGroup = (Rhs2116ProbeGroup)editorDialog.ChannelDialog.ProbeGroup;
+                        configureNode.ProbeInterfaceFile = editorDialog.ChannelDialog.ProbeInterfaceFile;
+
+                        ProbeGroupHelper.SaveExternalProbeConfigurationFile(editorDialog.ChannelDialog.ProbeGroup, configureNode.ProbeInterfaceFile);
 
                         return true;
                     }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -128,7 +128,8 @@ namespace OpenEphys.Onix1
         /// Gets or sets the NeuropixelsV1 probe configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [Description("Neuropixels 1.0e probe configuration")]
+        [Description("Neuropixels 1.0 probe configuration")]
+        [TypeConverter(typeof(GenericPropertyConverter))]
         public NeuropixelsV1ProbeConfiguration ProbeConfiguration { get; set; } = new();
 
         /// <summary>
@@ -154,7 +155,7 @@ namespace OpenEphys.Onix1
             {
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
-                device.WriteRegister(DS90UB9x.ENABLE, enable ? 1u : 0);
+                device.WriteRegister(DS90UB9x.ENABLE, enable ? 1u : 0u);
 
                 // configure deserializer aliases and serializer power supply
                 ConfigureDeserializer(device);

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
@@ -83,7 +83,8 @@ namespace OpenEphys.Onix1
         /// Gets or sets the NeuropixelsV1 probe configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [Description("Neuropixels 1.0e probe configuration.")]
+        [Description("Neuropixels 1.0 probe configuration.")]
+        [TypeConverter(typeof(GenericPropertyConverter))]
         public NeuropixelsV1ProbeConfiguration ProbeConfiguration { get; set; } = new();
 
         /// <summary>
@@ -156,7 +157,7 @@ namespace OpenEphys.Onix1
             return source.ConfigureDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, typeof(NeuropixelsV1f));
-                device.WriteRegister(NeuropixelsV1f.ENABLE, enable ? 1u : 0);
+                device.WriteRegister(NeuropixelsV1f.ENABLE, enable ? 1u : 0u);
 
                 if (enable)
                 {

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -74,6 +74,7 @@ namespace OpenEphys.Onix1
         [Category(ConfigurationCategory)]
         [Description("Probe A electrode configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(GenericPropertyConverter))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; } = new(NeuropixelsV2Probe.ProbeA);
 
         /// <inheritdoc/>
@@ -105,6 +106,7 @@ namespace OpenEphys.Onix1
         [Category(ConfigurationCategory)]
         [Description("Probe B electrode configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(GenericPropertyConverter))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; } = new(NeuropixelsV2Probe.ProbeB);
 
         /// <inheritdoc/>

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -89,6 +89,7 @@ namespace OpenEphys.Onix1
         [Category(ConfigurationCategory)]
         [Description("Probe A electrode configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(GenericPropertyConverter))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; } = new(NeuropixelsV2Probe.ProbeA);
 
         /// <inheritdoc/>
@@ -120,6 +121,7 @@ namespace OpenEphys.Onix1
         [Category(ConfigurationCategory)]
         [Description("Probe B electrode configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
+        [TypeConverter(typeof(GenericPropertyConverter))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; } = new(NeuropixelsV2Probe.ProbeB);
 
         /// <inheritdoc/>

--- a/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
@@ -66,7 +66,19 @@ namespace OpenEphys.Onix1
         [XmlIgnore]
         [Category(ConfigurationCategory)]
         [Description("Defines the channel configuration")]
-        public Rhs2116ProbeGroup ProbeGroup { get; set; } = new();
+        [Obsolete("Holding the class has been superseded by an externalized configuration file. Remove in 1.0.0.")]
+        [Browsable(false)]
+        [Externalizable(false)]
+        public Rhs2116ProbeGroup ProbeGroup { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file path to a configuration file holding the Probe Interface JSON specifications for this probe.
+        /// </summary>
+        [Category(DeviceFactory.ConfigurationCategory)]
+        [Description("File path to a configuration file holding the Probe Interface JSON specifications for this probe.")]
+        [FileNameFilter($"Probe Interface files ({ProbeGroupHelper.ProbeInterfaceFileString}*.json)|*.json")]
+        [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string ProbeInterfaceFile { get; set; }
 
         /// <summary>
         /// Gets or sets if trigger is armed.
@@ -81,30 +93,6 @@ namespace OpenEphys.Onix1
         {
             get => triggerArmed.Value;
             set => triggerArmed.OnNext(value);
-        }
-
-        /// <summary>
-        /// Gets or sets a string defining the <see cref="ProbeGroup"/> in Base64.
-        /// </summary>
-        /// <remarks>
-        /// This variable is needed to properly save a workflow in Bonsai, but it is not
-        /// directly accessible in the Bonsai editor.
-        /// </remarks>
-        [Browsable(false)]
-        [Externalizable(false)]
-        [XmlElement(nameof(ProbeGroup))]
-        public string ProbeGroupString
-        {
-            get
-            {
-                var jsonString = JsonConvert.SerializeObject(ProbeGroup);
-                return Convert.ToBase64String(Encoding.UTF8.GetBytes(jsonString));
-            }
-            set
-            {
-                var jsonString = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-                ProbeGroup = JsonConvert.DeserializeObject<Rhs2116ProbeGroup>(jsonString);
-            }
         }
 
         /// <summary>

--- a/OpenEphys.Onix1/GenericPropertyConverter.cs
+++ b/OpenEphys.Onix1/GenericPropertyConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Generic property converter that can expand all sub-properties of a given class.
+    /// </summary>
+    internal class GenericPropertyConverter : ExpandableObjectConverter
+    {
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        {
+            var properties = (from property in base.GetProperties(context, value, attributes).Cast<PropertyDescriptor>()
+                              where !property.IsReadOnly
+                              select property)
+                              .ToArray();
+            return new PropertyDescriptorCollection(properties).Sort(properties.Select(p => p.Name).ToArray());
+        }
+    }
+}

--- a/OpenEphys.Onix1/NeuropixelsV1.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.IO;
 
 namespace OpenEphys.Onix1
 {
@@ -33,6 +34,14 @@ namespace OpenEphys.Onix1
 
         internal static BitArray MakeShankBits(NeuropixelsV1ProbeConfiguration configuration)
         {
+            if (!File.Exists(configuration.ProbeInterfaceFile))
+                throw new FileNotFoundException("Must specify a valid Probe Interface file.");
+
+            var probeGroup = ProbeGroupHelper.LoadExternalProbeConfigurationFile<NeuropixelsV1eProbeGroup>(configuration.ProbeInterfaceFile);
+
+            if (probeGroup == null)
+                throw new ArgumentNullException(nameof(probeGroup));
+
             const int ShankConfigurationBitCount = 968;
             const int ShankBitExt1 = 965;
             const int ShankBitExt2 = 2;
@@ -42,7 +51,7 @@ namespace OpenEphys.Onix1
 
             var shankBits = new BitArray(ShankConfigurationBitCount);
 
-            foreach (var e in configuration.ChannelMap)
+            foreach (var e in probeGroup.ToChannelMap())
             {
                 if (e.Index == InternalReferenceChannel) continue;
 

--- a/OpenEphys.Onix1/NeuropixelsV1ProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1ProbeConfiguration.cs
@@ -107,7 +107,7 @@ namespace OpenEphys.Onix1
         /// The spike-band is from DC to 10 kHz if <see cref="SpikeFilter"/> is set to false, while the 
         /// spike-band is from 300 Hz to 10 kHz if <see cref="SpikeFilter"/> is set to true.
         /// </remarks>
-        [Category("Configuration")]
+        [Category(DeviceFactory.ConfigurationCategory)]
         [Description("Amplifier gain for spike-band.")]
         public NeuropixelsV1Gain SpikeAmplifierGain { get; set; } = NeuropixelsV1Gain.Gain1000;
 
@@ -117,7 +117,7 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// The LFP band is from 0.5 to 500 Hz.
         /// </remarks>
-        [Category("Configuration")]
+        [Category(DeviceFactory.ConfigurationCategory)]
         [Description("Amplifier gain for LFP-band.")]
         public NeuropixelsV1Gain LfpAmplifierGain { get; set; } = NeuropixelsV1Gain.Gain50;
 
@@ -130,7 +130,7 @@ namespace OpenEphys.Onix1
         /// Setting to <see cref="NeuropixelsV1ReferenceSource.External"/> will use the external reference, while 
         /// <see cref="NeuropixelsV1ReferenceSource.Tip"/> sets the reference to the electrode at the tip of the probe.
         /// </remarks>
-        [Category("Configuration")]
+        [Category(DeviceFactory.ConfigurationCategory)]
         [Description("Reference selection.")]
         public NeuropixelsV1ReferenceSource Reference { get; set; } = NeuropixelsV1ReferenceSource.External;
 
@@ -141,7 +141,7 @@ namespace OpenEphys.Onix1
         /// If set to true, the spike-band has a 300 Hz high-pass filter which will be activated. If set to
         /// false, the high-pass filter will not to be activated.
         /// </remarks>
-        [Category("Configuration")]
+        [Category(DeviceFactory.ConfigurationCategory)]
         [Description("If true, activates a 300 Hz high-pass filter in the spike-band data stream.")]
         public bool SpikeFilter { get; set; } = true;
 
@@ -179,7 +179,7 @@ namespace OpenEphys.Onix1
         /// Gets or sets the <see cref="NeuropixelsV1eProbeGroup"/> channel configuration for this probe.
         /// </summary>
         [XmlIgnore]
-        [Category("Configuration")]
+        [Category(DeviceFactory.ConfigurationCategory)]
         [Description("Defines all aspects of the probe group, including probe contours, electrode size and location, enabled channels, etc.")]
         public NeuropixelsV1eProbeGroup ProbeGroup { get; set; } = new();
 

--- a/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 namespace OpenEphys.Onix1
 {
+    // TODO: This class is supposed to be named `NeuropixelsV1ProbeGroup`. At the next major update, deprecate this class and change the name
     /// <summary>
     /// A <see cref="ProbeGroup"/> class for NeuropixelsV1e.
     /// </summary>
@@ -186,44 +187,6 @@ namespace OpenEphys.Onix1
             }
 
             UpdateDeviceChannelIndices(0, newDeviceChannelIndices);
-        }
-
-        /// <summary>
-        /// Convert a <see cref="NeuropixelsV1eProbeGroup"/> object to a list of electrodes, which only includes currently enabled electrodes
-        /// </summary>
-        /// <param name="probeGroup">A <see cref="NeuropixelsV1eProbeGroup"/> object</param>
-        /// <returns>List of <see cref="NeuropixelsV1Electrode"/>'s that are enabled</returns>
-        public static NeuropixelsV1Electrode[] ToChannelMap(NeuropixelsV1eProbeGroup probeGroup)
-        {
-            var enabledContacts = probeGroup.GetContacts().Where(c => c.DeviceId != -1);
-
-            if (enabledContacts.Count() != NeuropixelsV1.ChannelCount)
-            {
-                throw new InvalidOperationException($"Channel configuration must have {NeuropixelsV1.ChannelCount} contacts enabled." +
-                    $"Instead there are {enabledContacts.Count()} contacts enabled. Enabled contacts are designated by a device channel" +
-                    $"index >= 0.");
-            }
-
-            return enabledContacts.Select(c => new NeuropixelsV1Electrode(c.Index))
-                                  .OrderBy(e => e.Channel)
-                                  .ToArray();
-        }
-
-        /// <summary>
-        /// Convert a ProbeInterface object to a list of electrodes, which includes all possible electrodes.
-        /// </summary>
-        /// <param name="probeGroup">A <see cref="NeuropixelsV1eProbeGroup"/> object.</param>
-        /// <returns>List of <see cref="NeuropixelsV1Electrode"/> electrodes.</returns>
-        public static List<NeuropixelsV1Electrode> ToElectrodes(NeuropixelsV1eProbeGroup probeGroup)
-        {
-            List<NeuropixelsV1Electrode> electrodes = new();
-
-            foreach (var c in probeGroup.GetContacts())
-            {
-                electrodes.Add(new NeuropixelsV1Electrode(c.Index));
-            }
-
-            return electrodes;
         }
     }
 }

--- a/OpenEphys.Onix1/NeuropixelsV1fRegisterContext.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1fRegisterContext.cs
@@ -55,7 +55,6 @@ namespace OpenEphys.Onix1
             var gainCorrection = NeuropixelsV1Helper.TryParseGainCalibrationFile(gainCalibrationFile,
                 configuration.SpikeAmplifierGain, configuration.LfpAmplifierGain, NeuropixelsV1.ElectrodeCount);
 
-
             if (!gainCorrection.HasValue)
             {
                 throw new ArgumentException($"The calibration file \"{gainCalibrationFile}\" is invalid.");

--- a/OpenEphys.Onix1/NeuropixelsV2.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.IO;
 
 namespace OpenEphys.Onix1
 {
@@ -36,6 +37,14 @@ namespace OpenEphys.Onix1
 
         internal static BitArray[] GenerateShankBits(NeuropixelsV2QuadShankProbeConfiguration probe)
         {
+            if (!File.Exists(probe.ProbeInterfaceFile))
+                throw new FileNotFoundException("Must specify a valid Probe Interface file.");
+
+            var probeGroup = ProbeGroupHelper.LoadExternalProbeConfigurationFile<NeuropixelsV2eProbeGroup>(probe.ProbeInterfaceFile);
+
+            if (probeGroup == null)
+                throw new ArgumentNullException(nameof(probeGroup));
+
             BitArray[] shankBits =
             {
                 new(RegistersPerShank, false),
@@ -70,7 +79,7 @@ namespace OpenEphys.Onix1
 
             const int PixelOffset = (ElectrodePerShank - 1) / 2;
             const int ReferencePixelOffset = 3;
-            foreach (var c in probe.ChannelMap)
+            foreach (var c in probeGroup.ToChannelMap())
             {
                 var baseIndex = c.IntraShankElectrodeIndex % 2;
                 var pixelIndex = c.IntraShankElectrodeIndex / 2;

--- a/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
@@ -200,7 +200,7 @@ namespace OpenEphys.Onix1
         /// Gets the <see cref="NeuropixelsV2eProbeGroup"/> channel configuration for this probe.
         /// </summary>
         [XmlIgnore]
-        [Category("Configuration")]
+        [Category(DeviceFactory.ConfigurationCategory)]
         [Description("Defines the shape of the probe, and which contacts are currently selected for streaming")]
         public NeuropixelsV2eProbeGroup ProbeGroup { get; private set; } = new();
 

--- a/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
@@ -6,8 +6,9 @@ using OpenEphys.ProbeInterface.NET;
 
 namespace OpenEphys.Onix1
 {
+    // TODO: This should be named "NeuropixelsV2ProbeGroup". Rename in 1.0.0
     /// <summary>
-    /// A <see cref="ProbeGroup"/> class for NeuropixelsV2e.
+    /// A <see cref="ProbeGroup"/> class for NeuropixelsV2.
     /// </summary>
     public class NeuropixelsV2eProbeGroup : ProbeGroup
     {

--- a/OpenEphys.Onix1/ProbeGroupHelper.cs
+++ b/OpenEphys.Onix1/ProbeGroupHelper.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using OpenEphys.ProbeInterface.NET;
+using System.IO;
+using System.Linq;
+
+namespace OpenEphys.Onix1
+{
+    internal static class ProbeGroupHelper
+    {
+        public const string ProbeInterfaceFileString = "probe_interface";
+
+        /// <summary>
+        /// Given a string with a valid JSON structure, deserialize the string to the given type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="jsonString"></param>
+        /// <returns></returns>
+#nullable enable
+        public static T? DeserializeString<T>(string jsonString)
+        {
+            var errors = new List<string>();
+
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                Error = delegate (object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
+                {
+                    errors.Add(args.ErrorContext.Error.Message);
+                    args.ErrorContext.Handled = true;
+                }
+            };
+
+            var obj = JsonConvert.DeserializeObject<T>(jsonString, serializerSettings);
+
+            if (errors.Count > 0)
+            {
+                Console.WriteLine($"There were errors encountered while parsing a JSON string.\n\n");
+
+                foreach (var e in errors)
+                {
+                    Console.Error.WriteLine(e);
+                }
+
+                return default;
+            }
+
+            return obj;
+        }
+#nullable disable
+
+        public static void SerializeObject(object _object, string filepath)
+        {
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+            };
+
+            var stringJson = JsonConvert.SerializeObject(_object, Formatting.Indented, serializerSettings);
+
+            File.WriteAllText(filepath, stringJson);
+        }
+
+        public static T LoadExternalProbeConfigurationFile<T>(string probeConfigurationFile) where T : ProbeGroup
+        {
+            if (File.Exists(probeConfigurationFile))
+            {
+                return DeserializeString<T>(File.ReadAllText(probeConfigurationFile));
+            }
+            else
+            {
+                throw new NullReferenceException($"The Probe Interface file given for {typeof(T).Name} does not exist. Double check that the file exists and can be read. " +
+                    $"\n\nFilepath: '{probeConfigurationFile}'");
+            }
+        }
+
+        public static void SaveExternalProbeConfigurationFile(ProbeGroup probeGroup, string probeConfigurationFile)
+        {
+            SerializeObject(probeGroup, probeConfigurationFile);
+        }
+
+        public static string GenerateProbeConfigurationFilename()
+        {
+            const string extension = ".json";
+
+            string basename = Path.Combine(Directory.GetCurrentDirectory(), ProbeInterfaceFileString);
+            string filename = basename + extension;
+
+            int counter = 0;
+
+            while (File.Exists(filename))
+            {
+                filename = basename + $"_{++counter}" + extension;
+            }
+
+            return filename;
+        }
+
+        /// <summary>
+        /// Compares two file paths to determine if they are equal.
+        /// </summary>
+        /// <param name="path1">The first path.</param>
+        /// <param name="path2">The second path.</param>
+        /// <returns>
+        /// Returns true if the two paths are equal. Returns false if either string is null or empty, or if the
+        /// two paths are different in any way.</returns>
+        public static bool CompareFilePaths(string path1, string path2)
+        {
+            if (string.IsNullOrEmpty(path1) || string.IsNullOrEmpty(path2)) return false;
+
+            return Path.GetFullPath(path1) == Path.GetFullPath(path2);
+        }
+
+        #region Neuropixels 1.0
+
+        /// <summary>
+        /// Convert a <see cref="NeuropixelsV1eProbeGroup"/> object to a list of electrodes, which only includes currently enabled electrodes
+        /// </summary>
+        /// <param name="probeGroup">A <see cref="NeuropixelsV1eProbeGroup"/> object</param>
+        /// <returns>List of <see cref="NeuropixelsV1Electrode"/>'s that are enabled</returns>
+        public static NeuropixelsV1Electrode[] ToChannelMap(this NeuropixelsV1eProbeGroup probeGroup)
+        {
+            var enabledContacts = probeGroup.GetContacts().Where(c => c.DeviceId != -1);
+
+            if (enabledContacts.Count() != NeuropixelsV1.ChannelCount)
+            {
+                throw new InvalidOperationException($"Channel configuration must have {NeuropixelsV1.ChannelCount} contacts enabled." +
+                    $"Instead there are {enabledContacts.Count()} contacts enabled. Enabled contacts are designated by a device channel" +
+                    $"index >= 0.");
+            }
+
+            return enabledContacts.Select(c => new NeuropixelsV1Electrode(c.Index))
+                                  .OrderBy(e => e.Channel)
+                                  .ToArray();
+        }
+
+        public static void SelectElectrodes(this NeuropixelsV1eProbeGroup probeGroup, NeuropixelsV1Electrode[] electrodes)
+        {
+            var channelMap = probeGroup.ToChannelMap();
+
+            foreach (var e in electrodes)
+            {
+                try
+                {
+                    channelMap[e.Channel] = e;
+                }
+                catch (IndexOutOfRangeException ex)
+                {
+                    throw new IndexOutOfRangeException($"Electrode {e.Index} specifies channel {e.Channel} but only channels " +
+                        $"0 to {channelMap.Length - 1} are supported.", ex);
+                }
+            }
+
+            probeGroup.UpdateDeviceChannelIndices(channelMap);
+        }
+
+        /// <summary>
+        /// Convert a ProbeInterface object to a list of electrodes, which includes all possible electrodes.
+        /// </summary>
+        /// <param name="probeGroup">A <see cref="NeuropixelsV1eProbeGroup"/> object.</param>
+        /// <returns>List of <see cref="NeuropixelsV1Electrode"/> electrodes.</returns>
+        public static List<NeuropixelsV1Electrode> ToElectrodes(this NeuropixelsV1eProbeGroup probeGroup)
+        {
+            List<NeuropixelsV1Electrode> electrodes = new();
+
+            foreach (var c in probeGroup.GetContacts())
+            {
+                electrodes.Add(new NeuropixelsV1Electrode(c.Index));
+            }
+
+            return electrodes;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
All Probe Interface configuration files are now external, no longer are they saved within the .bonsai file causing them to bloat up. 

If the user does not choose a probe interface file, one will be automatically created at the same level as the .bonsai file. If the user cancels the GUI without saving the configuration, this file will be automatically deleted. If the user saves the data, this file will instead be populated with the configuration selected.

This applies to `Neuropixels 1.0e`, `Neuropixels 1.0f`, `Neuropixels 2.0e`, and `Rhs2116` headstages.

- Fixes #366 