### PR TITLE
Account for two tick delay in sample counter on DigitalIO device

### DIFF
--- a/OpenEphys.Onix1/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix1/ConfigureDigitalIO.cs
@@ -116,7 +116,7 @@ namespace OpenEphys.Onix1
 
                 if (sr is not null)
                 {
-                    var periodTicks = (uint)(baseFreqHz / sr);
+                    var periodTicks = (uint)(baseFreqHz / sr) - 2; // NB: -2 results from known issue in version 2 of DigitalIO device
                     device.WriteRegister(DigitalIO.SAMPLE_PERIOD, periodTicks);
                 } else
                 {


### PR DESCRIPTION
- This is known issue in version 2 of the DigitalIO device. This correction results in the digital sampling rate matching the value specified by SampleRate
- Fixes #479 