### PR TITLE
Mark AxisMap and AxisSign as not browsable

### DIFF
--- a/OpenEphys.Onix1.Design/PolledBno055Dialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/PolledBno055Dialog.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Text = "NeuropixelsV1eBno055Dialog";
+            this.Text = "Bno055Dialog";
         }
 
         #endregion

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1e.cs
@@ -50,7 +50,7 @@ namespace OpenEphys.Onix1
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(DevicesCategory)]
-        [TypeConverter(typeof(PolledBno055SingleDeviceFactoryConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigurePolledBno055 Bno055 { get; set; } =
             new ConfigurePolledBno055 { AxisMap = Bno055AxisMap.YZX, AxisSign = Bno055AxisSign.MirrorX | Bno055AxisSign.MirrorZ };

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV1f.cs
@@ -60,7 +60,7 @@ namespace OpenEphys.Onix1
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(DevicesCategory)]
-        [TypeConverter(typeof(PolledBno055SingleDeviceFactoryConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigureBno055 Bno055 { get; set; } = new();
 

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2e.cs
@@ -49,7 +49,7 @@ namespace OpenEphys.Onix1
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(DevicesCategory)]
-        [TypeConverter(typeof(PolledBno055SingleDeviceFactoryConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigurePolledBno055 Bno055 { get; set; } =
             new ConfigurePolledBno055 { AxisMap = Bno055AxisMap.YZX, AxisSign = Bno055AxisSign.MirrorX | Bno055AxisSign.MirrorY };

--- a/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstageNeuropixelsV2eBeta.cs
@@ -49,7 +49,7 @@ namespace OpenEphys.Onix1
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(DevicesCategory)]
-        [TypeConverter(typeof(PolledBno055SingleDeviceFactoryConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigurePolledBno055 Bno055 { get; set; } =
             new ConfigurePolledBno055 { AxisMap = Bno055AxisMap.YZX, AxisSign = Bno055AxisSign.MirrorX | Bno055AxisSign.MirrorY };

--- a/OpenEphys.Onix1/ConfigurePolledBno055.cs
+++ b/OpenEphys.Onix1/ConfigurePolledBno055.cs
@@ -62,6 +62,7 @@ namespace OpenEphys.Onix1
         /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Specifies the axis map that will be applied during configuration.")]
+        [Browsable(false)]
         public Bno055AxisMap AxisMap { get; set; } = Bno055AxisMap.XYZ;
 
         /// <summary>
@@ -74,6 +75,7 @@ namespace OpenEphys.Onix1
         /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Specifies axis sign that will be applied during configuration.")]
+        [Browsable(false)]
         public Bno055AxisSign AxisSign { get; set; } = Bno055AxisSign.Default;
 
         /// <summary>
@@ -227,24 +229,6 @@ namespace OpenEphys.Onix1
         /// Specifies that X' axis should be mirrored.
         /// </summary>
         MirrorX = 0b00000_100,
-    }
-
-    // NB: Can be used to remove axis map and sign properties from MultiDeviceFactories that include a
-    // ConfigurePolledBno055 when having those options would cause confusion and potential
-    // commutator malfunction
-    internal class PolledBno055SingleDeviceFactoryConverter : SingleDeviceFactoryConverter
-    {
-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
-        {
-            var properties = (from property in base.GetProperties(context, value, attributes).Cast<PropertyDescriptor>()
-                              where !property.IsReadOnly &&
-                                    !(property.PropertyType == typeof(Bno055AxisMap)) &&
-                                    !(property.PropertyType == typeof(Bno055AxisSign)) &&
-                                    property.ComponentType != typeof(SingleDeviceFactory)
-                              select property)
-                              .ToArray();
-            return new PropertyDescriptorCollection(properties).Sort(properties.Select(p => p.Name).ToArray());
-        }
     }
 
     /// <inheritdoc cref = "ConfigurePolledBno055"/>

--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4.cs
@@ -47,7 +47,7 @@ namespace OpenEphys.Onix1
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(DevicesCategory)]
-        [TypeConverter(typeof(PolledBno055SingleDeviceFactoryConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigurePolledBno055 Bno055 { get; set; } =
             new ConfigurePolledBno055 { AxisMap = Bno055AxisMap.ZYX, AxisSign = Bno055AxisSign.MirrorZ };


### PR DESCRIPTION
During our discussions, we came to the conclusion that the `AxisMap` and `AxisSign` variables should not be browsable in any situation; this is different from the original behavior where they were browsable for the device outside of the context of a headstage.

This PR removes the `PolledBno055SingleDeviceFactoryConverter` as it is no longer needed, and marks the two properties as `Browsable(false)`. This removes them from the editor in all instances, which achieves the original goal of hiding these properties in the GUIs.

Fixes #314 