### PR TITLE
Move Neuropixels XML comments to common interface

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -43,15 +43,13 @@ namespace OpenEphys.Onix1
             InvertPolarity = configureNeuropixelsV1e.InvertPolarity;
         }
 
-        /// <summary>
-        /// Gets or sets the device enable state.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// If set to true, <see cref="NeuropixelsV1eData"/> will produce data. If set to false, 
         /// <see cref="NeuropixelsV1eData"/> will not produce data.
         /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Specifies whether the Neuropixels data stream is enabled.")]
+        [Description("Specifies whether the NeuropixelsV1 device is enabled.")]
         public bool Enable { get; set; } = true;
 
         /// <summary>
@@ -61,74 +59,31 @@ namespace OpenEphys.Onix1
         /// If true, the headstage LED will turn on during data acquisition. If false, the LED will not turn on.
         /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("If true, the headstage LED will turn on during data acquisition. If false, the LED will not turn on.")]
+        [Description("Specifies whether the headstage LED will turn on during acquisition.")]
         public bool EnableLed { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets a value determining if the polarity of the electrode voltages acquired by the probe
-        /// should be inverted.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The analog channels on the probe ASIC have negative gain coefficients. This means that neural data
-        /// that is captured by the probe will be inverted compared to the physical signal that occurs at the
-        /// electrode: e.g. extracellular action potentials will tend to have positive deflections instead of
-        /// negative. Setting this property to true will apply a gain of -1 to neural data to undo this
-        /// effect.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [Category(ConfigurationCategory)]
         [Description("Invert the polarity of the electrode voltages acquired by the probe.")]
         public bool InvertPolarity { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets the path to the gain calibration file.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
-        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
-        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the 
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration 
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [FileNameFilter("Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv")]
         [Description("Path to the Neuropixels 1.0 gain calibration file.")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Category(ConfigurationCategory)]
         public string GainCalibrationFile { get; set; }
 
-        /// <summary>
-        /// Gets or sets the path to the ADC calibration file.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Each probe must be provided with an ADC calibration file that contains probe-specific hardware settings that is
-        /// created by IMEC during factory calibration. These files are used to set internal bias currents, correct for ADC
-        /// nonlinearities, correct ADC-zero crossing non-monotonicities, etc. Using the correct calibration file is mandatory
-        /// for the probe to operate correctly. 
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the 
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration 
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [FileNameFilter("ADC calibration files (*_ADCCalibration.csv)|*_ADCCalibration.csv")]
         [Description("Path to the Neuropixels 1.0 ADC calibration file.")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Category(ConfigurationCategory)]
         public string AdcCalibrationFile { get; set; }
 
-        /// <summary>
-        /// Gets or sets the NeuropixelsV1 probe configuration.
-        /// </summary>
+        /// <inheritdoc/>
         [Category(ConfigurationCategory)]
-        [Description("Neuropixels 1.0e probe configuration")]
+        [Description("NeuropixelsV1 probe configuration")]
         public NeuropixelsV1ProbeConfiguration ProbeConfiguration { get; set; } = new();
 
         /// <summary>

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
@@ -51,78 +51,33 @@ namespace OpenEphys.Onix1
             InvertPolarity = configureNeuropixelsV1f.InvertPolarity;
         }
 
-        /// <summary>
-        /// Gets or sets the device enable state.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// If set to true, <see cref="NeuropixelsV1fData"/> will produce data. If set to false, 
         /// <see cref="NeuropixelsV1fData"/> will not produce data.
         /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Specifies whether the Neuro data stream is enabled.")]
+        [Description("Specifies whether the NeuropixelsV1 device is enabled.")]
         public bool Enable { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets a value determining if the polarity of the electrode voltages acquired by the probe
-        /// should be inverted.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The analog channels on the probe ASIC have negative gain coefficients. This means that neural data
-        /// that is captured by the probe will be inverted compared to the physical signal that occurs at the
-        /// electrode: e.g. extracellular action potentials will tend to have positive deflections instead of
-        /// negative. Setting this property to true will apply a gain of -1 to neural data to undo this
-        /// effect.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [Category(ConfigurationCategory)]
         [Description("Invert the polarity of the electrode voltages acquired by the probe.")]
         public bool InvertPolarity { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets the NeuropixelsV1 probe configuration.
-        /// </summary>
+        /// <inheritdoc/>
         [Category(ConfigurationCategory)]
-        [Description("Neuropixels 1.0e probe configuration.")]
+        [Description("NeuropixelsV1 probe configuration.")]
         public NeuropixelsV1ProbeConfiguration ProbeConfiguration { get; set; } = new();
 
-        /// <summary>
-        /// Gets or sets the path to the gain calibration file.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
-        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
-        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the 
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration 
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [FileNameFilter("Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv")]
         [Description("Path to the Neuropixels 1.0 gain calibration file.")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Category(ConfigurationCategory)]
         public string GainCalibrationFile { get; set; }
 
-        /// <summary>
-        /// Gets or sets the path to the ADC calibration file.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Each probe must be provided with an ADC calibration file that contains probe-specific hardware settings that is
-        /// created by IMEC during factory calibration. These files are used to set internal bias currents, correct for ADC
-        /// nonlinearities, correct ADC-zero crossing non-monotonicities, etc. Using the correct calibration file is mandatory
-        /// for the probe to operate correctly. 
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the 
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration 
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [FileNameFilter("ADC calibration files (*_ADCCalibration.csv)|*_ADCCalibration.csv")]
         [Description("Path to the Neuropixels 1.0 ADC calibration file.")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -47,48 +47,18 @@ namespace OpenEphys.Onix1
         [Description("Specifies whether the NeuropixelsV2 device is enabled.")]
         public bool Enable { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets a value determining if the polarity of the electrode voltages acquired by the probe
-        /// should be inverted.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The analog channels on the probe ASIC have negative gain coefficients. This means that neural data
-        /// that is captured by the probe will be inverted compared to the physical signal that occurs at the
-        /// electrode: e.g. extracellular action potentials will tend to have positive deflections instead of
-        /// negative. Setting this property to true will apply a gain of -1 to neural data to undo this
-        /// effect.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [Category(ConfigurationCategory)]
         [Description("Invert the polarity of the electrode voltages acquired by the probe.")]
         public bool InvertPolarity { get; set; } = true;
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
-        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2e"/> to configure both
-        /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
-        /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Probe A electrode configuration.")]
+        [Description("Probe A configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; } = new(NeuropixelsV2Probe.ProbeA);
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// <para>
-        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
-        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
-        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
         [Category(ConfigurationCategory)]
         [FileNameFilter("Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv")]
         [Description("Path to the gain calibration file for probe A.")]
@@ -96,30 +66,12 @@ namespace OpenEphys.Onix1
         public string GainCalibrationFileA { get; set; }
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
-        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2e"/> to configure both
-        /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
-        /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Probe B electrode configuration.")]
+        [Description("Probe B configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; } = new(NeuropixelsV2Probe.ProbeB);
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// <para>
-        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
-        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
-        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
         [Category(ConfigurationCategory)]
         [FileNameFilter("Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv")]
         [Description("Path to the gain calibration file for probe B.")]

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -59,51 +59,21 @@ namespace OpenEphys.Onix1
         /// If true, the headstage LED will turn on during data acquisition. If false, the LED will not turn on.
         /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("If true, the headstage LED will turn on during data acquisition. If false, the LED will not turn on.")]
+        [Description("Specifies whether the headstage LED will turn on during acquisition.")]
         public bool EnableLed { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets a value determining if the polarity of the electrode voltages acquired by the probe
-        /// should be inverted.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The analog channels on the probe ASIC have negative gain coefficients. This means that neural data
-        /// that is captured by the probe will be inverted compared to the physical signal that occurs at the
-        /// electrode: e.g. extracellular action potentials will tend to have positive deflections instead of
-        /// negative. Setting this property to true will apply a gain of -1 to neural data to undo this
-        /// effect.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [Category(ConfigurationCategory)]
         [Description("Invert the polarity of the electrode voltages acquired by the probe.")]
         public bool InvertPolarity { get; set; } = true;
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
-        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2eBeta"/> to configure both
-        /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
-        /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Probe A electrode configuration.")]
+        [Description("Probe A configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; } = new(NeuropixelsV2Probe.ProbeA);
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// <para>
-        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
-        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
-        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
         [Category(ConfigurationCategory)]
         [FileNameFilter("Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv")]
         [Description("Path to the gain calibration file for probe A.")]
@@ -111,30 +81,12 @@ namespace OpenEphys.Onix1
         public string GainCalibrationFileA { get; set; }
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
-        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
-        /// in the property pane, or double-click <see cref="ConfigureHeadstageNeuropixelsV2eBeta"/> to configure both
-        /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
-        /// </remarks>
         [Category(ConfigurationCategory)]
-        [Description("Probe B electrode configuration.")]
+        [Description("Probe B configuration.")]
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; } = new(NeuropixelsV2Probe.ProbeB);
 
         /// <inheritdoc/>
-        /// <remarks>
-        /// <para>
-        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
-        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
-        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
-        /// </para>
-        /// <para>
-        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the
-        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration
-        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
-        /// </para>
-        /// </remarks>
         [Category(ConfigurationCategory)]
         [FileNameFilter("Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv")]
         [Description("Path to the gain calibration file for probe B.")]

--- a/OpenEphys.Onix1/IConfigureNeuropixelsV1.cs
+++ b/OpenEphys.Onix1/IConfigureNeuropixelsV1.cs
@@ -13,23 +13,62 @@ namespace OpenEphys.Onix1
         public bool Enable { get; set; }
 
         /// <summary>
-        /// Gets or sets the electrode configuration.
+        /// Gets or sets the probe configuration.
         /// </summary>
+        /// <remarks>
+        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
+        /// To open a probe configuration GUI, select the ellipses next the ProbeConfiguration variable
+        /// in the property pane, or double-click the configuration node to configure the probe and the Bno055 simultaneously.
+        /// </remarks>
         public NeuropixelsV1ProbeConfiguration ProbeConfiguration { get; set; }
 
         /// <summary>
         /// Gets or sets the path to the gain calibration file.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
+        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
+        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
+        /// </para>
+        /// <para>
+        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the 
+        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration 
+        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
+        /// </para>
+        /// </remarks>
         public string GainCalibrationFile { get; set; }
 
         /// <summary>
-        /// Gets or sets the path to the gain calibration file.
+        /// Gets or sets the path to the ADC calibration file.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Each probe must be provided with an ADC calibration file that contains probe-specific hardware settings that is
+        /// created by IMEC during factory calibration. These files are used to set internal bias currents, correct for ADC
+        /// nonlinearities, correct ADC-zero crossing non-monotonicities, etc. Using the correct calibration file is mandatory
+        /// for the probe to operate correctly. 
+        /// </para>
+        /// <para>
+        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the 
+        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration 
+        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
+        /// </para>
+        /// </remarks>
         public string AdcCalibrationFile { get; set; }
 
         /// <summary>
-        /// Gets or sets the boolean to determine if neural data is inverted
+        /// Gets or sets a value determining if the polarity of the electrode voltages acquired by the probe
+        /// should be inverted.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Neuropixels contain inverting amplifiers.This means that neural data that is captured by the probe
+        /// will be inverted compared to the physical signal that occurs at the electrode: e.g. extracellular
+        /// action potentials will tend to have positive deflections instead of negative. Enabling this
+        /// setting this property to true will apply a gain of -1 to undo this effect.
+        /// </para>
+        /// </remarks>
         public bool InvertPolarity { get; set; }
     }
 }

--- a/OpenEphys.Onix1/IConfigureNeuropixelsV2.cs
+++ b/OpenEphys.Onix1/IConfigureNeuropixelsV2.cs
@@ -13,26 +13,71 @@
         /// <summary>
         /// Gets or sets the electrode configuration for Probe A.
         /// </summary>
+        /// <remarks>
+        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
+        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
+        /// in the property pane, or double-click the configuration node to configure both
+        /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
+        /// </remarks>
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; }
 
         /// <summary>
         /// Gets or sets the path to the gain calibration file for Probe A.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
+        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
+        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
+        /// </para>
+        /// <para>
+        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the
+        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration
+        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
+        /// </para>
+        /// </remarks>
         public string GainCalibrationFileA { get; set; }
 
         /// <summary>
         /// Gets or sets the electrode configuration for Probe B.
         /// </summary>
+        /// <remarks>
+        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
+        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
+        /// in the property pane, or double-click the configuration node to configure both
+        /// probes and the <see cref="ConfigurePolledBno055"/> simultaneously.
+        /// </remarks>
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; }
 
         /// <summary>
         /// Gets or sets the path to the gain calibration file for Probe B.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
+        /// factory testing. Electrode voltages are scaled using these values to ensure they can be accurately compared
+        /// across probes. Therefore, using the correct gain calibration file is mandatory to create standardized recordings.
+        /// </para>
+        /// <para>
+        /// Calibration files are probe-specific and not interchangeable across probes. Calibration files must contain the
+        /// serial number of the corresponding probe on their first line of text. If you have lost track of a calibration
+        /// file for your probe, email IMEC at neuropixels.info@imec.be with the probe serial number to retrieve a new copy.
+        /// </para>
+        /// </remarks>
         public string GainCalibrationFileB { get; set; }
 
         /// <summary>
-        /// Gets or sets the boolean to determine if neural data is inverted
+        /// Gets or sets a value determining if the polarity of the electrode voltages acquired by the probe
+        /// should be inverted.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Neuropixels contain inverting amplifiers.This means that neural data that is captured by the probe
+        /// will be inverted compared to the physical signal that occurs at the electrode: e.g. extracellular
+        /// action potentials will tend to have positive deflections instead of negative. Enabling this
+        /// setting this property to true will apply a gain of -1 to undo this effect.
+        /// </para>
+        /// </remarks>
         public bool InvertPolarity { get; set; }
     }
 }


### PR DESCRIPTION
Instead of duplicating XML comments across devices, especially when these devices share a common interface, this PR moves all XML comments to the interface and the implementing classes now inherit the docs. 

We still need to add specific comments for properties that are not in the interface, or when a property needs to reference an external class that is different for each device (e.g., referencing the correct `*Data` node).

Also, consolidated some `Description` attributes so they are consistent.

Fixes #488 