### PR TITLE
Add support for load tester device

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.6.1</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix1/ConfigureLoadTester.cs
@@ -32,15 +32,15 @@ namespace OpenEphys.Onix1
         public bool Enable { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets the number of repetitions incrementing, unsigned 16-bit integers sent with each read frame.
+        /// Gets or sets the number of incrementing, unsigned 16-bit integers sent with each read frame.
         /// </summary>
         /// <remarks>
-        /// These data are produced by the controller and are used to impose a load the controller to host
+        /// These data are produced by the controller and are used to impose a load on the controller to host
         /// communication. These data can be used in downstream computational operations that model the
         /// computational load imposed by a closed-loop algorithm.
         /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Number of repetitions of the 16-bit unsigned integer 42 sent with each read-frame.")]
+        [Description("Number of incrementing, unsigned 16-bit integers sent with each read-frame.")]
         [Range(0, 10e6)]
         public uint ReceivedWords { get; set; }
 
@@ -53,7 +53,7 @@ namespace OpenEphys.Onix1
         /// commutation. They are discarded by the controller when they are received.
         /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Number of repetitions of the 32-bit integer 42 sent with each write frame.")]
+        [Description("Number of repetitions of the 32-bit integer dummy words sent with each write frame.")]
         [Range(0, 10e6)]
         public uint TransmittedWords { get; set; }
 

--- a/OpenEphys.Onix1/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix1/ConfigureLoadTester.cs
@@ -50,7 +50,7 @@ namespace OpenEphys.Onix1
         /// </summary>
         /// <remarks>
         /// These data are produced by the host and are used to impose a load on host to controller
-        /// commutation. They are discarded by the controller when they are received.
+        /// communication. They are discarded by the controller when they are received.
         /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Number of repetitions of the 32-bit integer dummy words sent with each write frame.")]
@@ -124,18 +124,11 @@ namespace OpenEphys.Onix1
         public const int ID = 27;
 
         public const uint ENABLE = 0;
-        public const uint CLK_DIV = 1;      // Heartbeat clock divider ratio. Default results in 10 Hz heartbeat.
-                                            // Values less than CLK_HZ / 10e6 Hz will result in 1kHz.
-        public const uint CLK_HZ = 2;       // The frequency parameter, CLK_HZ, used in the calculation of CLK_DIV
-        public const uint DT0H16_WORDS = 3; // Number of repetitions of 16-bit unsigned integer 42 sent with each frame. 
-                                            // Note: max here depends of CLK_HZ and CLK_DIV. There needs to be enough clock
-                                            // cycles to push the data at the requested CLK_HZ. Specifically,
-                                            // CLK_HZ / CLK_DIV >= DT0H16_WORDS + 9. Going above this will result in 
-                                            // decreased bandwidth as samples will be skipped.
-        public const uint HTOD32_WORDS = 4; // Number of 32-bit words in a write-frame. All write frame data is ignored except
-                                            // the first 64-bits, which are looped back into the device to host data frame for   
-                                            // testing loop latency. This value must be at least 2.
-
+        public const uint CLK_DIV = 1;
+        public const uint CLK_HZ = 2;
+        public const uint DT0H16_WORDS = 3;
+        public const uint HTOD32_WORDS = 4;
+        public const uint DTOH_START = 5;
 
         internal class NameConverter : DeviceNameConverter
         {

--- a/OpenEphys.Onix1/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix1/ConfigureLoadTester.cs
@@ -1,27 +1,21 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
 using Bonsai;
 
 namespace OpenEphys.Onix1
 {
-    // TODO: Add data IO operators, update XML comment to link to them (<see cref="LoadTesterData"/>)
     /// <summary>
-    /// Configures a load tester device.
+    /// Configures a load tester device for measuring system performance.
     /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a data IO operator, such as LoadTesterData,
-    /// using a shared <c>DeviceName</c>. The load tester device can be configured
-    /// to produce data at user-settable size and rate to stress test various communication links and test
-    /// closed-loop response latency.
+    /// This configuration operator can be linked to a data IO operator, such as <see cref="LoadTesterData"/>,
+    /// using a shared <c>DeviceName</c>. The load tester device can be configured to produce and consume data
+    /// at user-defined sizes and rates to stress test various communication links and measure closed-loop
+    /// response latency using a high-resolution hardware timer.
     /// </remarks>
     [Description("Configures a load testing device.")]
     public class ConfigureLoadTester : SingleDeviceFactory
     {
-        readonly BehaviorSubject<uint> frameHz = new(1000);
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigureLoadTester"/> class.
         /// </summary>
@@ -38,31 +32,37 @@ namespace OpenEphys.Onix1
         public bool Enable { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets the number of repetitions of the 16-bit unsigned integer 42 sent with each read-frame.
+        /// Gets or sets the number of repetitions incrementing, unsigned 16-bit integers sent with each read frame.
         /// </summary>
+        /// <remarks>
+        /// These data are produced by the controller and are used to impose a load the controller to host
+        /// communication. These data can be used in downstream computational operations that model the
+        /// computational load imposed by a closed-loop algorithm.
+        /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Number of repetitions of the 16-bit unsigned integer 42 sent with each read-frame.")]
         [Range(0, 10e6)]
         public uint ReceivedWords { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of repetitions of the 32-bit integer 42 sent with each write frame.
+        /// Gets or sets the number of repetitions of the 32-bit integer dummy words sent with each write
+        /// frame.
         /// </summary>
+        /// <remarks>
+        /// These data are produced by the host and are used to impose a load on host to controller
+        /// commutation. They are discarded by the controller when they are received.
+        /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Number of repetitions of the 32-bit integer 42 sent with each write frame.")]
         [Range(0, 10e6)]
         public uint TransmittedWords { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying the rate at which frames are produced, in Hz.
+        /// Gets or sets a value specifying the rate at which frames are produced in Hz.
         /// </summary>
-        [Category(AcquisitionCategory)]
+        [Category(ConfigurationCategory)]
         [Description("Specifies the rate at which frames are produced (Hz).")]
-        public uint FramesPerSecond
-        {
-            get { return frameHz.Value; }
-            set { frameHz.OnNext(value); }
-        }
+        public uint FramesPerSecond { get; set; }
 
         /// <summary>
         /// Configures a load testing device.
@@ -83,6 +83,8 @@ namespace OpenEphys.Onix1
             var deviceAddress = DeviceAddress;
             var receivedWords = ReceivedWords;
             var transmittedWords = TransmittedWords;
+            var framesPerSecond = FramesPerSecond;
+
             return source.ConfigureDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
@@ -90,33 +92,29 @@ namespace OpenEphys.Onix1
 
                 var clockHz = device.ReadRegister(LoadTester.CLK_HZ);
 
-                // Assumes 8-byte timer
-                uint ValidSize()
+                const int OverheadCycles = 9; // 4 cycles to produce hub clock, and 5 state machine overhead per the datasheet
+
+                var maxFramesPerSecond = clockHz / OverheadCycles;
+                if (framesPerSecond > maxFramesPerSecond)
                 {
-                    var clkDiv = device.ReadRegister(LoadTester.CLK_DIV);
-                    return clkDiv - 4 - 10; // -10 is overhead hack
+                    throw new ArgumentOutOfRangeException(nameof(FramesPerSecond), $"{nameof(FramesPerSecond)} must be less than {maxFramesPerSecond}.");
                 }
 
-                var maxSize = ValidSize();
-                var bounded = receivedWords > maxSize ? maxSize : receivedWords;
-                device.WriteRegister(LoadTester.DT0H16_WORDS, bounded);
+                device.WriteRegister(LoadTester.CLK_DIV, clockHz / framesPerSecond);
 
-                var writeArray = Enumerable.Repeat((uint)42, (int)(transmittedWords + 2)).ToArray();
-                device.WriteRegister(LoadTester.HTOD32_WORDS, transmittedWords);
-                var frameHzSubscription = frameHz.SubscribeSafe(observer, newValue =>
+                var maxSize = device.ReadRegister(LoadTester.CLK_DIV) - OverheadCycles;
+
+                if (receivedWords > maxSize)
                 {
-                    device.WriteRegister(LoadTester.CLK_DIV, clockHz / newValue);
-                    var maxSize = ValidSize();
-                    if (receivedWords > maxSize)
-                    {
-                        receivedWords = maxSize;
-                    }
-                });
+                    throw new ArgumentOutOfRangeException(nameof(ReceivedWords), 
+                        $"{nameof(ReceivedWords)} must be less than {maxSize} for the requested frame rate of {framesPerSecond} Hz.");
+                }
 
-                return new CompositeDisposable(
-                    DeviceManager.RegisterDevice(deviceName, device, DeviceType),
-                    frameHzSubscription
-                );
+                device.WriteRegister(LoadTester.DT0H16_WORDS, receivedWords);
+                device.WriteRegister(LoadTester.HTOD32_WORDS, transmittedWords);
+                
+                var deviceInfo = new LoadTesterDeviceInfo(context, DeviceType, deviceAddress, ReceivedWords, TransmittedWords);
+                return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
     }
@@ -132,11 +130,12 @@ namespace OpenEphys.Onix1
         public const uint DT0H16_WORDS = 3; // Number of repetitions of 16-bit unsigned integer 42 sent with each frame. 
                                             // Note: max here depends of CLK_HZ and CLK_DIV. There needs to be enough clock
                                             // cycles to push the data at the requested CLK_HZ. Specifically,
-                                            // CLK_HZ / CLK_DIV >= TX16_WORDS + 9. Going above this will result in 
+                                            // CLK_HZ / CLK_DIV >= DT0H16_WORDS + 9. Going above this will result in 
                                             // decreased bandwidth as samples will be skipped.
         public const uint HTOD32_WORDS = 4; // Number of 32-bit words in a write-frame. All write frame data is ignored except
                                             // the first 64-bits, which are looped back into the device to host data frame for   
                                             // testing loop latency. This value must be at least 2.
+
 
         internal class NameConverter : DeviceNameConverter
         {

--- a/OpenEphys.Onix1/LoadTesterData.cs
+++ b/OpenEphys.Onix1/LoadTesterData.cs
@@ -7,11 +7,11 @@ using Bonsai;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of heartbeat data frames.
+    /// Produces a sequence of LoadTester data frames.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureHeartbeat"/>, using a shared <c>DeviceName</c>.
+    /// cref="ConfigureLoadTester"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of load tester data frames.")]
     public class LoadTesterData : Source<LoadTesterDataFrame>

--- a/OpenEphys.Onix1/LoadTesterData.cs
+++ b/OpenEphys.Onix1/LoadTesterData.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Produces a sequence of heartbeat data frames.
+    /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeartbeat"/>, using a shared <c>DeviceName</c>.
+    /// </remarks>
+    [Description("Produces a sequence of load tester data frames.")]
+    public class LoadTesterData : Source<LoadTesterDataFrame>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(LoadTester.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        [Category(DeviceFactory.ConfigurationCategory)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Generates a sequence of <see cref="LoadTesterDataFrame"/> objects, each of which contains period signal from the
+        /// acquisition system indicating that it is active.
+        /// </summary>
+        /// <returns>A sequence of <see cref="LoadTesterDataFrame"/> objects.</returns>
+        public override IObservable<LoadTesterDataFrame> Generate()
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var info = (LoadTesterDeviceInfo)deviceInfo;
+                var device = info.GetDeviceContext(typeof(LoadTester));
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
+                    .Select(frame => new LoadTesterDataFrame(frame, info.ReceivedWords));
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/LoadTesterDataFrame.cs
+++ b/OpenEphys.Onix1/LoadTesterDataFrame.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A load tester data frame.
+    /// </summary>
+    public class LoadTesterDataFrame : DataFrame
+    {
+        /// <summary>
+        /// Gets the difference between the hub clock and the loopback value at the moment the loopback
+        /// value was received.
+        /// </summary>
+        /// <remarks>
+        /// This value is the result of subtracting the loopback value written by the <see
+        /// cref="LoadTesterLoopback"/> operator from the device's hub clock counter value at the moment that
+        /// the loop back value was received. Typically, the <see cref="DataFrame.HubClock"/> member is sent
+        /// to <see cref="LoadTesterLoopback"/> operator such that this value is a hardware-timed measurement
+        /// value of real-time latency. This value is only updated when a new loopback value is sent to the
+        /// device using the <see cref="LoadTesterLoopback"/> operator.
+        /// </remarks>
+        public ulong HubClockDelta { get; }
+
+        /// <summary>
+        /// Gets the counter array.
+        /// </summary>
+        /// <remarks>
+        /// This is a <see cref="ConfigureLoadTester.ReceivedWords"/>-long array of incrementing integers that
+        /// is used for simulating the bandwidth of physical data sources.
+        /// </remarks>
+        public ushort[] Counter { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadTesterDataFrame"/> class.
+        /// </summary>
+        /// <param name="frame">A data frame produced by a load tester device.</param>
+        /// <param name="receivedWords">The number of counter words that appear at the end of the load test
+        /// data frame. This number is determined by the value of <see
+        /// cref="ConfigureLoadTester.ReceivedWords"/>.</param>
+        public unsafe LoadTesterDataFrame(oni.Frame frame, uint receivedWords)
+            : base(frame.Clock)
+        {
+            var payload = (LoadTesterPayload*)frame.Data.ToPointer();
+            var counterPtr = (ushort*)((byte*)payload + sizeof(LoadTesterPayload));
+
+            HubClock = payload->HubClock;
+            HubClockDelta = payload->HubClockDelta;
+            Counter = new Span<ushort>(counterPtr, (int)receivedWords).ToArray();
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct LoadTesterPayload
+    {
+        public ulong HubClock;
+        public ulong HubClockDelta;
+        // NB: The ushort Counter array may or may not reside here. Its size is determined by ReceivedWords.
+    }
+}
+

--- a/OpenEphys.Onix1/LoadTesterDeviceInfo.cs
+++ b/OpenEphys.Onix1/LoadTesterDeviceInfo.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace OpenEphys.Onix1
+{
+    class LoadTesterDeviceInfo : DeviceInfo
+    {
+        public LoadTesterDeviceInfo(ContextTask context, Type deviceType, uint deviceAddress, uint receivedWords, uint transmittedWords)
+            : base(context, deviceType, deviceAddress)
+        {
+            ReceivedWords = receivedWords;
+            TransmittedWords = transmittedWords;
+        }
+
+        public uint ReceivedWords { get; }
+
+        public uint TransmittedWords { get; }
+    }
+}

--- a/OpenEphys.Onix1/LoadTesterLoopback.cs
+++ b/OpenEphys.Onix1/LoadTesterLoopback.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+
+    /// <summary>
+    /// Sends loopback data to the load testing device for closed-loop latency measurement.
+    /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureLoadTester"/>, using a shared <c>DeviceName</c>.
+    /// </remarks>
+    [Description("Sends analog output data to an ONIX breakout board.")]
+    public class LoadTesterLoopback : Sink<ulong>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(LoadTester.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        [Category(DeviceFactory.ConfigurationCategory)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Creates and sends an loopback frame to the load testing device.
+        /// </summary>
+        /// <remarks>
+        /// A loopback frame consists the <c>ulong</c> loopback value provided by <paramref name="source"/>
+        /// that is prepended to a <see cref="ConfigureLoadTester.TransmittedWords"/>-element <c>ushort</c>
+        /// array of dummy data. When the frame is received by hardware, the loopback value is subtracted from
+        /// the current hub clock count on the load testing device and stored. Therefore, if the loopback
+        /// value is is that of a previous <see cref="DataFrame.HubClock"/> from the <see
+        /// cref="LoadTesterData"/> with the same <see cref="DeviceName"/> as this operator, this difference will provide a
+        /// hardware-timed measurement of real-time latency. The the variably-sized dummy data in the loopback
+        /// frame is used for testing the effect of increasing the frame size, and thus the write
+        /// communication bandwidth, on real-time latency.
+        /// </remarks>
+        /// <param name="source">A sequence of loopback values to send to the device</param>
+        /// <returns> A sequence of loopback values to send to the device.</returns>
+        public unsafe override IObservable<ulong> Process(IObservable<ulong> source)
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var info = (LoadTesterDeviceInfo)deviceInfo;
+                var device = info.GetDeviceContext(typeof(LoadTester));
+                var transmittedWords = info.TransmittedWords;
+
+                if (transmittedWords > 0)
+                {
+                    var payload = new uint[transmittedWords + 2];
+
+                    return source.Do(loopbackValue =>
+                    {
+                        payload[0] = (uint)loopbackValue;
+                        payload[1] = (uint)(loopbackValue >> 32);
+                        device.Write(payload);
+                    });
+                }
+                else
+                {
+                    return source.Do(device.Write);
+                }
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/LoadTesterLoopback.cs
+++ b/OpenEphys.Onix1/LoadTesterLoopback.cs
@@ -6,7 +6,6 @@ using Bonsai;
 
 namespace OpenEphys.Onix1
 {
-
     /// <summary>
     /// Sends loopback data to the load testing device for closed-loop latency measurement.
     /// </summary>
@@ -14,7 +13,7 @@ namespace OpenEphys.Onix1
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
     /// cref="ConfigureLoadTester"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
-    [Description("Sends analog output data to an ONIX breakout board.")]
+    [Description("Sends loopback data to an ONIX breakout board.")]
     public class LoadTesterLoopback : Sink<ulong>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
@@ -24,16 +23,16 @@ namespace OpenEphys.Onix1
         public string DeviceName { get; set; }
 
         /// <summary>
-        /// Creates and sends an loopback frame to the load testing device.
+        /// Creates and sends a loopback frame to the load testing device.
         /// </summary>
         /// <remarks>
-        /// A loopback frame consists the <c>ulong</c> loopback value provided by <paramref name="source"/>
+        /// A loopback frame consists of the <c>ulong</c> loopback value provided by <paramref name="source"/>
         /// that is prepended to a <see cref="ConfigureLoadTester.TransmittedWords"/>-element <c>ushort</c>
         /// array of dummy data. When the frame is received by hardware, the loopback value is subtracted from
         /// the current hub clock count on the load testing device and stored. Therefore, if the loopback
-        /// value is is that of a previous <see cref="DataFrame.HubClock"/> from the <see
+        /// value is that of a previous <see cref="DataFrame.HubClock"/> from the <see
         /// cref="LoadTesterData"/> with the same <see cref="DeviceName"/> as this operator, this difference will provide a
-        /// hardware-timed measurement of real-time latency. The the variably-sized dummy data in the loopback
+        /// hardware-timed measurement of real-time latency. The variably-sized dummy data in the loopback
         /// frame is used for testing the effect of increasing the frame size, and thus the write
         /// communication bandwidth, on real-time latency.
         /// </remarks>

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -16,5 +16,6 @@
     <PackageReference Include="Microsoft.Bcl.Numerics" Version="9.0.7" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
     <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.3.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Modify the existing configuration operator since it had implementation issues
- Add frame reader and frame writer operators and support classes
- Fixes #274 


### Documentation content
Here is a screenshot of an example workflow in operation for documentation purposes:

<img width="990" height="818" alt="image" src="https://github.com/user-attachments/assets/daf0fecb-2764-48d8-873b-a3c4cad89b29" />

- 1000 corresponds to 1 millisecond in this histogram so the average latency is about 100 usec.
- Input bandwidth is 200 bytes at 100kHz = 20 MB/s
- Output bandwidth is 1/100th of this, 200 kB/s
- Block ReadSize is 2048 bytes
- Block WriteSize is 16384 bytes (preallocation size)
- Computer specs are:
<img width="1063" height="588" alt="image" src="https://github.com/user-attachments/assets/c2ff6d09-ceff-4a7a-9f62-932ba80c50b3" />



### Example workflow
<details>
  <summary>Here is the workflow used to generate above:</summary>

  ```xml
<?xml version="1.0" encoding="utf-8"?>
<WorkflowBuilder Version="2.9.0"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:onix1="clr-namespace:OpenEphys.Onix1;assembly=OpenEphys.Onix1"
                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
                 xmlns="https://bonsai-rx.org/2018/workflow">
  <Workflow>
    <Nodes>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="onix1:CreateContext">
          <onix1:Driver>riffa</onix1:Driver>
          <onix1:Index>0</onix1:Index>
        </Combinator>
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="onix1:ConfigureLoadTester">
          <onix1:DeviceName>Load Tester</onix1:DeviceName>
          <onix1:DeviceAddress>11</onix1:DeviceAddress>
          <onix1:Enable>true</onix1:Enable>
          <onix1:ReceivedWords>100</onix1:ReceivedWords>
          <onix1:TransmittedWords>100</onix1:TransmittedWords>
          <onix1:FramesPerSecond>100000</onix1:FramesPerSecond>
        </Combinator>
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="onix1:ConfigureBreakoutBoard">
          <onix1:Name>BreakoutBoard</onix1:Name>
          <onix1:Heartbeat>
            <onix1:DeviceName>BreakoutBoard/PersistentHeartbeat</onix1:DeviceName>
            <onix1:DeviceAddress>0</onix1:DeviceAddress>
            <onix1:BeatsPerSecond>100</onix1:BeatsPerSecond>
          </onix1:Heartbeat>
          <onix1:AnalogIO>
            <onix1:DeviceName>BreakoutBoard/AnalogIO</onix1:DeviceName>
            <onix1:DeviceAddress>6</onix1:DeviceAddress>
            <onix1:Enable>false</onix1:Enable>
            <onix1:InputRange0>TenVolts</onix1:InputRange0>
            <onix1:InputRange1>TenVolts</onix1:InputRange1>
            <onix1:InputRange2>TenVolts</onix1:InputRange2>
            <onix1:InputRange3>TenVolts</onix1:InputRange3>
            <onix1:InputRange4>TenVolts</onix1:InputRange4>
            <onix1:InputRange5>TenVolts</onix1:InputRange5>
            <onix1:InputRange6>TenVolts</onix1:InputRange6>
            <onix1:InputRange7>TenVolts</onix1:InputRange7>
            <onix1:InputRange8>TenVolts</onix1:InputRange8>
            <onix1:InputRange9>TenVolts</onix1:InputRange9>
            <onix1:InputRange10>TenVolts</onix1:InputRange10>
            <onix1:InputRange11>TenVolts</onix1:InputRange11>
            <onix1:Direction0>Input</onix1:Direction0>
            <onix1:Direction1>Input</onix1:Direction1>
            <onix1:Direction2>Input</onix1:Direction2>
            <onix1:Direction3>Input</onix1:Direction3>
            <onix1:Direction4>Input</onix1:Direction4>
            <onix1:Direction5>Input</onix1:Direction5>
            <onix1:Direction6>Input</onix1:Direction6>
            <onix1:Direction7>Input</onix1:Direction7>
            <onix1:Direction8>Input</onix1:Direction8>
            <onix1:Direction9>Input</onix1:Direction9>
            <onix1:Direction10>Input</onix1:Direction10>
            <onix1:Direction11>Input</onix1:Direction11>
          </onix1:AnalogIO>
          <onix1:DigitalIO>
            <onix1:DeviceName>BreakoutBoard/DigitalIO</onix1:DeviceName>
            <onix1:DeviceAddress>7</onix1:DeviceAddress>
            <onix1:Enable>false</onix1:Enable>
            <onix1:DeadTime>0</onix1:DeadTime>
            <onix1:SampleRate xsi:nil="true" />
          </onix1:DigitalIO>
          <onix1:ClockOutput>
            <onix1:DeviceName>BreakoutBoard/OutputClock</onix1:DeviceName>
            <onix1:DeviceAddress>5</onix1:DeviceAddress>
            <onix1:ClockGate>false</onix1:ClockGate>
            <onix1:Frequency>1000000</onix1:Frequency>
            <onix1:DutyCycle>50</onix1:DutyCycle>
            <onix1:Delay>0</onix1:Delay>
          </onix1:ClockOutput>
          <onix1:HarpInput>
            <onix1:DeviceName>BreakoutBoard/HarpSyncInput</onix1:DeviceName>
            <onix1:DeviceAddress>12</onix1:DeviceAddress>
            <onix1:Enable>false</onix1:Enable>
            <onix1:Source>Breakout</onix1:Source>
          </onix1:HarpInput>
          <onix1:MemoryMonitor>
            <onix1:DeviceName>BreakoutBoard/MemoryMonitor</onix1:DeviceName>
            <onix1:DeviceAddress>10</onix1:DeviceAddress>
            <onix1:Enable>true</onix1:Enable>
            <onix1:SamplesPerSecond>100</onix1:SamplesPerSecond>
          </onix1:MemoryMonitor>
        </Combinator>
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="onix1:StartAcquisition">
          <onix1:ReadSize>2048</onix1:ReadSize>
          <onix1:WriteSize>16384</onix1:WriteSize>
        </Combinator>
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="onix1:LoadTesterData">
          <onix1:DeviceName>Load Tester</onix1:DeviceName>
        </Combinator>
      </Expression>
      <Expression xsi:type="MemberSelector">
        <Selector>HubClockDelta</Selector>
      </Expression>
      <Expression xsi:type="scr:ExpressionTransform">
        <scr:Name>ToMilliseconds</scr:Name>
        <scr:Expression>it/250000.0</scr:Expression>
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="rx:DistinctUntilChanged" />
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="dsp:Histogram1D">
          <dsp:Min>0</dsp:Min>
          <dsp:Max>1</dsp:Max>
          <dsp:Bins>1000</dsp:Bins>
          <dsp:Normalize>false</dsp:Normalize>
          <dsp:Accumulate>true</dsp:Accumulate>
        </Combinator>
      </Expression>
      <Expression xsi:type="MemberSelector">
        <Selector>HubClock</Selector>
      </Expression>
      <Expression xsi:type="rx:Condition">
        <Name>Every Nth</Name>
        <Workflow>
          <Nodes>
            <Expression xsi:type="WorkflowInput">
              <Name>Source1</Name>
            </Expression>
            <Expression xsi:type="Combinator">
              <Combinator xsi:type="rx:ElementIndex" />
            </Expression>
            <Expression xsi:type="MemberSelector">
              <Selector>Index</Selector>
            </Expression>
            <Expression xsi:type="ExternalizedMapping">
              <Property Name="Value" DisplayName="N" />
            </Expression>
            <Expression xsi:type="Mod">
              <Operand xsi:type="IntProperty">
                <Value>100</Value>
              </Operand>
            </Expression>
            <Expression xsi:type="Equal">
              <Operand xsi:type="IntProperty">
                <Value>0</Value>
              </Operand>
            </Expression>
            <Expression xsi:type="WorkflowOutput" />
          </Nodes>
          <Edges>
            <Edge From="0" To="1" Label="Source1" />
            <Edge From="1" To="2" Label="Source1" />
            <Edge From="2" To="4" Label="Source1" />
            <Edge From="3" To="4" Label="Source2" />
            <Edge From="4" To="5" Label="Source1" />
            <Edge From="5" To="6" Label="Source1" />
          </Edges>
        </Workflow>
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="onix1:LoadTesterLoopback">
          <onix1:DeviceName>Load Tester</onix1:DeviceName>
        </Combinator>
      </Expression>
      <Expression xsi:type="Combinator">
        <Combinator xsi:type="onix1:MemoryMonitorData">
          <onix1:DeviceName>BreakoutBoard/MemoryMonitor</onix1:DeviceName>
        </Combinator>
      </Expression>
      <Expression xsi:type="MemberSelector">
        <Selector>PercentUsed</Selector>
      </Expression>
    </Nodes>
    <Edges>
      <Edge From="0" To="1" Label="Source1" />
      <Edge From="1" To="2" Label="Source1" />
      <Edge From="2" To="3" Label="Source1" />
      <Edge From="4" To="5" Label="Source1" />
      <Edge From="4" To="9" Label="Source1" />
      <Edge From="5" To="6" Label="Source1" />
      <Edge From="6" To="7" Label="Source1" />
      <Edge From="7" To="8" Label="Source1" />
      <Edge From="9" To="10" Label="Source1" />
      <Edge From="10" To="11" Label="Source1" />
      <Edge From="12" To="13" Label="Source1" />
    </Edges>
  </Workflow>
</WorkflowBuilder>
  ```
</details>


