### PR TITLE
Add Ground as reference option for Neuropixels 2.0 probes

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -200,6 +200,12 @@ namespace OpenEphys.Onix1
                 // configure probe A streaming
                 if (probeAMetadata.ProbeSerialNumber != null)
                 {
+                    if (ProbeConfigurationA.Reference == NeuropixelsV2QuadShankReference.Ground)
+                    {
+                        throw new InvalidOperationException($"Neuropixels 2.0-Beta probes do not provide a Ground reference selection. Please select a different reference" +
+                            $" for {NeuropixelsV2Probe.ProbeA}.");
+                    }
+
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(GainCalibrationFileA);
 
                     if (!gainCorrection.HasValue)
@@ -221,8 +227,14 @@ namespace OpenEphys.Onix1
                 }
 
                 // configure probe B streaming
-                if (probeAMetadata.ProbeSerialNumber != null)
+                if (probeBMetadata.ProbeSerialNumber != null)
                 {
+                    if (ProbeConfigurationB.Reference == NeuropixelsV2QuadShankReference.Ground)
+                    {
+                        throw new InvalidOperationException($"Neuropixels 2.0-Beta probes do not provide a Ground reference selection. Please select a different reference" +
+                            $" for {NeuropixelsV2Probe.ProbeB}.");
+                    }
+
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(GainCalibrationFileB);
 
                     if (!gainCorrection.HasValue)

--- a/OpenEphys.Onix1/NeuropixelsV2.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2.cs
@@ -99,6 +99,7 @@ namespace OpenEphys.Onix1
                 NeuropixelsV2QuadShankReference.Tip2 => 2,
                 NeuropixelsV2QuadShankReference.Tip3 => 2,
                 NeuropixelsV2QuadShankReference.Tip4 => 2,
+                NeuropixelsV2QuadShankReference.Ground => 3,
                 _ => throw new InvalidOperationException("Invalid reference selection."),
             };
 

--- a/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
@@ -34,7 +34,11 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Specifies that the tip reference of shank 4 will be used.
         /// </summary>
-        Tip4
+        Tip4,
+        /// <summary>
+        /// Specifies that the ground reference will be used.
+        /// </summary>
+        Ground
     }
 
     /// <summary>


### PR DESCRIPTION
Adds `Ground` as an option for the reference. This is added as part of the reference enum, and is propagated to the GUI drop-down menu.

Fixes #294 