### PR TITLE
Invert stimulus waveform channel ordering

### DIFF
--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -263,7 +263,7 @@ namespace OpenEphys.Onix1.Design
 
             for (int i = 0; i < Sequence.Stimuli.Length; i++)
             {
-                var channelOffset = peakToPeak * i;
+                var channelOffset = -peakToPeak * i;
 
                 if (ChannelDialog.SelectedContacts[i] || plotAllContacts)
                 {
@@ -289,7 +289,7 @@ namespace OpenEphys.Onix1.Design
             }
 
             zedGraphWaveform.GraphPane.YAxis.Scale.MajorStep = 1;
-            zedGraphWaveform.GraphPane.YAxis.Scale.BaseTic = 0;
+            zedGraphWaveform.GraphPane.YAxis.Scale.BaseTic = -Sequence.Stimuli.Length + 1;
 
             HighlightInvalidContacts();
 
@@ -298,8 +298,13 @@ namespace OpenEphys.Onix1.Design
 
             zedGraphWaveform.GraphPane.XAxis.Scale.Max = maxLength;
             zedGraphWaveform.GraphPane.XAxis.Scale.Min = -(maxLength * 0.02);
-            zedGraphWaveform.GraphPane.YAxis.Scale.Min = -2;
-            zedGraphWaveform.GraphPane.YAxis.Scale.Max = Sequence.Stimuli.Length - 0.2;
+            zedGraphWaveform.GraphPane.YAxis.Scale.Min = -Sequence.Stimuli.Length - 2;
+            zedGraphWaveform.GraphPane.YAxis.Scale.Max =  1;
+
+            zedGraphWaveform.GraphPane.YAxis.ScaleFormatEvent += (GraphPane gp, Axis axis, double val, int index) =>
+            {
+                return Math.Abs(val).ToString("0");
+            };
 
             DrawScale();
 
@@ -1062,7 +1067,7 @@ namespace OpenEphys.Onix1.Design
             {
                 StepSize = validStepSizes.First();
                 textBoxStepSize.Text = GetStepSizeStringuA(StepSize);
-                
+
                 return true;
             }
 


### PR DESCRIPTION
This PR inverts the waveform channel ordering so that `0` is at the top and `31` is at the bottom:

<img width="1274" height="912" alt="image" src="https://github.com/user-attachments/assets/51710239-0556-493d-85db-97208d16d365" />

Selecting channels still plots the correct channel after the re-ordering:

<img width="1269" height="914" alt="image" src="https://github.com/user-attachments/assets/5211f767-12ed-439e-9b78-4ae7860d530c" />

Fixes #487 