### PR TITLE
Reorder tabs to flow from left to right, top to bottom

### DIFF
--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
@@ -67,6 +67,7 @@
             this.splitContainer1.Size = new System.Drawing.Size(609, 550);
             this.splitContainer1.SplitterDistance = 513;
             this.splitContainer1.TabIndex = 0;
+            this.splitContainer1.TabStop = false;
             // 
             // zedGraphChannels
             // 
@@ -84,6 +85,7 @@
             this.zedGraphChannels.ScrollMinY2 = 0D;
             this.zedGraphChannels.Size = new System.Drawing.Size(609, 513);
             this.zedGraphChannels.TabIndex = 4;
+            this.zedGraphChannels.TabStop = false;
             this.zedGraphChannels.UseExtendedPrintDialog = true;
             this.zedGraphChannels.ZoomEvent += new ZedGraph.ZedGraphControl.ZoomEventHandler(this.ZoomEvent);
             // 
@@ -95,7 +97,7 @@
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(144, 32);
-            this.buttonCancel.TabIndex = 4;
+            this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
             // 
@@ -106,7 +108,7 @@
             this.buttonOK.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(144, 32);
-            this.buttonOK.TabIndex = 3;
+            this.buttonOK.TabIndex = 0;
             this.buttonOK.Text = "OK";
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.ButtonOK);

--- a/OpenEphys.Onix1.Design/CustomMessageBox.Designer.cs
+++ b/OpenEphys.Onix1.Design/CustomMessageBox.Designer.cs
@@ -55,8 +55,8 @@
             // 
             // flowLayoutPanel1
             // 
-            this.flowLayoutPanel1.Controls.Add(this.buttonConfirm);
             this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
+            this.flowLayoutPanel1.Controls.Add(this.buttonConfirm);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 148);
@@ -68,7 +68,7 @@
             // 
             this.buttonConfirm.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.buttonConfirm.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.buttonConfirm.Location = new System.Drawing.Point(441, 3);
+            this.buttonConfirm.Location = new System.Drawing.Point(308, 3);
             this.buttonConfirm.Name = "buttonConfirm";
             this.buttonConfirm.Size = new System.Drawing.Size(127, 39);
             this.buttonConfirm.TabIndex = 0;
@@ -79,7 +79,7 @@
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.buttonCancel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.buttonCancel.Location = new System.Drawing.Point(308, 3);
+            this.buttonCancel.Location = new System.Drawing.Point(441, 3);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(127, 39);
             this.buttonCancel.TabIndex = 1;

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.Designer.cs
@@ -285,13 +285,13 @@
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(1320, 747);
-            this.tableLayoutPanel1.TabIndex = 37;
+            this.tableLayoutPanel1.TabIndex = 0;
             // 
             // panelProbe
             // 
@@ -299,7 +299,7 @@
             this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelProbe.Location = new System.Drawing.Point(4, 4);
-            this.panelProbe.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(4);
             this.panelProbe.Name = "panelProbe";
             this.panelProbe.Size = new System.Drawing.Size(982, 697);
             this.panelProbe.TabIndex = 0;
@@ -311,7 +311,7 @@
             this.panelTrackBar.Controls.Add(label3);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
             this.panelTrackBar.Location = new System.Drawing.Point(917, 5);
-            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4);
             this.panelTrackBar.Name = "panelTrackBar";
             this.panelTrackBar.Size = new System.Drawing.Size(61, 686);
             this.panelTrackBar.TabIndex = 33;
@@ -329,6 +329,7 @@
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
             this.trackBarProbePosition.Size = new System.Drawing.Size(45, 670);
             this.trackBarProbePosition.TabIndex = 30;
+            this.trackBarProbePosition.TabStop = false;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
             this.trackBarProbePosition.Value = 50;
@@ -377,7 +378,7 @@
             this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
             this.checkBoxInvertPolarity.Size = new System.Drawing.Size(77, 20);
-            this.checkBoxInvertPolarity.TabIndex = 43;
+            this.checkBoxInvertPolarity.TabIndex = 5;
             this.checkBoxInvertPolarity.Text = "Enabled";
             this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
             // 
@@ -391,6 +392,7 @@
             this.textBoxLfpCorrection.ReadOnly = true;
             this.textBoxLfpCorrection.Size = new System.Drawing.Size(210, 22);
             this.textBoxLfpCorrection.TabIndex = 41;
+            this.textBoxLfpCorrection.TabStop = false;
             // 
             // textBoxApCorrection
             // 
@@ -402,6 +404,7 @@
             this.textBoxApCorrection.ReadOnly = true;
             this.textBoxApCorrection.Size = new System.Drawing.Size(210, 22);
             this.textBoxApCorrection.TabIndex = 39;
+            this.textBoxApCorrection.TabStop = false;
             // 
             // buttonViewAdcs
             // 
@@ -424,7 +427,7 @@
             this.buttonChooseAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseAdcCalibrationFile.Name = "buttonChooseAdcCalibrationFile";
             this.buttonChooseAdcCalibrationFile.Size = new System.Drawing.Size(37, 25);
-            this.buttonChooseAdcCalibrationFile.TabIndex = 36;
+            this.buttonChooseAdcCalibrationFile.TabIndex = 0;
             this.buttonChooseAdcCalibrationFile.Text = "...";
             this.buttonChooseAdcCalibrationFile.UseVisualStyleBackColor = true;
             this.buttonChooseAdcCalibrationFile.Click += new System.EventHandler(this.ChooseAdcCalibrationFile_Click);
@@ -436,7 +439,7 @@
             this.buttonChooseGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseGainCalibrationFile.Name = "buttonChooseGainCalibrationFile";
             this.buttonChooseGainCalibrationFile.Size = new System.Drawing.Size(37, 25);
-            this.buttonChooseGainCalibrationFile.TabIndex = 35;
+            this.buttonChooseGainCalibrationFile.TabIndex = 1;
             this.buttonChooseGainCalibrationFile.Text = "...";
             this.buttonChooseGainCalibrationFile.UseVisualStyleBackColor = true;
             this.buttonChooseGainCalibrationFile.Click += new System.EventHandler(this.ChooseGainCalibrationFile_Click);
@@ -449,7 +452,7 @@
             this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
             this.buttonEnableContacts.Size = new System.Drawing.Size(299, 44);
-            this.buttonEnableContacts.TabIndex = 28;
+            this.buttonEnableContacts.TabIndex = 8;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.buttonEnableContacts.UseVisualStyleBackColor = true;
             this.buttonEnableContacts.Click += new System.EventHandler(this.EnableContacts_Click);
@@ -462,7 +465,7 @@
             this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
             this.buttonClearSelections.Size = new System.Drawing.Size(299, 44);
-            this.buttonClearSelections.TabIndex = 27;
+            this.buttonClearSelections.TabIndex = 9;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.buttonClearSelections.UseVisualStyleBackColor = true;
             this.buttonClearSelections.Click += new System.EventHandler(this.ClearSelection_Click);
@@ -477,7 +480,7 @@
             this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
             this.comboBoxChannelPresets.Size = new System.Drawing.Size(210, 24);
-            this.comboBoxChannelPresets.TabIndex = 26;
+            this.comboBoxChannelPresets.TabIndex = 7;
             // 
             // buttonResetZoom
             // 
@@ -487,7 +490,7 @@
             this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
             this.buttonResetZoom.Size = new System.Drawing.Size(299, 44);
-            this.buttonResetZoom.TabIndex = 22;
+            this.buttonResetZoom.TabIndex = 10;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.buttonResetZoom.UseVisualStyleBackColor = true;
             this.buttonResetZoom.Click += new System.EventHandler(this.ResetZoom_Click);
@@ -499,7 +502,7 @@
             this.checkBoxSpikeFilter.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxSpikeFilter.Name = "checkBoxSpikeFilter";
             this.checkBoxSpikeFilter.Size = new System.Drawing.Size(77, 20);
-            this.checkBoxSpikeFilter.TabIndex = 14;
+            this.checkBoxSpikeFilter.TabIndex = 4;
             this.checkBoxSpikeFilter.Text = "Enabled";
             this.checkBoxSpikeFilter.UseVisualStyleBackColor = true;
             // 
@@ -510,8 +513,10 @@
             this.textBoxAdcCalibrationFile.Location = new System.Drawing.Point(13, 30);
             this.textBoxAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxAdcCalibrationFile.Name = "textBoxAdcCalibrationFile";
+            this.textBoxAdcCalibrationFile.ReadOnly = true;
             this.textBoxAdcCalibrationFile.Size = new System.Drawing.Size(255, 22);
             this.textBoxAdcCalibrationFile.TabIndex = 12;
+            this.textBoxAdcCalibrationFile.TabStop = false;
             this.textBoxAdcCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.textBoxAdcCalibrationFile.TextChanged += new System.EventHandler(this.AdcCalibrationFileTextChanged);
             // 
@@ -522,8 +527,10 @@
             this.textBoxGainCalibrationFile.Location = new System.Drawing.Point(13, 133);
             this.textBoxGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxGainCalibrationFile.Name = "textBoxGainCalibrationFile";
+            this.textBoxGainCalibrationFile.ReadOnly = true;
             this.textBoxGainCalibrationFile.Size = new System.Drawing.Size(255, 22);
             this.textBoxGainCalibrationFile.TabIndex = 9;
+            this.textBoxGainCalibrationFile.TabStop = false;
             this.textBoxGainCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.textBoxGainCalibrationFile.TextChanged += new System.EventHandler(this.GainCalibrationFileTextChanged);
             // 
@@ -537,7 +544,7 @@
             this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
             this.comboBoxReference.Size = new System.Drawing.Size(210, 24);
-            this.comboBoxReference.TabIndex = 5;
+            this.comboBoxReference.TabIndex = 6;
             // 
             // comboBoxLfpGain
             // 
@@ -561,7 +568,7 @@
             this.comboBoxApGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxApGain.Name = "comboBoxApGain";
             this.comboBoxApGain.Size = new System.Drawing.Size(210, 24);
-            this.comboBoxApGain.TabIndex = 1;
+            this.comboBoxApGain.TabIndex = 2;
             // 
             // flowLayoutPanel1
             // 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
@@ -49,14 +49,14 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(1139, 26);
+            this.menuStrip.Size = new System.Drawing.Size(1139, 24);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tabControlProbe
@@ -66,8 +66,9 @@
             this.tabControlProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControlProbe.Name = "tabControlProbe";
             this.tabControlProbe.SelectedIndex = 0;
-            this.tabControlProbe.Size = new System.Drawing.Size(1133, 632);
+            this.tabControlProbe.Size = new System.Drawing.Size(1133, 634);
             this.tabControlProbe.TabIndex = 1;
+            this.tabControlProbe.TabStop = false;
             // 
             // buttonCancel
             // 
@@ -99,13 +100,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControlProbe, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 49F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1139, 685);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1139, 687);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -114,8 +115,8 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 640);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 642);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1131, 41);
             this.flowLayoutPanel1.TabIndex = 2;

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
@@ -80,14 +80,14 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1151, 26);
+            this.menuStrip1.Size = new System.Drawing.Size(1151, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -97,13 +97,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1151, 623);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1151, 625);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // tabControl1
@@ -115,8 +115,9 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1145, 577);
+            this.tabControl1.Size = new System.Drawing.Size(1145, 579);
             this.tabControl1.TabIndex = 0;
+            this.tabControl1.TabStop = false;
             // 
             // tabPageNeuropixelsV2e
             // 
@@ -125,7 +126,7 @@
             this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageNeuropixelsV2e.Name = "tabPageNeuropixelsV2e";
             this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(1137, 548);
+            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(1137, 550);
             this.tabPageNeuropixelsV2e.TabIndex = 0;
             this.tabPageNeuropixelsV2e.Text = "NeuropixelsV2e";
             this.tabPageNeuropixelsV2e.UseVisualStyleBackColor = true;
@@ -136,7 +137,7 @@
             this.panelNeuropixelsV2e.Location = new System.Drawing.Point(3, 2);
             this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV2e.Name = "panelNeuropixelsV2e";
-            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(1131, 544);
+            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(1131, 546);
             this.panelNeuropixelsV2e.TabIndex = 0;
             // 
             // tabPageBno055
@@ -146,7 +147,7 @@
             this.tabPageBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageBno055.Name = "tabPageBno055";
             this.tabPageBno055.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageBno055.Size = new System.Drawing.Size(1137, 541);
+            this.tabPageBno055.Size = new System.Drawing.Size(1137, 548);
             this.tabPageBno055.TabIndex = 1;
             this.tabPageBno055.Text = "Bno055";
             this.tabPageBno055.UseVisualStyleBackColor = true;
@@ -158,7 +159,7 @@
             this.panelBno055.Location = new System.Drawing.Point(3, 2);
             this.panelBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(1131, 537);
+            this.panelBno055.Size = new System.Drawing.Size(1131, 544);
             this.panelBno055.TabIndex = 0;
             // 
             // flowLayoutPanel1
@@ -169,8 +170,8 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 585);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 587);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1143, 34);
             this.flowLayoutPanel1.TabIndex = 1;

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
@@ -49,6 +49,7 @@
             this.panelTrackBar = new System.Windows.Forms.Panel();
             this.trackBarProbePosition = new System.Windows.Forms.TrackBar();
             this.panelChannelOptions = new System.Windows.Forms.Panel();
+            this.checkBoxInvertPolarity = new System.Windows.Forms.CheckBox();
             this.textBoxGainCorrection = new System.Windows.Forms.TextBox();
             this.textBoxProbeCalibrationFile = new System.Windows.Forms.TextBox();
             this.comboBoxReference = new System.Windows.Forms.ComboBox();
@@ -59,7 +60,6 @@
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripGainCalSN = new System.Windows.Forms.ToolStripStatusLabel();
-            this.checkBoxInvertPolarity = new System.Windows.Forms.CheckBox();
             label6 = new System.Windows.Forms.Label();
             label7 = new System.Windows.Forms.Label();
             probeCalibrationFile = new System.Windows.Forms.Label();
@@ -81,10 +81,9 @@
             // 
             label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             label6.AutoSize = true;
-            label6.Location = new System.Drawing.Point(0, 440);
-            label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label6.Location = new System.Drawing.Point(0, 542);
             label6.Name = "label6";
-            label6.Size = new System.Drawing.Size(32, 13);
+            label6.Size = new System.Drawing.Size(39, 16);
             label6.TabIndex = 28;
             label6.Text = "0 mm";
             // 
@@ -93,9 +92,8 @@
             label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             label7.AutoSize = true;
             label7.Location = new System.Drawing.Point(0, 0);
-            label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             label7.Name = "label7";
-            label7.Size = new System.Drawing.Size(38, 13);
+            label7.Size = new System.Drawing.Size(46, 16);
             label7.TabIndex = 29;
             label7.Text = "10 mm";
             label7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -103,43 +101,48 @@
             // probeCalibrationFile
             // 
             probeCalibrationFile.AutoSize = true;
-            probeCalibrationFile.Location = new System.Drawing.Point(11, 9);
-            probeCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            probeCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            probeCalibrationFile.Location = new System.Drawing.Point(15, 11);
+            probeCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             probeCalibrationFile.Name = "probeCalibrationFile";
-            probeCalibrationFile.Size = new System.Drawing.Size(109, 13);
+            probeCalibrationFile.Size = new System.Drawing.Size(139, 16);
             probeCalibrationFile.TabIndex = 32;
             probeCalibrationFile.Text = "Probe Calibration File:";
             // 
             // Reference
             // 
             Reference.AutoSize = true;
-            Reference.Location = new System.Drawing.Point(11, 93);
-            Reference.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            Reference.Location = new System.Drawing.Point(15, 114);
             Reference.Name = "Reference";
-            Reference.Size = new System.Drawing.Size(60, 13);
+            Reference.Size = new System.Drawing.Size(73, 16);
             Reference.TabIndex = 30;
             Reference.Text = "Reference:";
             // 
             // labelPresets
             // 
             labelPresets.AutoSize = true;
-            labelPresets.Location = new System.Drawing.Point(11, 119);
-            labelPresets.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            labelPresets.Location = new System.Drawing.Point(15, 146);
             labelPresets.Name = "labelPresets";
-            labelPresets.Size = new System.Drawing.Size(49, 26);
+            labelPresets.Size = new System.Drawing.Size(59, 32);
             labelPresets.TabIndex = 23;
             labelPresets.Text = "Channel \nPresets:";
             // 
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(11, 51);
-            label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label1.Location = new System.Drawing.Point(15, 63);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(58, 26);
+            label1.Size = new System.Drawing.Size(71, 32);
             label1.TabIndex = 35;
             label1.Text = "Gain\r\nCorrection:";
+            // 
+            // invertPolarity
+            // 
+            invertPolarity.AutoSize = true;
+            invertPolarity.Location = new System.Drawing.Point(15, 187);
+            invertPolarity.Name = "invertPolarity";
+            invertPolarity.Size = new System.Drawing.Size(55, 32);
+            invertPolarity.TabIndex = 44;
+            invertPolarity.Text = "Invert\r\nPolarity:";
             // 
             // toolStripLabelGainCalibrationSN
             // 
@@ -157,8 +160,8 @@
             this.fileToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(834, 24);
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip.Size = new System.Drawing.Size(1112, 24);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
@@ -172,11 +175,11 @@
             // 
             this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(11, 184);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonEnableContacts.Location = new System.Drawing.Point(15, 226);
+            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(183, 36);
-            this.buttonEnableContacts.TabIndex = 20;
+            this.buttonEnableContacts.Size = new System.Drawing.Size(243, 44);
+            this.buttonEnableContacts.TabIndex = 4;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select electrodes in the probe view. \r\nPress this button to ena" +
         "ble the selected electrodes. \r\nNot all electrode combinations are possible.");
@@ -187,11 +190,11 @@
             // 
             this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(11, 224);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonClearSelections.Location = new System.Drawing.Point(15, 276);
+            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(183, 36);
-            this.buttonClearSelections.TabIndex = 19;
+            this.buttonClearSelections.Size = new System.Drawing.Size(243, 44);
+            this.buttonClearSelections.TabIndex = 5;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.toolTip.SetToolTip(this.buttonClearSelections, "Deselect all electrodes in the probe view. \r\nNote that this does not disable elec" +
         "trodes, but simply deselects them.");
@@ -202,11 +205,11 @@
             // 
             this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(11, 264);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonResetZoom.Location = new System.Drawing.Point(15, 325);
+            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(183, 36);
-            this.buttonResetZoom.TabIndex = 4;
+            this.buttonResetZoom.Size = new System.Drawing.Size(243, 44);
+            this.buttonResetZoom.TabIndex = 6;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.");
             this.buttonResetZoom.UseVisualStyleBackColor = true;
@@ -215,11 +218,11 @@
             // buttonChooseCalibrationFile
             // 
             this.buttonChooseCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(166, 24);
-            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(220, 30);
+            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseCalibrationFile.Name = "buttonChooseCalibrationFile";
-            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(28, 20);
-            this.buttonChooseCalibrationFile.TabIndex = 34;
+            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(37, 25);
+            this.buttonChooseCalibrationFile.TabIndex = 0;
             this.buttonChooseCalibrationFile.Text = "...";
             this.toolTip.SetToolTip(this.buttonChooseCalibrationFile, "Browse for a gain calibration file.");
             this.buttonChooseCalibrationFile.UseVisualStyleBackColor = true;
@@ -230,10 +233,10 @@
             this.panelProbe.AutoSize = true;
             this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(2, 2);
-            this.panelProbe.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelProbe.Location = new System.Drawing.Point(3, 2);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(621, 443);
+            this.panelProbe.Size = new System.Drawing.Size(828, 557);
             this.panelProbe.TabIndex = 1;
             // 
             // panelTrackBar
@@ -242,9 +245,10 @@
             this.panelTrackBar.Controls.Add(label6);
             this.panelTrackBar.Controls.Add(label7);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(581, -5);
+            this.panelTrackBar.Location = new System.Drawing.Point(775, 0);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(37, 454);
+            this.panelTrackBar.Size = new System.Drawing.Size(49, 559);
             this.panelTrackBar.TabIndex = 30;
             // 
             // trackBarProbePosition
@@ -252,13 +256,14 @@
             this.trackBarProbePosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBarProbePosition.AutoSize = false;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(-6, 9);
-            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(-8, 11);
+            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(37, 435);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(49, 535);
             this.trackBarProbePosition.TabIndex = 22;
+            this.trackBarProbePosition.TabStop = false;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
             this.trackBarProbePosition.Value = 50;
@@ -284,21 +289,32 @@
             this.panelChannelOptions.Controls.Add(this.buttonClearSelections);
             this.panelChannelOptions.Controls.Add(this.buttonResetZoom);
             this.panelChannelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelChannelOptions.Location = new System.Drawing.Point(627, 2);
-            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelChannelOptions.Location = new System.Drawing.Point(837, 2);
+            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelChannelOptions.Name = "panelChannelOptions";
-            this.panelChannelOptions.Size = new System.Drawing.Size(205, 443);
+            this.panelChannelOptions.Size = new System.Drawing.Size(272, 557);
             this.panelChannelOptions.TabIndex = 1;
+            // 
+            // checkBoxInvertPolarity
+            // 
+            this.checkBoxInvertPolarity.AutoSize = true;
+            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(107, 193);
+            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
+            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(77, 20);
+            this.checkBoxInvertPolarity.TabIndex = 3;
+            this.checkBoxInvertPolarity.Text = "Enabled";
+            this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
             // 
             // textBoxGainCorrection
             // 
             this.textBoxGainCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxGainCorrection.Location = new System.Drawing.Point(80, 55);
-            this.textBoxGainCorrection.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxGainCorrection.Location = new System.Drawing.Point(107, 68);
+            this.textBoxGainCorrection.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxGainCorrection.Name = "textBoxGainCorrection";
             this.textBoxGainCorrection.ReadOnly = true;
-            this.textBoxGainCorrection.Size = new System.Drawing.Size(115, 20);
+            this.textBoxGainCorrection.Size = new System.Drawing.Size(151, 22);
             this.textBoxGainCorrection.TabIndex = 36;
             this.textBoxGainCorrection.TabStop = false;
             // 
@@ -306,11 +322,13 @@
             // 
             this.textBoxProbeCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(11, 24);
-            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(15, 30);
+            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxProbeCalibrationFile.Name = "textBoxProbeCalibrationFile";
-            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(150, 20);
+            this.textBoxProbeCalibrationFile.ReadOnly = true;
+            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(198, 22);
             this.textBoxProbeCalibrationFile.TabIndex = 33;
+            this.textBoxProbeCalibrationFile.TabStop = false;
             this.textBoxProbeCalibrationFile.TextChanged += new System.EventHandler(this.FileTextChanged);
             // 
             // comboBoxReference
@@ -319,11 +337,11 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxReference.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxReference.FormattingEnabled = true;
-            this.comboBoxReference.Location = new System.Drawing.Point(80, 89);
-            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.comboBoxReference.Location = new System.Drawing.Point(107, 110);
+            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
-            this.comboBoxReference.Size = new System.Drawing.Size(115, 21);
-            this.comboBoxReference.TabIndex = 31;
+            this.comboBoxReference.Size = new System.Drawing.Size(151, 24);
+            this.comboBoxReference.TabIndex = 1;
             // 
             // comboBoxChannelPresets
             // 
@@ -331,21 +349,21 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxChannelPresets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxChannelPresets.FormattingEnabled = true;
-            this.comboBoxChannelPresets.Location = new System.Drawing.Point(80, 122);
-            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.comboBoxChannelPresets.Location = new System.Drawing.Point(107, 150);
+            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
-            this.comboBoxChannelPresets.Size = new System.Drawing.Size(115, 21);
-            this.comboBoxChannelPresets.TabIndex = 24;
+            this.comboBoxChannelPresets.Size = new System.Drawing.Size(151, 24);
+            this.comboBoxChannelPresets.TabIndex = 2;
             // 
             // buttonCancel
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(743, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(990, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 28);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -355,10 +373,10 @@
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonOkay.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOkay.Location = new System.Drawing.Point(656, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonOkay.Location = new System.Drawing.Point(873, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 28);
+            this.buttonOkay.Size = new System.Drawing.Size(111, 34);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
@@ -375,13 +393,14 @@
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 16F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(834, 484);
-            this.tableLayoutPanel1.TabIndex = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 46F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1112, 607);
+            this.tableLayoutPanel1.TabIndex = 0;
             // 
             // flowLayoutPanel1
             // 
@@ -390,9 +409,10 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 450);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 565);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(828, 31);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1104, 38);
             this.flowLayoutPanel1.TabIndex = 2;
             // 
             // statusStrip1
@@ -401,10 +421,10 @@
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabelGainCalibrationSN,
             this.toolStripGainCalSN});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 508);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 631);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 10, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(834, 25);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 13, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1112, 25);
             this.statusStrip1.TabIndex = 3;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -415,39 +435,18 @@
             this.toolStripGainCalSN.Text = "No file selected.";
             this.toolStripGainCalSN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // checkBoxInvertPolarity
-            // 
-            this.checkBoxInvertPolarity.AutoSize = true;
-            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(80, 157);
-            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(2);
-            this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
-            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(65, 17);
-            this.checkBoxInvertPolarity.TabIndex = 45;
-            this.checkBoxInvertPolarity.Text = "Enabled";
-            this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
-            // 
-            // invertPolarity
-            // 
-            invertPolarity.AutoSize = true;
-            invertPolarity.Location = new System.Drawing.Point(11, 152);
-            invertPolarity.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            invertPolarity.Name = "invertPolarity";
-            invertPolarity.Size = new System.Drawing.Size(44, 26);
-            invertPolarity.TabIndex = 44;
-            invertPolarity.Text = "Invert\r\nPolarity:";
-            // 
             // NeuropixelsV2eProbeConfigurationDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(834, 533);
+            this.ClientSize = new System.Drawing.Size(1112, 656);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.menuStrip);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip;
-            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV2eProbeConfigurationDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Probe Configuration";

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.Designer.cs
@@ -38,11 +38,13 @@
             this.panelParameters = new System.Windows.Forms.Panel();
             this.textBoxStepSize = new System.Windows.Forms.TextBox();
             this.groupBoxCathode = new System.Windows.Forms.GroupBox();
+            this.textboxAmplitudeCathodic = new System.Windows.Forms.TextBox();
             this.labelAmplitudeCathodic = new System.Windows.Forms.Label();
             this.labelPulseWidthCathodic = new System.Windows.Forms.Label();
             this.textboxPulseWidthCathodic = new System.Windows.Forms.TextBox();
             this.textboxAmplitudeCathodicRequested = new System.Windows.Forms.TextBox();
             this.groupBoxAnode = new System.Windows.Forms.GroupBox();
+            this.textboxAmplitudeAnodic = new System.Windows.Forms.TextBox();
             this.labelAmplitudeAnodic = new System.Windows.Forms.Label();
             this.labelPulseWidthAnodic = new System.Windows.Forms.Label();
             this.textboxPulseWidthAnodic = new System.Windows.Forms.TextBox();
@@ -76,8 +78,6 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.textboxAmplitudeAnodic = new System.Windows.Forms.TextBox();
-            this.textboxAmplitudeCathodic = new System.Windows.Forms.TextBox();
             this.statusStrip.SuspendLayout();
             this.panelParameters.SuspendLayout();
             this.groupBoxCathode.SuspendLayout();
@@ -100,7 +100,7 @@
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(144, 32);
-            this.buttonCancel.TabIndex = 0;
+            this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
             // 
@@ -126,14 +126,14 @@
             this.toolStripStatusIsValid.Image = global::OpenEphys.Onix1.Design.Properties.Resources.StatusReadyImage;
             this.toolStripStatusIsValid.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.toolStripStatusIsValid.Name = "toolStripStatusIsValid";
-            this.toolStripStatusIsValid.Size = new System.Drawing.Size(186, 20);
+            this.toolStripStatusIsValid.Size = new System.Drawing.Size(153, 21);
             this.toolStripStatusIsValid.Text = "Valid stimulus sequence";
             this.toolStripStatusIsValid.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // toolStripStatusSlotsUsed
             // 
             this.toolStripStatusSlotsUsed.Name = "toolStripStatusSlotsUsed";
-            this.toolStripStatusSlotsUsed.Size = new System.Drawing.Size(132, 20);
+            this.toolStripStatusSlotsUsed.Size = new System.Drawing.Size(104, 21);
             this.toolStripStatusSlotsUsed.Text = "100% of slots used";
             this.toolStripStatusSlotsUsed.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -144,7 +144,7 @@
             this.buttonOk.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOk.Name = "buttonOk";
             this.buttonOk.Size = new System.Drawing.Size(144, 32);
-            this.buttonOk.TabIndex = 4;
+            this.buttonOk.TabIndex = 0;
             this.buttonOk.Text = "OK";
             this.buttonOk.UseVisualStyleBackColor = true;
             this.buttonOk.Click += new System.EventHandler(this.ButtonOk_Click);
@@ -175,6 +175,7 @@
             this.panelParameters.Name = "panelParameters";
             this.panelParameters.Size = new System.Drawing.Size(439, 285);
             this.panelParameters.TabIndex = 0;
+            this.panelParameters.TabStop = true;
             // 
             // textBoxStepSize
             // 
@@ -199,10 +200,20 @@
             this.groupBoxCathode.Name = "groupBoxCathode";
             this.groupBoxCathode.Padding = new System.Windows.Forms.Padding(4);
             this.groupBoxCathode.Size = new System.Drawing.Size(195, 101);
-            this.groupBoxCathode.TabIndex = 3;
+            this.groupBoxCathode.TabIndex = 5;
             this.groupBoxCathode.TabStop = false;
             this.groupBoxCathode.Text = "Cathode";
             this.groupBoxCathode.Visible = false;
+            // 
+            // textboxAmplitudeCathodic
+            // 
+            this.textboxAmplitudeCathodic.Location = new System.Drawing.Point(132, 39);
+            this.textboxAmplitudeCathodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.textboxAmplitudeCathodic.Name = "textboxAmplitudeCathodic";
+            this.textboxAmplitudeCathodic.ReadOnly = true;
+            this.textboxAmplitudeCathodic.Size = new System.Drawing.Size(55, 22);
+            this.textboxAmplitudeCathodic.TabIndex = 9;
+            this.textboxAmplitudeCathodic.TabStop = false;
             // 
             // labelAmplitudeCathodic
             // 
@@ -228,7 +239,7 @@
             this.textboxPulseWidthCathodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxPulseWidthCathodic.Name = "textboxPulseWidthCathodic";
             this.textboxPulseWidthCathodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxPulseWidthCathodic.TabIndex = 6;
+            this.textboxPulseWidthCathodic.TabIndex = 2;
             this.textboxPulseWidthCathodic.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ParameterKeyPress_Time);
             this.textboxPulseWidthCathodic.Leave += new System.EventHandler(this.Samples_TextChanged);
             // 
@@ -238,7 +249,7 @@
             this.textboxAmplitudeCathodicRequested.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxAmplitudeCathodicRequested.Name = "textboxAmplitudeCathodicRequested";
             this.textboxAmplitudeCathodicRequested.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeCathodicRequested.TabIndex = 5;
+            this.textboxAmplitudeCathodicRequested.TabIndex = 1;
             this.textboxAmplitudeCathodicRequested.Leave += new System.EventHandler(this.Amplitude_TextChanged);
             // 
             // groupBoxAnode
@@ -253,9 +264,19 @@
             this.groupBoxAnode.Name = "groupBoxAnode";
             this.groupBoxAnode.Padding = new System.Windows.Forms.Padding(4);
             this.groupBoxAnode.Size = new System.Drawing.Size(195, 101);
-            this.groupBoxAnode.TabIndex = 2;
+            this.groupBoxAnode.TabIndex = 4;
             this.groupBoxAnode.TabStop = false;
             this.groupBoxAnode.Text = "Anode";
+            // 
+            // textboxAmplitudeAnodic
+            // 
+            this.textboxAmplitudeAnodic.Location = new System.Drawing.Point(129, 39);
+            this.textboxAmplitudeAnodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.textboxAmplitudeAnodic.Name = "textboxAmplitudeAnodic";
+            this.textboxAmplitudeAnodic.ReadOnly = true;
+            this.textboxAmplitudeAnodic.Size = new System.Drawing.Size(55, 22);
+            this.textboxAmplitudeAnodic.TabIndex = 8;
+            this.textboxAmplitudeAnodic.TabStop = false;
             // 
             // labelAmplitudeAnodic
             // 
@@ -281,7 +302,7 @@
             this.textboxPulseWidthAnodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxPulseWidthAnodic.Name = "textboxPulseWidthAnodic";
             this.textboxPulseWidthAnodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxPulseWidthAnodic.TabIndex = 4;
+            this.textboxPulseWidthAnodic.TabIndex = 3;
             this.textboxPulseWidthAnodic.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ParameterKeyPress_Time);
             this.textboxPulseWidthAnodic.Leave += new System.EventHandler(this.Samples_TextChanged);
             // 
@@ -291,7 +312,7 @@
             this.textboxAmplitudeAnodicRequested.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxAmplitudeAnodicRequested.Name = "textboxAmplitudeAnodicRequested";
             this.textboxAmplitudeAnodicRequested.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeAnodicRequested.TabIndex = 3;
+            this.textboxAmplitudeAnodicRequested.TabIndex = 2;
             this.textboxAmplitudeAnodicRequested.Leave += new System.EventHandler(this.Amplitude_TextChanged);
             // 
             // buttonClearPulses
@@ -301,8 +322,7 @@
             this.buttonClearPulses.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearPulses.Name = "buttonClearPulses";
             this.buttonClearPulses.Size = new System.Drawing.Size(99, 34);
-            this.buttonClearPulses.TabIndex = 7;
-            this.buttonClearPulses.TabStop = false;
+            this.buttonClearPulses.TabIndex = 8;
             this.buttonClearPulses.Text = "Clear";
             this.toolTip1.SetToolTip(this.buttonClearPulses, "Removes the settings for all selected contacts. If no contacts are selected, this" +
         " will clear the parameters for all contacts.");
@@ -316,8 +336,7 @@
             this.buttonReadPulses.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonReadPulses.Name = "buttonReadPulses";
             this.buttonReadPulses.Size = new System.Drawing.Size(100, 34);
-            this.buttonReadPulses.TabIndex = 8;
-            this.buttonReadPulses.TabStop = false;
+            this.buttonReadPulses.TabIndex = 9;
             this.buttonReadPulses.Text = "Read";
             this.toolTip1.SetToolTip(this.buttonReadPulses, "If a single contact is selected, this will read the current settings for that con" +
         "tact and display in the parameters. Useful for copying settings from one channel" +
@@ -331,7 +350,7 @@
             this.textboxInterPulseInterval.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxInterPulseInterval.Name = "textboxInterPulseInterval";
             this.textboxInterPulseInterval.Size = new System.Drawing.Size(55, 22);
-            this.textboxInterPulseInterval.TabIndex = 1;
+            this.textboxInterPulseInterval.TabIndex = 3;
             this.textboxInterPulseInterval.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ParameterKeyPress_Time);
             this.textboxInterPulseInterval.Leave += new System.EventHandler(this.Samples_TextChanged);
             // 
@@ -362,9 +381,8 @@
             this.checkBoxAnodicFirst.Location = new System.Drawing.Point(91, 33);
             this.checkBoxAnodicFirst.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxAnodicFirst.Name = "checkBoxAnodicFirst";
-            this.checkBoxAnodicFirst.Size = new System.Drawing.Size(99, 20);
-            this.checkBoxAnodicFirst.TabIndex = 16;
-            this.checkBoxAnodicFirst.TabStop = false;
+            this.checkBoxAnodicFirst.Size = new System.Drawing.Size(96, 20);
+            this.checkBoxAnodicFirst.TabIndex = 1;
             this.checkBoxAnodicFirst.Text = "Anodic First";
             this.checkBoxAnodicFirst.UseVisualStyleBackColor = true;
             this.checkBoxAnodicFirst.CheckedChanged += new System.EventHandler(this.Checkbox_CheckedChanged);
@@ -376,7 +394,7 @@
             this.buttonAddPulses.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonAddPulses.Name = "buttonAddPulses";
             this.buttonAddPulses.Size = new System.Drawing.Size(100, 34);
-            this.buttonAddPulses.TabIndex = 6;
+            this.buttonAddPulses.TabIndex = 10;
             this.buttonAddPulses.Text = "Apply";
             this.toolTip1.SetToolTip(this.buttonAddPulses, "Applies the currently chosen parameters to all selected contacts. If no contacts " +
         "are selected, this will apply the settings to all contacts.");
@@ -389,7 +407,7 @@
             this.textboxDelay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxDelay.Name = "textboxDelay";
             this.textboxDelay.Size = new System.Drawing.Size(55, 22);
-            this.textboxDelay.TabIndex = 0;
+            this.textboxDelay.TabIndex = 2;
             this.textboxDelay.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ParameterKeyPress_Time);
             this.textboxDelay.Leave += new System.EventHandler(this.Samples_TextChanged);
             // 
@@ -417,7 +435,7 @@
             this.textboxNumberOfStimuli.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxNumberOfStimuli.Name = "textboxNumberOfStimuli";
             this.textboxNumberOfStimuli.Size = new System.Drawing.Size(55, 22);
-            this.textboxNumberOfStimuli.TabIndex = 5;
+            this.textboxNumberOfStimuli.TabIndex = 7;
             // 
             // checkboxBiphasicSymmetrical
             // 
@@ -428,9 +446,8 @@
             this.checkboxBiphasicSymmetrical.Location = new System.Drawing.Point(43, 14);
             this.checkboxBiphasicSymmetrical.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkboxBiphasicSymmetrical.Name = "checkboxBiphasicSymmetrical";
-            this.checkboxBiphasicSymmetrical.Size = new System.Drawing.Size(147, 20);
-            this.checkboxBiphasicSymmetrical.TabIndex = 5;
-            this.checkboxBiphasicSymmetrical.TabStop = false;
+            this.checkboxBiphasicSymmetrical.Size = new System.Drawing.Size(144, 20);
+            this.checkboxBiphasicSymmetrical.TabIndex = 0;
             this.checkboxBiphasicSymmetrical.Text = "Biphasic Symmetric";
             this.checkboxBiphasicSymmetrical.UseVisualStyleBackColor = true;
             this.checkboxBiphasicSymmetrical.CheckedChanged += new System.EventHandler(this.Checkbox_CheckedChanged);
@@ -441,7 +458,7 @@
             this.textboxInterStimulusInterval.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textboxInterStimulusInterval.Name = "textboxInterStimulusInterval";
             this.textboxInterStimulusInterval.Size = new System.Drawing.Size(55, 22);
-            this.textboxInterStimulusInterval.TabIndex = 4;
+            this.textboxInterStimulusInterval.TabIndex = 6;
             this.textboxInterStimulusInterval.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ParameterKeyPress_Time);
             this.textboxInterStimulusInterval.Leave += new System.EventHandler(this.Samples_TextChanged);
             // 
@@ -464,7 +481,7 @@
             this.tabControlVisualization.Name = "tabControlVisualization";
             this.tableLayoutPanel1.SetRowSpan(this.tabControlVisualization, 2);
             this.tabControlVisualization.SelectedIndex = 0;
-            this.tabControlVisualization.Size = new System.Drawing.Size(1090, 675);
+            this.tabControlVisualization.Size = new System.Drawing.Size(1090, 679);
             this.tabControlVisualization.TabIndex = 6;
             // 
             // tabPageWaveform
@@ -474,7 +491,7 @@
             this.tabPageWaveform.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageWaveform.Name = "tabPageWaveform";
             this.tabPageWaveform.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageWaveform.Size = new System.Drawing.Size(1082, 646);
+            this.tabPageWaveform.Size = new System.Drawing.Size(1082, 650);
             this.tabPageWaveform.TabIndex = 0;
             this.tabPageWaveform.Text = "Stimulus Waveform";
             this.tabPageWaveform.UseVisualStyleBackColor = true;
@@ -492,8 +509,9 @@
             this.zedGraphWaveform.ScrollMinX = 0D;
             this.zedGraphWaveform.ScrollMinY = 0D;
             this.zedGraphWaveform.ScrollMinY2 = 0D;
-            this.zedGraphWaveform.Size = new System.Drawing.Size(1076, 642);
+            this.zedGraphWaveform.Size = new System.Drawing.Size(1076, 646);
             this.zedGraphWaveform.TabIndex = 4;
+            this.zedGraphWaveform.TabStop = false;
             this.zedGraphWaveform.UseExtendedPrintDialog = true;
             // 
             // tabPageTable
@@ -503,7 +521,7 @@
             this.tabPageTable.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageTable.Name = "tabPageTable";
             this.tabPageTable.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageTable.Size = new System.Drawing.Size(1082, 644);
+            this.tabPageTable.Size = new System.Drawing.Size(1082, 650);
             this.tabPageTable.TabIndex = 1;
             this.tabPageTable.Text = "Table";
             this.tabPageTable.UseVisualStyleBackColor = true;
@@ -521,8 +539,9 @@
             this.dataGridViewStimulusTable.Name = "dataGridViewStimulusTable";
             this.dataGridViewStimulusTable.RowHeadersWidth = 62;
             this.dataGridViewStimulusTable.RowTemplate.Height = 28;
-            this.dataGridViewStimulusTable.Size = new System.Drawing.Size(1076, 640);
+            this.dataGridViewStimulusTable.Size = new System.Drawing.Size(1076, 646);
             this.dataGridViewStimulusTable.TabIndex = 0;
+            this.dataGridViewStimulusTable.TabStop = false;
             this.dataGridViewStimulusTable.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.DataGridViewStimulusTable_CellEndEdit);
             this.dataGridViewStimulusTable.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.DataGridViewStimulusTable_DataBindingComplete);
             this.dataGridViewStimulusTable.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.DataGridViewStimulusTable_DataError);
@@ -533,7 +552,7 @@
             this.panelProbe.Location = new System.Drawing.Point(1099, 2);
             this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(445, 367);
+            this.panelProbe.Size = new System.Drawing.Size(445, 371);
             this.panelProbe.TabIndex = 0;
             // 
             // menuStrip
@@ -544,7 +563,7 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 2, 0, 2);
-            this.menuStrip.Size = new System.Drawing.Size(1547, 28);
+            this.menuStrip.Size = new System.Drawing.Size(1547, 24);
             this.menuStrip.TabIndex = 7;
             this.menuStrip.Text = "menuStrip1";
             // 
@@ -553,7 +572,7 @@
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.stimulusWaveformToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // stimulusWaveformToolStripMenuItem
@@ -562,20 +581,20 @@
             this.openFileToolStripMenuItem,
             this.saveFileToolStripMenuItem});
             this.stimulusWaveformToolStripMenuItem.Name = "stimulusWaveformToolStripMenuItem";
-            this.stimulusWaveformToolStripMenuItem.Size = new System.Drawing.Size(220, 26);
+            this.stimulusWaveformToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.stimulusWaveformToolStripMenuItem.Text = "Stimulus Waveform";
             // 
             // openFileToolStripMenuItem
             // 
             this.openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
-            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(155, 26);
+            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.openFileToolStripMenuItem.Text = "Open File";
             this.openFileToolStripMenuItem.Click += new System.EventHandler(this.MenuItemLoadFile_Click);
             // 
             // saveFileToolStripMenuItem
             // 
             this.saveFileToolStripMenuItem.Name = "saveFileToolStripMenuItem";
-            this.saveFileToolStripMenuItem.Size = new System.Drawing.Size(155, 26);
+            this.saveFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveFileToolStripMenuItem.Text = "Save File";
             this.saveFileToolStripMenuItem.Click += new System.EventHandler(this.MenuItemSaveFile_Click);
             // 
@@ -589,21 +608,21 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControlVisualization, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 28);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 308F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1547, 721);
-            this.tableLayoutPanel1.TabIndex = 8;
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1547, 725);
+            this.tableLayoutPanel1.TabIndex = 0;
             // 
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.panelParameters);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Location = new System.Drawing.Point(1099, 373);
+            this.groupBox1.Location = new System.Drawing.Point(1099, 377);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
@@ -619,29 +638,11 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOk);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 681);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 685);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1541, 38);
-            this.flowLayoutPanel1.TabIndex = 7;
-            // 
-            // textboxAmplitudeAnodic
-            // 
-            this.textboxAmplitudeAnodic.Location = new System.Drawing.Point(129, 39);
-            this.textboxAmplitudeAnodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.textboxAmplitudeAnodic.Name = "textboxAmplitudeAnodic";
-            this.textboxAmplitudeAnodic.ReadOnly = true;
-            this.textboxAmplitudeAnodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeAnodic.TabIndex = 8;
-            // 
-            // textboxAmplitudeCathodic
-            // 
-            this.textboxAmplitudeCathodic.Location = new System.Drawing.Point(132, 39);
-            this.textboxAmplitudeCathodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.textboxAmplitudeCathodic.Name = "textboxAmplitudeCathodic";
-            this.textboxAmplitudeCathodic.ReadOnly = true;
-            this.textboxAmplitudeCathodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeCathodic.TabIndex = 9;
+            this.flowLayoutPanel1.TabIndex = 1;
             // 
             // Rhs2116StimulusSequenceDialog
             // 


### PR DESCRIPTION
To make it easier to follow the flow of logic, when pressing <kbd>tab</kbd>, it now follows a logical flow from left-to-right, and top-to-bottom. This is true for all existing dialogs, and this pattern should be followed for all future dialogs added.

**Rhs2116**
![example_rhs2116](https://github.com/user-attachments/assets/2c457b5b-d39d-44e2-a1c4-c7e0561e806a)

**Neuropixels V1**
![example_npxv1](https://github.com/user-attachments/assets/891a175a-5888-43a4-8729-87e60b02e316)

**Neuropixels V2**
![example_npxv2](https://github.com/user-attachments/assets/cfb28228-fd1b-4e78-b633-b57df08c1d6c)

Fixes #290 