### PR TITLE
Fix scale on right side of pane for channel configuration dialogs

### DIFF
--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -1,11 +1,11 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
-using ZedGraph;
-using System;
 using OpenEphys.ProbeInterface.NET;
-using System.Collections.Generic;
+using ZedGraph;
 
 namespace OpenEphys.Onix1.Design
 {
@@ -17,6 +17,7 @@ namespace OpenEphys.Onix1.Design
     public abstract partial class ChannelConfigurationDialog : Form
     {
         internal event EventHandler OnResizeZedGraph;
+        internal event EventHandler OnDrawProbeGroup;
 
         internal ProbeGroup ProbeGroup;
 
@@ -50,7 +51,17 @@ namespace OpenEphys.Onix1.Design
             zedGraphChannels.MouseMoveEvent += MouseMoveEvent;
             zedGraphChannels.MouseUpEvent += MouseUpEvent;
 
-            InitializeZedGraphChannels();
+            if (IsDrawScale())
+            {
+                var pane = new GraphPane();
+
+                InitializeScalePane(pane);
+
+                zedGraphChannels.MasterPane.Add(pane);
+            }
+
+            InitializeZedGraphControl(zedGraphChannels);
+            InitializeProbePane(zedGraphChannels.GraphPane);
             DrawProbeGroup();
             RefreshZedGraph();
         }
@@ -91,17 +102,23 @@ namespace OpenEphys.Onix1.Design
                 if (CheckZoomBoundaries(sender))
                 {
                     CenterAxesOnCursor(sender);
-                    CheckProbeIsInView(sender);
                 }
                 else
                 {
                     sender.ZoomOut(sender.GraphPane);
                 }
             }
-            else if (newState.Type == ZoomState.StateType.Pan)
-            {
-                CheckProbeIsInView(sender);
-            }
+
+            CheckProbeIsInView(sender);
+
+            if (IsDrawScale())
+                SyncYAxes(zedGraphChannels.MasterPane.PaneList[0], zedGraphChannels.MasterPane.PaneList[1]);
+        }
+
+        static void SyncYAxes(GraphPane source, GraphPane target)
+        {
+            target.YAxis.Scale.Min = source.YAxis.Scale.Min;
+            target.YAxis.Scale.Max = source.YAxis.Scale.Max;
         }
 
         private void SetEqualAxisLimits(ZedGraphControl zedGraphControl)
@@ -192,139 +209,79 @@ namespace OpenEphys.Onix1.Design
             }
         }
 
-        private void CheckProbeIsInView(ZedGraphControl zedGraphControl)
+        static void CheckProbeIsInView(ZedGraphControl zedGraphControl)
         {
-            var probeEdge = new ProbeEdge(zedGraphControl);
-            var scaleEdge = new ScaleEdge(zedGraphControl);
+            var probe = new ProbeEdge(zedGraphControl);
+            var scale = new ScaleEdge(zedGraphControl);
+            var pane = zedGraphControl.GraphPane;
 
-            var rangeX = CalculateScaleRange(zedGraphControl.GraphPane.XAxis.Scale);
-            var rangeY = CalculateScaleRange(zedGraphControl.GraphPane.YAxis.Scale);
-
-            var boundaryX = rangeX / 4;
-            var boundaryY = rangeY / 4;
-
-            if (IsProbeCentered(probeEdge, scaleEdge))
+            if (scale.Left > probe.Left && scale.Right > probe.Right)
             {
-                return;
-            }
-            else if (IsProbeCenteredX(probeEdge, scaleEdge))
-            {
-                if (IsProbeTooHigh(probeEdge, scaleEdge, boundaryY))
+                var diffLeft = Math.Abs(scale.Left - probe.Left);
+                var diffRight = Math.Abs(scale.Right - probe.Right);
+
+                if (scale.Right - diffLeft > probe.Right)
                 {
-                    MoveProbeDown(zedGraphControl, probeEdge, scaleEdge, boundaryY);
+                    pane.XAxis.Scale.Min -= diffLeft;
+                    pane.XAxis.Scale.Max -= diffLeft;
                 }
-                else if (IsProbeTooLow(probeEdge, scaleEdge, boundaryY))
+                else
                 {
-                    MoveProbeUp(zedGraphControl, probeEdge, scaleEdge, boundaryY);
+                    pane.XAxis.Scale.Min -= diffRight;
+                    pane.XAxis.Scale.Max -= diffRight;
                 }
             }
-            else if (IsProbeCenteredY(probeEdge, scaleEdge))
+
+            if (scale.Right < probe.Right && scale.Left < probe.Left)
             {
-                if (IsProbeTooLeft(probeEdge, scaleEdge, boundaryX))
+                var diffLeft = Math.Abs(scale.Left - probe.Left);
+                var diffRight = Math.Abs(scale.Right - probe.Right);
+
+                if (scale.Left + diffRight > probe.Left)
                 {
-                    MoveProbeRight(zedGraphControl, probeEdge, scaleEdge, boundaryX);
+                    pane.XAxis.Scale.Min += diffLeft;
+                    pane.XAxis.Scale.Max += diffLeft;
                 }
-                else if (IsProbeTooRight(probeEdge, scaleEdge, boundaryX))
+                else
                 {
-                    MoveProbeLeft(zedGraphControl, probeEdge, scaleEdge, boundaryX);
+                    pane.XAxis.Scale.Min += diffRight;
+                    pane.XAxis.Scale.Max += diffRight;
                 }
             }
-            else
-            {
-                if (IsProbeTooHigh(probeEdge, scaleEdge, boundaryY))
-                {
-                    MoveProbeDown(zedGraphControl, probeEdge, scaleEdge, boundaryY);
-                }
-                else if (IsProbeTooLow(probeEdge, scaleEdge, boundaryY))
-                {
-                    MoveProbeUp(zedGraphControl, probeEdge, scaleEdge, boundaryY);
-                }
 
-                if (IsProbeTooLeft(probeEdge, scaleEdge, boundaryX))
+            if (scale.Top > probe.Top && scale.Bottom > probe.Bottom)
+            {
+                var diffTop = Math.Abs(scale.Top - probe.Top);
+                var diffBottom = Math.Abs(scale.Bottom - probe.Bottom);
+
+                if (scale.Bottom - diffTop > probe.Bottom)
                 {
-                    MoveProbeRight(zedGraphControl, probeEdge, scaleEdge, boundaryX);
+                    pane.YAxis.Scale.Min -= diffTop;
+                    pane.YAxis.Scale.Max -= diffTop;
                 }
-                else if (IsProbeTooRight(probeEdge, scaleEdge, boundaryX))
+                else
                 {
-                    MoveProbeLeft(zedGraphControl, probeEdge, scaleEdge, boundaryX);
+                    pane.YAxis.Scale.Min -= diffBottom;
+                    pane.YAxis.Scale.Max -= diffBottom;
                 }
             }
-        }
 
-        private void MoveProbeLeft(ZedGraphControl zedGraphControl, ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            bool probeSmallerThanScale = probeEdge.Right - probeEdge.Left < scaleEdge.Right - scaleEdge.Left;
+            if (scale.Bottom < probe.Bottom && scale.Top < probe.Top)
+            {
+                var diffBottom = Math.Abs(scale.Bottom - probe.Bottom);
+                var diffTop = Math.Abs(scale.Top - probe.Top);
 
-            double diff = probeSmallerThanScale ? probeEdge.Right - scaleEdge.Right : probeEdge.Left - (scaleEdge.Left + boundary);
-
-            zedGraphControl.GraphPane.XAxis.Scale.Min += diff;
-            zedGraphControl.GraphPane.XAxis.Scale.Max += diff;
-        }
-
-        private bool IsProbeTooRight(ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            return probeEdge.Left > scaleEdge.Left + boundary;
-        }
-
-        private void MoveProbeRight(ZedGraphControl zedGraphControl, ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            bool probeSmallerThanScale = probeEdge.Right - probeEdge.Left < scaleEdge.Right - scaleEdge.Left;
-
-            var diff = probeSmallerThanScale ? probeEdge.Left - scaleEdge.Left : probeEdge.Right - (scaleEdge.Right - boundary);
-
-            zedGraphControl.GraphPane.XAxis.Scale.Min += diff;
-            zedGraphControl.GraphPane.XAxis.Scale.Max += diff;
-        }
-
-        private bool IsProbeTooLeft(ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            return probeEdge.Right < scaleEdge.Right - boundary;
-        }
-
-        private void MoveProbeUp(ZedGraphControl zedGraphControl, ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            var diff = probeEdge.Top - (scaleEdge.Top - boundary);
-
-            zedGraphControl.GraphPane.YAxis.Scale.Min += diff;
-            zedGraphControl.GraphPane.YAxis.Scale.Max += diff;
-        }
-
-        private bool IsProbeTooLow(ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            return probeEdge.Top < scaleEdge.Top - boundary;
-        }
-
-        private void MoveProbeDown(ZedGraphControl zedGraphControl, ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            var diff = probeEdge.Bottom - (scaleEdge.Bottom + boundary);
-
-            zedGraphControl.GraphPane.YAxis.Scale.Min += diff;
-            zedGraphControl.GraphPane.YAxis.Scale.Max += diff;
-        }
-
-        private bool IsProbeTooHigh(ProbeEdge probeEdge, ScaleEdge scaleEdge, double boundary)
-        {
-            return probeEdge.Bottom > scaleEdge.Bottom + boundary;
-        }
-
-        private bool IsProbeCenteredY(ProbeEdge probeEdge, ScaleEdge scaleEdge)
-        {
-            return probeEdge.Bottom >= scaleEdge.Bottom && probeEdge.Top <= scaleEdge.Top ||
-                   probeEdge.Bottom <= scaleEdge.Bottom && probeEdge.Top >= scaleEdge.Top;
-        }
-
-        private bool IsProbeCenteredX(ProbeEdge probeEdge, ScaleEdge scaleEdge)
-        {
-            return probeEdge.Left >= scaleEdge.Left && probeEdge.Right <= scaleEdge.Right ||
-                   probeEdge.Left <= scaleEdge.Left && probeEdge.Right >= scaleEdge.Right;
-        }
-
-        private bool IsProbeCentered(ProbeEdge probeEdge, ScaleEdge scaleEdge)
-        {
-            return (probeEdge.Left >= scaleEdge.Left && probeEdge.Right <= scaleEdge.Right &&
-                    probeEdge.Bottom >= scaleEdge.Bottom && probeEdge.Top <= scaleEdge.Top) ||
-                   (probeEdge.Left <= scaleEdge.Left && probeEdge.Right >= scaleEdge.Right &&
-                    probeEdge.Bottom <= scaleEdge.Bottom && probeEdge.Top >= scaleEdge.Top);
+                if (scale.Top + diffBottom > probe.Top)
+                {
+                    pane.YAxis.Scale.Min += diffTop;
+                    pane.YAxis.Scale.Max += diffTop;
+                }
+                else
+                {
+                    pane.YAxis.Scale.Min += diffBottom;
+                    pane.YAxis.Scale.Max += diffBottom;
+                }
+            }
         }
 
         internal static double CalculateScaleRange(Scale scale)
@@ -414,12 +371,7 @@ namespace OpenEphys.Onix1.Design
                 menuStrip.Visible = false;
 
                 ConnectResizeEventHandler();
-                ZedGraphChannels_Resize(null, null);
-            }
-            else
-            {
-                UpdateFontSize();
-                zedGraphChannels.Refresh();
+                ResizeZedGraph();
             }
         }
 
@@ -481,7 +433,18 @@ namespace OpenEphys.Onix1.Design
             HighlightEnabledContacts();
             HighlightSelectedContacts();
             DrawContactLabels();
-            DrawScale();
+
+            if (IsDrawScale())
+            {
+                DrawScale();
+            }
+
+            OnDrawProbeGroupHandler();
+        }
+
+        void OnDrawProbeGroupHandler()
+        {
+            OnDrawProbeGroup?.Invoke(this, EventArgs.Empty);
         }
 
         private double ZoomOutBoundaryLeft = default;
@@ -782,6 +745,8 @@ namespace OpenEphys.Onix1.Design
             return deviceChannelIndex == -1 ? DisabledContactString : index.ToString();
         }
 
+        internal virtual bool IsDrawScale() => false;
+
         internal virtual void DrawScale() { }
 
         internal void UpdateFontSize()
@@ -949,34 +914,108 @@ namespace OpenEphys.Onix1.Design
             return pointD;
         }
 
-        /// <summary>
-        /// Initialize the given <see cref="ZedGraphControl"/> so that almost everything other than the 
-        /// axis itself is hidden, reducing visual clutter before plotting contacts
-        /// </summary>
-        public void InitializeZedGraphChannels()
+        static void InitializeZedGraphControl(ZedGraphControl zedGraph)
         {
-            zedGraphChannels.IsZoomOnMouseCenter = true;
+            zedGraph.IsZoomOnMouseCenter = true;
+            zedGraph.IsAntiAlias = true;
+            zedGraph.BorderStyle = BorderStyle.None;
 
-            zedGraphChannels.IsAntiAlias = true;
+            EnablePan(zedGraph);
+            EnableZoom(zedGraph);
+        }
 
-            zedGraphChannels.GraphPane.Title.IsVisible = false;
-            zedGraphChannels.GraphPane.TitleGap = 0;
-            zedGraphChannels.GraphPane.Border.IsVisible = false;
-            zedGraphChannels.GraphPane.Border.Width = 0;
-            zedGraphChannels.GraphPane.Chart.Border.IsVisible = false;
-            zedGraphChannels.GraphPane.Margin.All = -1;
-            zedGraphChannels.GraphPane.IsFontsScaled = true;
-            zedGraphChannels.BorderStyle = BorderStyle.None;
+        static void EnablePan(ZedGraphControl zedGraph)
+        {
+            zedGraph.IsEnableHPan = true;
+            zedGraph.IsEnableVPan = true;
+        }
 
-            zedGraphChannels.GraphPane.XAxis.IsVisible = false;
-            zedGraphChannels.GraphPane.XAxis.IsAxisSegmentVisible = false;
-            zedGraphChannels.GraphPane.XAxis.Scale.MaxAuto = true;
-            zedGraphChannels.GraphPane.XAxis.Scale.MinAuto = true;
+        static void DisablePan(ZedGraphControl zedGraph)
+        {
+            zedGraph.IsEnableHPan = false;
+            zedGraph.IsEnableVPan = false;
+        }
 
-            zedGraphChannels.GraphPane.YAxis.IsVisible = false;
-            zedGraphChannels.GraphPane.YAxis.IsAxisSegmentVisible = false;
-            zedGraphChannels.GraphPane.YAxis.Scale.MaxAuto = true;
-            zedGraphChannels.GraphPane.YAxis.Scale.MinAuto = true;
+        static void EnableZoom(ZedGraphControl zedGraph)
+        {
+            zedGraph.IsEnableZoom = true;
+            zedGraph.IsEnableWheelZoom = true;
+        }
+
+        static void DisableZoom(ZedGraphControl zedGraph)
+        {
+            zedGraph.IsEnableZoom = false;
+            zedGraph.IsEnableWheelZoom = false;
+        }
+
+        static void InitializeScalePane(GraphPane pane)
+        {
+            pane.Title.IsVisible = false;
+            pane.TitleGap = 0;
+            pane.Border.IsVisible = false;
+            pane.Border.Width = 0;
+            pane.Chart.Border.IsVisible = false;
+            pane.Margin.All = 0;
+
+            pane.Y2Axis.IsVisible = false;
+
+            pane.XAxis.IsVisible = false;
+            pane.XAxis.IsAxisSegmentVisible = false;
+            pane.XAxis.Scale.MaxAuto = true;
+            pane.XAxis.Scale.MinAuto = true;
+            pane.XAxis.MajorGrid.IsZeroLine = false;
+            pane.XAxis.CrossAuto = false;
+            pane.XAxis.Cross = double.MinValue;
+
+            pane.YAxis.IsVisible = true;
+            pane.YAxis.IsAxisSegmentVisible = true;
+            pane.YAxis.Scale.MaxAuto = true;
+            pane.YAxis.Scale.MinAuto = true;
+            pane.YAxis.CrossAuto = false;
+            pane.YAxis.Cross = double.MinValue;
+
+            pane.YAxis.MajorGrid.IsZeroLine = false;
+            pane.YAxis.MajorGrid.IsVisible = false;
+            pane.YAxis.MinorGrid.IsVisible = false;
+
+            pane.YAxis.Scale.IsPreventLabelOverlap = true;
+            pane.YAxis.Scale.MajorStep = 100;
+            pane.YAxis.Scale.BaseTic = 0;
+            pane.YAxis.Scale.IsLabelsInside = true;
+            pane.YAxis.Scale.FontSpec.Size = 65f;
+            pane.YAxis.Scale.FontSpec.IsBold = true;
+            pane.YAxis.Scale.LabelGap = 0.6f;
+
+            pane.YAxis.MinorTic.IsInside = false;
+            pane.YAxis.MinorTic.IsOutside = false;
+            pane.YAxis.MinorTic.IsOpposite = false;
+
+            pane.YAxis.MajorTic.IsInside = true;
+            pane.YAxis.MajorTic.IsOutside = false;
+            pane.YAxis.MajorTic.IsOpposite = false;
+            pane.YAxis.MajorTic.Size = 40f;
+            pane.YAxis.MajorTic.PenWidth = 2f;
+        }
+
+        static void InitializeProbePane(GraphPane graphPane)
+        {
+            graphPane.Title.IsVisible = false;
+            graphPane.TitleGap = 0;
+            graphPane.Border.IsVisible = false;
+            graphPane.Border.Width = 0;
+            graphPane.Chart.Border.IsVisible = false;
+            graphPane.Margin.All = -1;
+            graphPane.IsFontsScaled = true;
+
+            graphPane.XAxis.IsVisible = false;
+            graphPane.XAxis.IsAxisSegmentVisible = false;
+            graphPane.XAxis.Scale.MaxAuto = true;
+            graphPane.XAxis.Scale.MinAuto = true;
+
+            graphPane.YAxis.IsVisible = false;
+            graphPane.YAxis.IsAxisSegmentVisible = false;
+            graphPane.YAxis.Scale.MaxAuto = true;
+            graphPane.YAxis.Scale.MinAuto = true;
         }
 
         private void MenuItemSaveFile(object sender, EventArgs e)
@@ -1007,23 +1046,21 @@ namespace OpenEphys.Onix1.Design
 
         private void ZedGraphChannels_Resize(object sender, EventArgs e)
         {
-            if (zedGraphChannels.Size.Width == zedGraphChannels.Size.Height &&
-                zedGraphChannels.Size.Height == zedGraphChannels.GraphPane.Rect.Height &&
-                zedGraphChannels.Location.X == zedGraphChannels.GraphPane.Rect.X)
-            {
-                if (zedGraphChannels.GraphPane.Chart.Rect != zedGraphChannels.GraphPane.Rect)
-                {
-                    zedGraphChannels.GraphPane.Chart.Rect = zedGraphChannels.GraphPane.Rect;
-                }
+            ResizeZedGraph();
+        }
 
-                return;
+        internal void ResizeZedGraph()
+        {
+            ResizeAxes();
+
+            if (IsDrawScale())
+            {
+                SetPaneSizes(zedGraphChannels);
             }
 
-            ResizeAxes();
-            UpdateControlSizeBasedOnAxisSize();
             UpdateFontSize();
-            DrawScale();
             RefreshZedGraph();
+            Update();
             OnResizeHandler();
         }
 
@@ -1032,42 +1069,56 @@ namespace OpenEphys.Onix1.Design
             OnResizeZedGraph?.Invoke(this, EventArgs.Empty);
         }
 
-        /// <summary>
-        /// After a resize event (such as changing the window size), readjust the size of the control to 
-        /// ensure an equal aspect ratio for axes.
-        /// </summary>
-        public void ResizeAxes()
+        void ResizeAxes()
         {
-            SetEqualAspectRatio();
+            float scalingFactor = IsDrawScale() ? 1.15f : 1.0f;
+            RectangleF rect = IsDrawScale() ? zedGraphChannels.MasterPane.Rect : zedGraphChannels.GraphPane.Rect;
 
-            RectangleF axisRect = zedGraphChannels.GraphPane.Rect;
+            float width = rect.Width;
+            float height = rect.Height;
 
-            if (axisRect.Width > axisRect.Height)
+            float desiredWidth = height * scalingFactor;
+
+            if (width < desiredWidth)
             {
-                axisRect.X += (axisRect.Width - axisRect.Height) / 2;
-                axisRect.Width = axisRect.Height;
-            }
-            else if (axisRect.Height > axisRect.Width)
-            {
-                axisRect.Y += (axisRect.Height - axisRect.Width) / 2;
-                axisRect.Height = axisRect.Width;
+                height = width / scalingFactor;
             }
             else
             {
-                zedGraphChannels.GraphPane.Chart.Rect = axisRect;
-                return;
+                width = desiredWidth;
             }
 
-            zedGraphChannels.GraphPane.Rect = axisRect;
-            zedGraphChannels.GraphPane.Chart.Rect = axisRect;
+            float x = rect.Left + (rect.Width - width) / 2f;
+            float y = rect.Top + (rect.Height - height) / 2f;
+
+            var newRect = new RectangleF(x, y, width, height);
+
+            if (IsDrawScale())
+                zedGraphChannels.MasterPane.Rect = newRect;
+            else
+            {
+                zedGraphChannels.GraphPane.Rect = newRect;
+                DisconnectResizeEventHandler();
+                zedGraphChannels.Size = new Size((int)newRect.Width, (int)newRect.Height);
+                zedGraphChannels.Location = new Point((int)newRect.X, (int)newRect.Y);
+                ConnectResizeEventHandler();
+            }
         }
 
-        private void UpdateControlSizeBasedOnAxisSize()
+        static void SetPaneSizes(ZedGraphControl zedGraph)
         {
-            RectangleF axisRect = zedGraphChannels.GraphPane.Rect;
+            if (zedGraph == null || zedGraph.MasterPane.PaneList.Count <= 1)
+                return;
 
-            zedGraphChannels.Size = new Size((int)axisRect.Width, (int)axisRect.Height);
-            zedGraphChannels.Location = new Point((int)axisRect.X, (int)axisRect.Y);
+            var rect = zedGraph.MasterPane.Rect;
+
+            // NB: Assume that ResizeAxes() creates a rectangular MasterPane if there is a scale being drawn
+            float squareSize = rect.Height;
+
+            zedGraph.MasterPane.PaneList[0].Rect = new RectangleF(rect.Left, rect.Top, squareSize, squareSize);
+            zedGraph.MasterPane.PaneList[1].Rect = new RectangleF(rect.Left + squareSize, rect.Top, rect.Width - squareSize, squareSize);
+
+            zedGraph.MasterPane.PaneList[1].Margin.Left = 10;
         }
 
         private void MenuItemOpenFile(object sender, EventArgs e)
@@ -1103,15 +1154,7 @@ namespace OpenEphys.Onix1.Design
             UpdateFontSize();
         }
 
-        /// <summary>
-        /// Shifts the whole ZedGraph to the given relative position, where 0.0 is the very bottom of the horizontal 
-        /// space, and 1.0 is the very top. Note that this accounts for a buffer on the top and bottom, so giving a 
-        /// value of 0.0 would have the minimum value of Y axis equal to the bottom of the graph, and keep the range 
-        /// the same. Similarly, a value of 1.0 would set the maximum value of the Y axis to the top of the graph, 
-        /// and keep the range the same.
-        /// </summary>
-        /// <param name="relativePosition">A float value defining the percentage of the graph to move to vertically</param>
-        public void MoveToVerticalPosition(float relativePosition)
+        internal void MoveToVerticalPosition(float relativePosition)
         {
             if (relativePosition < 0.0 || relativePosition > 1.0)
             {
@@ -1128,6 +1171,9 @@ namespace OpenEphys.Onix1.Design
 
             zedGraphChannels.GraphPane.YAxis.Scale.Min = newMinY;
             zedGraphChannels.GraphPane.YAxis.Scale.Max = newMinY + currentRange;
+
+            if (IsDrawScale())
+                SyncYAxes(zedGraphChannels.MasterPane.PaneList[0], zedGraphChannels.MasterPane.PaneList[1]);
         }
 
         internal float GetRelativeVerticalPosition()
@@ -1199,9 +1245,31 @@ namespace OpenEphys.Onix1.Design
 
                 return true;
             }
+            else if (e.Button == MouseButtons.Middle)
+            {
+                if (IsDrawScale())
+                    SyncYAxes(zedGraphChannels.MasterPane.PaneList[0], zedGraphChannels.MasterPane.PaneList[1]);
+
+                CheckProbeIsInView(sender);
+
+                return false;
+            }
             else if (e.Button == MouseButtons.None)
             {
                 sender.Cursor = Cursors.Arrow;
+
+                var currentPane = sender.MasterPane.FindPane(new PointF(e.X, e.Y));
+
+                if (currentPane == sender.MasterPane.PaneList[0])
+                {
+                    EnablePan(sender);
+                    EnableZoom(sender);
+                }
+                else if (IsDrawScale() && currentPane == sender.MasterPane.PaneList[1])
+                {
+                    DisablePan(sender);
+                    DisableZoom(sender);
+                }
 
                 return true;
             }
@@ -1342,8 +1410,8 @@ namespace OpenEphys.Onix1.Design
         {
             foreach (var probe in probeGroup.Probes)
             {
-                if (probe.ContactAnnotations != null 
-                    && probe.ContactAnnotations.Annotations != null 
+                if (probe.ContactAnnotations != null
+                    && probe.ContactAnnotations.Annotations != null
                     && probe.ContactAnnotations.Annotations.Length > 0)
                 {
                     return true;

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ChannelConfigurationDialog.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using OpenEphys.ProbeInterface.NET;
@@ -40,8 +39,8 @@ namespace OpenEphys.Onix1.Design
 
             ProbeConfiguration = probeConfiguration;
 
-            ZoomInBoundaryX = 400;
-            ZoomInBoundaryY = 400;
+            ZoomInBoundaryX = 200;
+            ZoomInBoundaryY = 200;
 
             HighlightEnabledContacts();
             UpdateContactLabels();
@@ -87,7 +86,6 @@ namespace OpenEphys.Onix1.Design
             base.ZoomEvent(sender, oldState, newState);
 
             UpdateFontSize();
-            DrawScale();
             RefreshZedGraph();
 
             OnZoomHandler();
@@ -98,90 +96,21 @@ namespace OpenEphys.Onix1.Design
             OnZoom?.Invoke(this, EventArgs.Empty);
         }
 
+        internal override bool IsDrawScale() => true;
+
         internal override void DrawScale()
         {
-            if (ProbeConfiguration == null)
+            if (ProbeConfiguration == null || zedGraphChannels.MasterPane.PaneList.Count < 2)
                 return;
 
-            const string ScalePointsTag = "scale_points";
-            const string ScaleTextTag = "scale_text";
+            var pane = zedGraphChannels.MasterPane.PaneList[1];
 
-            zedGraphChannels.GraphPane.GraphObjList.RemoveAll(obj => obj is TextObj && obj.Tag is string tag && tag == ScaleTextTag);
-            zedGraphChannels.GraphPane.CurveList.RemoveAll(curve => curve.Tag is string tag && tag == ScalePointsTag);
+            pane.YAxis.Scale.Min = GetProbeBottom(zedGraphChannels.GraphPane.GraphObjList);
+            pane.YAxis.Scale.Max = GetProbeTop(zedGraphChannels.GraphPane.GraphObjList);
 
-            const int MajorTickIncrement = 100;
-            const int MajorTickLength = 10;
-            const int MinorTickIncrement = 10;
-            const int MinorTickLength = 5;
-
-            if (ProbeConfiguration.ProbeGroup.Probes.ElementAt(0).SiUnits != ProbeSiUnits.um)
-            {
-                MessageBox.Show("Warning: Expected ProbeGroup units to be in microns, but it is in millimeters. Scale might not be accurate.");
-            }
-
-            var fontSize = CalculateFontSize();
-
-            var zoomedOut = fontSize <= 2;
-
-            fontSize = zoomedOut ? 6 : fontSize * 3;
-            var majorTickOffset = MajorTickLength + CalculateScaleRange(zedGraphChannels.GraphPane.XAxis.Scale) * 0.015;
-            majorTickOffset = majorTickOffset > 50 ? 50 : majorTickOffset;
-
-            var x = GetProbeRight(zedGraphChannels.GraphPane.GraphObjList) + 40;
-            var minY = GetProbeBottom(zedGraphChannels.GraphPane.GraphObjList);
-            var maxY = GetProbeTop(zedGraphChannels.GraphPane.GraphObjList);
-
-            int textPosition = 0;
-
-            PointPairList pointList = new();
-
-            var countMajorTicks = 0;
-
-            for (int i = (int)minY; i < maxY; i += MajorTickIncrement)
-            {
-                PointPair majorTickLocation = new(x + MajorTickLength, minY + MajorTickIncrement * countMajorTicks);
-
-                pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks));
-                pointList.Add(majorTickLocation);
-                pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks));
-
-                if (!zoomedOut || countMajorTicks % 5 == 0)
-                {
-                    TextObj textObj = new($"{textPosition} µm", majorTickLocation.X + 10, majorTickLocation.Y, CoordType.AxisXYScale, AlignH.Left, AlignV.Center)
-                    {
-                        Tag = ScaleTextTag
-                    };
-                    textObj.FontSpec.Border.IsVisible = false;
-                    textObj.FontSpec.Size = fontSize;
-                    zedGraphChannels.GraphPane.GraphObjList.Add(textObj);
-
-                    textPosition += zoomedOut ? 5 * MajorTickIncrement : MajorTickIncrement;
-                }
-
-                if (!zoomedOut)
-                {
-                    var countMinorTicks = 1;
-
-                    for (int j = i + MinorTickIncrement; j < i + MajorTickIncrement && i + MinorTickIncrement * countMinorTicks < maxY; j += MinorTickIncrement)
-                    {
-                        pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks + MinorTickIncrement * countMinorTicks));
-                        pointList.Add(new PointPair(x + MinorTickLength, minY + MajorTickIncrement * countMajorTicks + MinorTickIncrement * countMinorTicks));
-                        pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks + MinorTickIncrement * countMinorTicks));
-
-                        countMinorTicks++;
-                    }
-                }
-
-                countMajorTicks++;
-            }
-
-            var curve = zedGraphChannels.GraphPane.AddCurve(ScalePointsTag, pointList, Color.Black, SymbolType.None);
-
-            const float scaleBarWidth = 1;
-
-            curve.Line.Width = scaleBarWidth;
-            curve.Label.IsVisible = false;
-            curve.Symbol.IsVisible = false;
+            pane.YAxis.Scale.Format = "#####0' " + ProbeGroup.Probes.First().SiUnits.ToString() + "'";
+            pane.YAxis.Scale.Mag = 0;
+            pane.YAxis.Scale.MagAuto = false;
         }
 
         internal override void HighlightEnabledContacts()

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.Designer.cs
@@ -89,7 +89,6 @@
             this.statusStrip1.SuspendLayout();
             this.menuStrip.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
-            this.panelProbe.SuspendLayout();
             this.panelTrackBar.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarProbePosition)).BeginInit();
             this.panelOptions.SuspendLayout();
@@ -100,7 +99,7 @@
             // 
             label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(19, 671);
+            label1.Location = new System.Drawing.Point(8, 647);
             label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label1.Name = "label1";
             label1.Size = new System.Drawing.Size(39, 16);
@@ -111,7 +110,7 @@
             // 
             label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             label3.AutoSize = true;
-            label3.Location = new System.Drawing.Point(15, 0);
+            label3.Location = new System.Drawing.Point(4, 0);
             label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label3.Name = "label3";
             label3.Size = new System.Drawing.Size(46, 16);
@@ -236,10 +235,10 @@
             this.toolStripAdcCalSN,
             this.toolStripLabelGainCalibrationSn,
             this.toolStripGainCalSN});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 771);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 736);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 13, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(1320, 25);
+            this.statusStrip1.Size = new System.Drawing.Size(1234, 25);
             this.statusStrip1.TabIndex = 35;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -265,7 +264,7 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(1320, 24);
+            this.menuStrip.Size = new System.Drawing.Size(1234, 24);
             this.menuStrip.TabIndex = 36;
             this.menuStrip.Text = "menuStrip1";
             // 
@@ -277,43 +276,44 @@
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 75F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 315F));
+            this.tableLayoutPanel1.Controls.Add(this.panelTrackBar, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.panelProbe, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.panelOptions, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.panelOptions, 2, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1320, 747);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1234, 712);
             this.tableLayoutPanel1.TabIndex = 37;
             // 
             // panelProbe
             // 
             this.panelProbe.BackColor = System.Drawing.SystemColors.Control;
-            this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelProbe.Location = new System.Drawing.Point(4, 4);
-            this.panelProbe.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(4);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(982, 697);
+            this.panelProbe.Size = new System.Drawing.Size(851, 662);
             this.panelProbe.TabIndex = 0;
             // 
             // panelTrackBar
             // 
-            this.panelTrackBar.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.panelTrackBar.Controls.Add(label1);
             this.panelTrackBar.Controls.Add(label3);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(917, 5);
-            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.panelTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelTrackBar.Location = new System.Drawing.Point(863, 4);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(61, 686);
+            this.panelTrackBar.Size = new System.Drawing.Size(52, 662);
             this.panelTrackBar.TabIndex = 33;
             // 
             // trackBarProbePosition
@@ -321,13 +321,14 @@
             this.trackBarProbePosition.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.trackBarProbePosition.AutoSize = false;
             this.trackBarProbePosition.BackColor = System.Drawing.SystemColors.Control;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(4, 9);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(9, 9);
             this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(45, 670);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(36, 645);
             this.trackBarProbePosition.TabIndex = 30;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
@@ -364,10 +365,10 @@
             this.panelOptions.Controls.Add(this.comboBoxApGain);
             this.panelOptions.Controls.Add(apGain);
             this.panelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelOptions.Location = new System.Drawing.Point(993, 2);
+            this.panelOptions.Location = new System.Drawing.Point(922, 2);
             this.panelOptions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelOptions.Name = "panelOptions";
-            this.panelOptions.Size = new System.Drawing.Size(324, 701);
+            this.panelOptions.Size = new System.Drawing.Size(309, 666);
             this.panelOptions.TabIndex = 2;
             // 
             // checkBoxInvertPolarity
@@ -389,7 +390,7 @@
             this.textBoxLfpCorrection.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxLfpCorrection.Name = "textBoxLfpCorrection";
             this.textBoxLfpCorrection.ReadOnly = true;
-            this.textBoxLfpCorrection.Size = new System.Drawing.Size(210, 22);
+            this.textBoxLfpCorrection.Size = new System.Drawing.Size(195, 22);
             this.textBoxLfpCorrection.TabIndex = 41;
             // 
             // textBoxApCorrection
@@ -400,7 +401,7 @@
             this.textBoxApCorrection.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxApCorrection.Name = "textBoxApCorrection";
             this.textBoxApCorrection.ReadOnly = true;
-            this.textBoxApCorrection.Size = new System.Drawing.Size(210, 22);
+            this.textBoxApCorrection.Size = new System.Drawing.Size(195, 22);
             this.textBoxApCorrection.TabIndex = 39;
             // 
             // buttonViewAdcs
@@ -411,7 +412,7 @@
             this.buttonViewAdcs.Location = new System.Drawing.Point(13, 66);
             this.buttonViewAdcs.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonViewAdcs.Name = "buttonViewAdcs";
-            this.buttonViewAdcs.Size = new System.Drawing.Size(299, 38);
+            this.buttonViewAdcs.Size = new System.Drawing.Size(284, 38);
             this.buttonViewAdcs.TabIndex = 37;
             this.buttonViewAdcs.Text = "View ADC Correction Values";
             this.buttonViewAdcs.UseVisualStyleBackColor = true;
@@ -420,7 +421,7 @@
             // buttonChooseAdcCalibrationFile
             // 
             this.buttonChooseAdcCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseAdcCalibrationFile.Location = new System.Drawing.Point(275, 30);
+            this.buttonChooseAdcCalibrationFile.Location = new System.Drawing.Point(260, 30);
             this.buttonChooseAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseAdcCalibrationFile.Name = "buttonChooseAdcCalibrationFile";
             this.buttonChooseAdcCalibrationFile.Size = new System.Drawing.Size(37, 25);
@@ -432,7 +433,7 @@
             // buttonChooseGainCalibrationFile
             // 
             this.buttonChooseGainCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseGainCalibrationFile.Location = new System.Drawing.Point(275, 133);
+            this.buttonChooseGainCalibrationFile.Location = new System.Drawing.Point(260, 133);
             this.buttonChooseGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseGainCalibrationFile.Name = "buttonChooseGainCalibrationFile";
             this.buttonChooseGainCalibrationFile.Size = new System.Drawing.Size(37, 25);
@@ -448,7 +449,7 @@
             this.buttonEnableContacts.Location = new System.Drawing.Point(13, 464);
             this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(299, 44);
+            this.buttonEnableContacts.Size = new System.Drawing.Size(284, 44);
             this.buttonEnableContacts.TabIndex = 28;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.buttonEnableContacts.UseVisualStyleBackColor = true;
@@ -461,7 +462,7 @@
             this.buttonClearSelections.Location = new System.Drawing.Point(13, 512);
             this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(299, 44);
+            this.buttonClearSelections.Size = new System.Drawing.Size(284, 44);
             this.buttonClearSelections.TabIndex = 27;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.buttonClearSelections.UseVisualStyleBackColor = true;
@@ -476,7 +477,7 @@
             this.comboBoxChannelPresets.Location = new System.Drawing.Point(101, 411);
             this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
-            this.comboBoxChannelPresets.Size = new System.Drawing.Size(210, 24);
+            this.comboBoxChannelPresets.Size = new System.Drawing.Size(195, 24);
             this.comboBoxChannelPresets.TabIndex = 26;
             // 
             // buttonResetZoom
@@ -486,7 +487,7 @@
             this.buttonResetZoom.Location = new System.Drawing.Point(13, 562);
             this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(299, 44);
+            this.buttonResetZoom.Size = new System.Drawing.Size(284, 44);
             this.buttonResetZoom.TabIndex = 22;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.buttonResetZoom.UseVisualStyleBackColor = true;
@@ -510,7 +511,7 @@
             this.textBoxAdcCalibrationFile.Location = new System.Drawing.Point(13, 30);
             this.textBoxAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxAdcCalibrationFile.Name = "textBoxAdcCalibrationFile";
-            this.textBoxAdcCalibrationFile.Size = new System.Drawing.Size(255, 22);
+            this.textBoxAdcCalibrationFile.Size = new System.Drawing.Size(240, 22);
             this.textBoxAdcCalibrationFile.TabIndex = 12;
             this.textBoxAdcCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.textBoxAdcCalibrationFile.TextChanged += new System.EventHandler(this.AdcCalibrationFileTextChanged);
@@ -522,7 +523,7 @@
             this.textBoxGainCalibrationFile.Location = new System.Drawing.Point(13, 133);
             this.textBoxGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxGainCalibrationFile.Name = "textBoxGainCalibrationFile";
-            this.textBoxGainCalibrationFile.Size = new System.Drawing.Size(255, 22);
+            this.textBoxGainCalibrationFile.Size = new System.Drawing.Size(240, 22);
             this.textBoxGainCalibrationFile.TabIndex = 9;
             this.textBoxGainCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.textBoxGainCalibrationFile.TextChanged += new System.EventHandler(this.GainCalibrationFileTextChanged);
@@ -536,7 +537,7 @@
             this.comboBoxReference.Location = new System.Drawing.Point(101, 373);
             this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
-            this.comboBoxReference.Size = new System.Drawing.Size(210, 24);
+            this.comboBoxReference.Size = new System.Drawing.Size(195, 24);
             this.comboBoxReference.TabIndex = 5;
             // 
             // comboBoxLfpGain
@@ -548,7 +549,7 @@
             this.comboBoxLfpGain.Location = new System.Drawing.Point(101, 240);
             this.comboBoxLfpGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxLfpGain.Name = "comboBoxLfpGain";
-            this.comboBoxLfpGain.Size = new System.Drawing.Size(210, 24);
+            this.comboBoxLfpGain.Size = new System.Drawing.Size(195, 24);
             this.comboBoxLfpGain.TabIndex = 3;
             // 
             // comboBoxApGain
@@ -560,26 +561,26 @@
             this.comboBoxApGain.Location = new System.Drawing.Point(101, 174);
             this.comboBoxApGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxApGain.Name = "comboBoxApGain";
-            this.comboBoxApGain.Size = new System.Drawing.Size(210, 24);
+            this.comboBoxApGain.Size = new System.Drawing.Size(195, 24);
             this.comboBoxApGain.TabIndex = 1;
             // 
             // flowLayoutPanel1
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
+            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 3);
             this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 707);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 672);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(1314, 38);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1228, 38);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // buttonCancel
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(1200, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(1114, 2);
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(111, 34);
@@ -590,7 +591,7 @@
             // buttonOkay
             // 
             this.buttonOkay.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOkay.Location = new System.Drawing.Point(1083, 2);
+            this.buttonOkay.Location = new System.Drawing.Point(997, 2);
             this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
             this.buttonOkay.Size = new System.Drawing.Size(111, 34);
@@ -602,7 +603,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1320, 796);
+            this.ClientSize = new System.Drawing.Size(1234, 761);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip);
             this.Controls.Add(this.statusStrip1);
@@ -616,7 +617,6 @@
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
-            this.panelProbe.ResumeLayout(false);
             this.panelTrackBar.ResumeLayout(false);
             this.panelTrackBar.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarProbePosition)).EndInit();

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -115,7 +115,6 @@ namespace OpenEphys.Onix1.Design
             }
 
             ChannelConfiguration.Show();
-            ChannelConfiguration.ConnectResizeEventHandler();
             ChannelConfiguration.OnResizeZedGraph += ResizeTrackBar;
         }
 
@@ -317,22 +316,22 @@ namespace OpenEphys.Onix1.Design
 
             panelProbe.Visible = adcCalibration.HasValue && gainCorrection.HasValue;
 
-            if (toolStripAdcCalSN.Text == NoFileSelected) 
+            if (toolStripAdcCalSN.Text == NoFileSelected)
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusWarningImage;
-            else if (toolStripAdcCalSN.Text == InvalidFile) 
+            else if (toolStripAdcCalSN.Text == InvalidFile)
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusCriticalImage;
             else if (toolStripGainCalSN.Text != NoFileSelected && toolStripGainCalSN.Text != InvalidFile && toolStripAdcCalSN.Text != toolStripGainCalSN.Text)
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusBlockedImage;
-            else 
+            else
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusReadyImage;
 
-            if (toolStripGainCalSN.Text == NoFileSelected) 
+            if (toolStripGainCalSN.Text == NoFileSelected)
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusWarningImage;
-            else if (toolStripGainCalSN.Text == InvalidFile) 
+            else if (toolStripGainCalSN.Text == InvalidFile)
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusCriticalImage;
             else if (toolStripAdcCalSN.Text != NoFileSelected && toolStripAdcCalSN.Text != InvalidFile && toolStripAdcCalSN.Text != toolStripGainCalSN.Text)
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusBlockedImage;
-            else 
+            else
                 toolStripLabelGainCalibrationSn.Image = Properties.Resources.StatusReadyImage;
         }
 
@@ -455,7 +454,6 @@ namespace OpenEphys.Onix1.Design
         {
             ChannelConfiguration.ResetZoom();
             ChannelConfiguration.RefreshZedGraph();
-            ChannelConfiguration.DrawScale();
         }
 
         private void MoveToVerticalPosition(float relativePosition)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
@@ -57,7 +57,7 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1350, 732);
+            this.tabControl1.Size = new System.Drawing.Size(1328, 741);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV1e
@@ -67,7 +67,7 @@
             this.tabPageNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageNeuropixelsV1e.Name = "tabPageNeuropixelsV1e";
             this.tabPageNeuropixelsV1e.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageNeuropixelsV1e.Size = new System.Drawing.Size(1342, 703);
+            this.tabPageNeuropixelsV1e.Size = new System.Drawing.Size(1320, 712);
             this.tabPageNeuropixelsV1e.TabIndex = 0;
             this.tabPageNeuropixelsV1e.Text = "NeuropixelsV1e";
             this.tabPageNeuropixelsV1e.UseVisualStyleBackColor = true;
@@ -79,7 +79,7 @@
             this.panelNeuropixelsV1e.Location = new System.Drawing.Point(3, 2);
             this.panelNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV1e.Name = "panelNeuropixelsV1e";
-            this.panelNeuropixelsV1e.Size = new System.Drawing.Size(1336, 699);
+            this.panelNeuropixelsV1e.Size = new System.Drawing.Size(1314, 708);
             this.panelNeuropixelsV1e.TabIndex = 0;
             // 
             // tabPageBno055
@@ -106,7 +106,7 @@
             // buttonCancel
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(1238, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(1216, 2);
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(111, 34);
@@ -117,7 +117,7 @@
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOK.Location = new System.Drawing.Point(1121, 2);
+            this.buttonOK.Location = new System.Drawing.Point(1099, 2);
             this.buttonOK.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(111, 34);
@@ -134,14 +134,14 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1356, 26);
+            this.menuStrip1.Size = new System.Drawing.Size(1334, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -151,13 +151,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1356, 778);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1334, 787);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -166,17 +166,17 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 738);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 747);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(1352, 38);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1330, 38);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // NeuropixelsV1eHeadstageDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1356, 804);
+            this.ClientSize = new System.Drawing.Size(1334, 811);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip1);
             this.DoubleBuffered = true;

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.Designer.cs
@@ -32,6 +32,8 @@
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPageNeuropixelsV1A = new System.Windows.Forms.TabPage();
             this.panelNeuropixelsV1A = new System.Windows.Forms.Panel();
+            this.tabPageNeuropixelsV1B = new System.Windows.Forms.TabPage();
+            this.panelNeuropixelsV1B = new System.Windows.Forms.Panel();
             this.tabPageBno055 = new System.Windows.Forms.TabPage();
             this.panelBno055 = new System.Windows.Forms.Panel();
             this.buttonCancel = new System.Windows.Forms.Button();
@@ -40,15 +42,13 @@
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.tabPageNeuropixelsV1B = new System.Windows.Forms.TabPage();
-            this.panelNeuropixelsV1B = new System.Windows.Forms.Panel();
             this.tabControl1.SuspendLayout();
             this.tabPageNeuropixelsV1A.SuspendLayout();
+            this.tabPageNeuropixelsV1B.SuspendLayout();
             this.tabPageBno055.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
-            this.tabPageNeuropixelsV1B.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControl1
@@ -61,7 +61,7 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1350, 732);
+            this.tabControl1.Size = new System.Drawing.Size(1328, 741);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV1A
@@ -69,7 +69,7 @@
             this.tabPageNeuropixelsV1A.Controls.Add(this.panelNeuropixelsV1A);
             this.tabPageNeuropixelsV1A.Location = new System.Drawing.Point(4, 25);
             this.tabPageNeuropixelsV1A.Name = "tabPageNeuropixelsV1A";
-            this.tabPageNeuropixelsV1A.Size = new System.Drawing.Size(1342, 703);
+            this.tabPageNeuropixelsV1A.Size = new System.Drawing.Size(1320, 712);
             this.tabPageNeuropixelsV1A.TabIndex = 0;
             this.tabPageNeuropixelsV1A.Text = "NeuropixelsV1A";
             this.tabPageNeuropixelsV1A.UseVisualStyleBackColor = true;
@@ -80,8 +80,28 @@
             this.panelNeuropixelsV1A.Location = new System.Drawing.Point(0, 0);
             this.panelNeuropixelsV1A.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV1A.Name = "panelNeuropixelsV1A";
-            this.panelNeuropixelsV1A.Size = new System.Drawing.Size(1342, 703);
+            this.panelNeuropixelsV1A.Size = new System.Drawing.Size(1320, 712);
             this.panelNeuropixelsV1A.TabIndex = 0;
+            // 
+            // tabPageNeuropixelsV1B
+            // 
+            this.tabPageNeuropixelsV1B.Controls.Add(this.panelNeuropixelsV1B);
+            this.tabPageNeuropixelsV1B.Location = new System.Drawing.Point(4, 25);
+            this.tabPageNeuropixelsV1B.Name = "tabPageNeuropixelsV1B";
+            this.tabPageNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
+            this.tabPageNeuropixelsV1B.TabIndex = 2;
+            this.tabPageNeuropixelsV1B.Text = "NeuropixelsV1B";
+            this.tabPageNeuropixelsV1B.UseVisualStyleBackColor = true;
+            // 
+            // panelNeuropixelsV1B
+            // 
+            this.panelNeuropixelsV1B.AutoSize = true;
+            this.panelNeuropixelsV1B.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelNeuropixelsV1B.Location = new System.Drawing.Point(0, 0);
+            this.panelNeuropixelsV1B.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.panelNeuropixelsV1B.Name = "panelNeuropixelsV1B";
+            this.panelNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
+            this.panelNeuropixelsV1B.TabIndex = 1;
             // 
             // tabPageBno055
             // 
@@ -107,7 +127,7 @@
             // buttonCancel
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(1238, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(1216, 2);
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(111, 34);
@@ -118,7 +138,7 @@
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOK.Location = new System.Drawing.Point(1121, 2);
+            this.buttonOK.Location = new System.Drawing.Point(1099, 2);
             this.buttonOK.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(111, 34);
@@ -135,14 +155,14 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1356, 26);
+            this.menuStrip1.Size = new System.Drawing.Size(1334, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -152,13 +172,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1356, 778);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1334, 787);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -167,37 +187,17 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 738);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 747);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(1352, 38);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1330, 38);
             this.flowLayoutPanel1.TabIndex = 0;
-            // 
-            // tabPageNeuropixelsV1B
-            // 
-            this.tabPageNeuropixelsV1B.Controls.Add(this.panelNeuropixelsV1B);
-            this.tabPageNeuropixelsV1B.Location = new System.Drawing.Point(4, 25);
-            this.tabPageNeuropixelsV1B.Name = "tabPageNeuropixelsV1B";
-            this.tabPageNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
-            this.tabPageNeuropixelsV1B.TabIndex = 2;
-            this.tabPageNeuropixelsV1B.Text = "NeuropixelsV1B";
-            this.tabPageNeuropixelsV1B.UseVisualStyleBackColor = true;
-            // 
-            // panelNeuropixelsV1B
-            // 
-            this.panelNeuropixelsV1B.AutoSize = true;
-            this.panelNeuropixelsV1B.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelNeuropixelsV1B.Location = new System.Drawing.Point(0, 0);
-            this.panelNeuropixelsV1B.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.panelNeuropixelsV1B.Name = "panelNeuropixelsV1B";
-            this.panelNeuropixelsV1B.Size = new System.Drawing.Size(1342, 703);
-            this.panelNeuropixelsV1B.TabIndex = 1;
             // 
             // NeuropixelsV1fHeadstageDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1356, 804);
+            this.ClientSize = new System.Drawing.Size(1334, 811);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip1);
             this.DoubleBuffered = true;
@@ -209,13 +209,13 @@
             this.Text = "NeuropixelsV1f Headstage Configuration";
             this.tabControl1.ResumeLayout(false);
             this.tabPageNeuropixelsV1A.ResumeLayout(false);
+            this.tabPageNeuropixelsV1B.ResumeLayout(false);
+            this.tabPageNeuropixelsV1B.PerformLayout();
             this.tabPageBno055.ResumeLayout(false);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.ResumeLayout(false);
-            this.tabPageNeuropixelsV1B.ResumeLayout(false);
-            this.tabPageNeuropixelsV1B.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using OpenEphys.ProbeInterface.NET;
@@ -36,11 +34,12 @@ namespace OpenEphys.Onix1.Design
 
             ProbeConfiguration = probeConfiguration;
 
-            ZoomInBoundaryX = 600;
-            ZoomInBoundaryY = 600;
+            ZoomInBoundaryX = 300;
+            ZoomInBoundaryY = 300;
 
             HighlightEnabledContacts();
             UpdateContactLabels();
+            DrawScale();
             RefreshZedGraph();
         }
 
@@ -81,7 +80,6 @@ namespace OpenEphys.Onix1.Design
             base.ZoomEvent(sender, oldState, newState);
 
             UpdateFontSize();
-            DrawScale();
             RefreshZedGraph();
 
             OnZoomHandler();
@@ -92,91 +90,21 @@ namespace OpenEphys.Onix1.Design
             OnZoom?.Invoke(this, EventArgs.Empty);
         }
 
+        internal override bool IsDrawScale() => true;
+
         internal override void DrawScale()
         {
-            if (ProbeConfiguration == null)
+            if (ProbeConfiguration == null || zedGraphChannels.MasterPane.PaneList.Count < 2)
                 return;
 
-            const string ScalePointsTag = "scale_points";
-            const string ScaleTextTag = "scale_text";
+            var pane = zedGraphChannels.MasterPane.PaneList[1];
 
-            zedGraphChannels.GraphPane.GraphObjList.RemoveAll(obj => obj is TextObj && obj.Tag is string tag && tag == ScaleTextTag);
-            zedGraphChannels.GraphPane.CurveList.RemoveAll(curve => curve.Tag is string tag && tag == ScalePointsTag);
+            pane.YAxis.Scale.Min = GetProbeBottom(zedGraphChannels.GraphPane.GraphObjList);
+            pane.YAxis.Scale.Max = GetProbeTop(zedGraphChannels.GraphPane.GraphObjList);
 
-            const int MajorTickIncrement = 100;
-            const int MajorTickLength = 10;
-            const int MinorTickIncrement = 10;
-            const int MinorTickLength = 5;
-
-            if (ProbeConfiguration.ProbeGroup.Probes.ElementAt(0).SiUnits != ProbeSiUnits.um)
-            {
-                MessageBox.Show("Warning: Expected ProbeGroup units to be in microns, but it is in millimeters. Scale might not be accurate.");
-            }
-
-            var fontSize = CalculateFontSize();
-
-            var zoomedOut = fontSize <= 2;
-
-            fontSize = zoomedOut ? 8 : fontSize * 4;
-            var majorTickOffset = MajorTickLength + CalculateScaleRange(zedGraphChannels.GraphPane.XAxis.Scale) * 0.015;
-            majorTickOffset = majorTickOffset > 50 ? 50 : majorTickOffset;
-
-            var x = GetProbeRight(zedGraphChannels.GraphPane.GraphObjList) + 50;
-            var minY = GetProbeBottom(zedGraphChannels.GraphPane.GraphObjList);
-            var maxY = GetProbeTop(zedGraphChannels.GraphPane.GraphObjList);
-
-            int textPosition = 0;
-
-            PointPairList pointList = new();
-
-            var countMajorTicks = 0;
-
-            for (int i = (int)minY; i < maxY; i += MajorTickIncrement)
-            {
-                PointPair majorTickLocation = new(x + majorTickOffset, minY + MajorTickIncrement * countMajorTicks);
-
-                pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks));
-                pointList.Add(majorTickLocation);
-                pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks));
-
-                if (!zoomedOut || countMajorTicks % 5 == 0)
-                {
-                    TextObj textObj = new($"{textPosition} µm\n", majorTickLocation.X + 5, majorTickLocation.Y, CoordType.AxisXYScale, AlignH.Left, AlignV.Center)
-                    {
-                        Tag = ScaleTextTag,
-                    };
-                    textObj.FontSpec.Border.IsVisible = false;
-                    textObj.FontSpec.Size = fontSize;
-                    zedGraphChannels.GraphPane.GraphObjList.Add(textObj);
-
-                    textPosition += zoomedOut ? 5 * MajorTickIncrement : MajorTickIncrement;
-                }
-
-                if (!zoomedOut)
-                {
-                    var countMinorTicks = 1;
-
-                    for (int j = i + MinorTickIncrement; j < i + MajorTickIncrement && i + MinorTickIncrement * countMinorTicks < maxY; j += MinorTickIncrement)
-                    {
-                        pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks + MinorTickIncrement * countMinorTicks));
-                        pointList.Add(new PointPair(x + MinorTickLength, minY + MajorTickIncrement * countMajorTicks + MinorTickIncrement * countMinorTicks));
-                        pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks + MinorTickIncrement * countMinorTicks));
-
-                        countMinorTicks++;
-                    }
-                }
-
-                countMajorTicks++;
-            }
-
-            var curve = zedGraphChannels.GraphPane.AddCurve("", pointList, Color.Black, SymbolType.None);
-
-            const float scaleBarWidth = 1;
-
-            curve.Line.Width = scaleBarWidth; 
-            curve.Label.IsVisible = false;
-            curve.Symbol.IsVisible = false;
-            curve.Tag = ScalePointsTag;
+            pane.YAxis.Scale.Format = "#####0' " + ProbeGroup.Probes.First().SiUnits.ToString() + "'";
+            pane.YAxis.Scale.Mag = 0;
+            pane.YAxis.Scale.MagAuto = false;
         }
 
         internal override void HighlightEnabledContacts()

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
@@ -52,7 +52,7 @@
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(996, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(1179, 2);
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(144, 32);
@@ -63,7 +63,7 @@
             // buttonOkay
             // 
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOkay.Location = new System.Drawing.Point(846, 2);
+            this.buttonOkay.Location = new System.Drawing.Point(1029, 2);
             this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
             this.buttonOkay.Size = new System.Drawing.Size(144, 32);
@@ -80,14 +80,14 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1151, 26);
+            this.menuStrip1.Size = new System.Drawing.Size(1334, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -97,13 +97,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1151, 623);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1334, 787);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // tabControl1
@@ -115,7 +115,7 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1145, 577);
+            this.tabControl1.Size = new System.Drawing.Size(1328, 741);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV2e
@@ -125,7 +125,7 @@
             this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageNeuropixelsV2e.Name = "tabPageNeuropixelsV2e";
             this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(1137, 548);
+            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(1320, 712);
             this.tabPageNeuropixelsV2e.TabIndex = 0;
             this.tabPageNeuropixelsV2e.Text = "NeuropixelsV2e";
             this.tabPageNeuropixelsV2e.UseVisualStyleBackColor = true;
@@ -136,7 +136,7 @@
             this.panelNeuropixelsV2e.Location = new System.Drawing.Point(3, 2);
             this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV2e.Name = "panelNeuropixelsV2e";
-            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(1131, 544);
+            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(1314, 708);
             this.panelNeuropixelsV2e.TabIndex = 0;
             // 
             // tabPageBno055
@@ -146,7 +146,7 @@
             this.tabPageBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageBno055.Name = "tabPageBno055";
             this.tabPageBno055.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageBno055.Size = new System.Drawing.Size(1137, 541);
+            this.tabPageBno055.Size = new System.Drawing.Size(1137, 548);
             this.tabPageBno055.TabIndex = 1;
             this.tabPageBno055.Text = "Bno055";
             this.tabPageBno055.UseVisualStyleBackColor = true;
@@ -158,7 +158,7 @@
             this.panelBno055.Location = new System.Drawing.Point(3, 2);
             this.panelBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(1131, 537);
+            this.panelBno055.Size = new System.Drawing.Size(1131, 544);
             this.panelBno055.TabIndex = 0;
             // 
             // flowLayoutPanel1
@@ -169,17 +169,17 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 585);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 749);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(1143, 34);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1326, 34);
             this.flowLayoutPanel1.TabIndex = 1;
             // 
             // NeuropixelsV2eHeadstageDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1151, 649);
+            this.ClientSize = new System.Drawing.Size(1334, 811);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip1);
             this.DoubleBuffered = true;

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
@@ -49,6 +49,7 @@
             this.panelTrackBar = new System.Windows.Forms.Panel();
             this.trackBarProbePosition = new System.Windows.Forms.TrackBar();
             this.panelChannelOptions = new System.Windows.Forms.Panel();
+            this.checkBoxInvertPolarity = new System.Windows.Forms.CheckBox();
             this.textBoxGainCorrection = new System.Windows.Forms.TextBox();
             this.textBoxProbeCalibrationFile = new System.Windows.Forms.TextBox();
             this.comboBoxReference = new System.Windows.Forms.ComboBox();
@@ -59,7 +60,6 @@
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripGainCalSN = new System.Windows.Forms.ToolStripStatusLabel();
-            this.checkBoxInvertPolarity = new System.Windows.Forms.CheckBox();
             label6 = new System.Windows.Forms.Label();
             label7 = new System.Windows.Forms.Label();
             probeCalibrationFile = new System.Windows.Forms.Label();
@@ -68,7 +68,6 @@
             label1 = new System.Windows.Forms.Label();
             invertPolarity = new System.Windows.Forms.Label();
             this.menuStrip.SuspendLayout();
-            this.panelProbe.SuspendLayout();
             this.panelTrackBar.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarProbePosition)).BeginInit();
             this.panelChannelOptions.SuspendLayout();
@@ -81,10 +80,9 @@
             // 
             label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             label6.AutoSize = true;
-            label6.Location = new System.Drawing.Point(0, 440);
-            label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label6.Location = new System.Drawing.Point(3, 641);
             label6.Name = "label6";
-            label6.Size = new System.Drawing.Size(32, 13);
+            label6.Size = new System.Drawing.Size(39, 16);
             label6.TabIndex = 28;
             label6.Text = "0 mm";
             // 
@@ -92,10 +90,9 @@
             // 
             label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             label7.AutoSize = true;
-            label7.Location = new System.Drawing.Point(0, 0);
-            label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label7.Location = new System.Drawing.Point(3, 0);
             label7.Name = "label7";
-            label7.Size = new System.Drawing.Size(38, 13);
+            label7.Size = new System.Drawing.Size(46, 16);
             label7.TabIndex = 29;
             label7.Text = "10 mm";
             label7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -103,43 +100,48 @@
             // probeCalibrationFile
             // 
             probeCalibrationFile.AutoSize = true;
-            probeCalibrationFile.Location = new System.Drawing.Point(11, 9);
-            probeCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            probeCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            probeCalibrationFile.Location = new System.Drawing.Point(15, 11);
+            probeCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             probeCalibrationFile.Name = "probeCalibrationFile";
-            probeCalibrationFile.Size = new System.Drawing.Size(109, 13);
+            probeCalibrationFile.Size = new System.Drawing.Size(139, 16);
             probeCalibrationFile.TabIndex = 32;
             probeCalibrationFile.Text = "Probe Calibration File:";
             // 
             // Reference
             // 
             Reference.AutoSize = true;
-            Reference.Location = new System.Drawing.Point(11, 93);
-            Reference.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            Reference.Location = new System.Drawing.Point(15, 114);
             Reference.Name = "Reference";
-            Reference.Size = new System.Drawing.Size(60, 13);
+            Reference.Size = new System.Drawing.Size(73, 16);
             Reference.TabIndex = 30;
             Reference.Text = "Reference:";
             // 
             // labelPresets
             // 
             labelPresets.AutoSize = true;
-            labelPresets.Location = new System.Drawing.Point(11, 119);
-            labelPresets.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            labelPresets.Location = new System.Drawing.Point(15, 146);
             labelPresets.Name = "labelPresets";
-            labelPresets.Size = new System.Drawing.Size(49, 26);
+            labelPresets.Size = new System.Drawing.Size(59, 32);
             labelPresets.TabIndex = 23;
             labelPresets.Text = "Channel \nPresets:";
             // 
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(11, 51);
-            label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label1.Location = new System.Drawing.Point(15, 63);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(58, 26);
+            label1.Size = new System.Drawing.Size(71, 32);
             label1.TabIndex = 35;
             label1.Text = "Gain\r\nCorrection:";
+            // 
+            // invertPolarity
+            // 
+            invertPolarity.AutoSize = true;
+            invertPolarity.Location = new System.Drawing.Point(15, 187);
+            invertPolarity.Name = "invertPolarity";
+            invertPolarity.Size = new System.Drawing.Size(55, 32);
+            invertPolarity.TabIndex = 44;
+            invertPolarity.Text = "Invert\r\nPolarity:";
             // 
             // toolStripLabelGainCalibrationSN
             // 
@@ -157,8 +159,8 @@
             this.fileToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(834, 24);
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip.Size = new System.Drawing.Size(1234, 24);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
@@ -172,10 +174,10 @@
             // 
             this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(11, 184);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonEnableContacts.Location = new System.Drawing.Point(15, 226);
+            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(183, 36);
+            this.buttonEnableContacts.Size = new System.Drawing.Size(280, 44);
             this.buttonEnableContacts.TabIndex = 20;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select electrodes in the probe view. \r\nPress this button to ena" +
@@ -187,10 +189,10 @@
             // 
             this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(11, 224);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonClearSelections.Location = new System.Drawing.Point(15, 276);
+            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(183, 36);
+            this.buttonClearSelections.Size = new System.Drawing.Size(280, 44);
             this.buttonClearSelections.TabIndex = 19;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.toolTip.SetToolTip(this.buttonClearSelections, "Deselect all electrodes in the probe view. \r\nNote that this does not disable elec" +
@@ -202,10 +204,10 @@
             // 
             this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(11, 264);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonResetZoom.Location = new System.Drawing.Point(15, 325);
+            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(183, 36);
+            this.buttonResetZoom.Size = new System.Drawing.Size(280, 44);
             this.buttonResetZoom.TabIndex = 4;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.");
@@ -215,10 +217,10 @@
             // buttonChooseCalibrationFile
             // 
             this.buttonChooseCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(166, 24);
-            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(257, 30);
+            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseCalibrationFile.Name = "buttonChooseCalibrationFile";
-            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(37, 25);
             this.buttonChooseCalibrationFile.TabIndex = 34;
             this.buttonChooseCalibrationFile.Text = "...";
             this.toolTip.SetToolTip(this.buttonChooseCalibrationFile, "Browse for a gain calibration file.");
@@ -228,23 +230,23 @@
             // panelProbe
             // 
             this.panelProbe.AutoSize = true;
-            this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(2, 2);
-            this.panelProbe.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelProbe.Location = new System.Drawing.Point(3, 2);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(621, 443);
+            this.panelProbe.Size = new System.Drawing.Size(853, 662);
             this.panelProbe.TabIndex = 1;
             // 
             // panelTrackBar
             // 
-            this.panelTrackBar.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.panelTrackBar.Controls.Add(label6);
             this.panelTrackBar.Controls.Add(label7);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(581, -5);
+            this.panelTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelTrackBar.Location = new System.Drawing.Point(863, 4);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(37, 454);
+            this.panelTrackBar.Size = new System.Drawing.Size(52, 658);
             this.panelTrackBar.TabIndex = 30;
             // 
             // trackBarProbePosition
@@ -252,12 +254,12 @@
             this.trackBarProbePosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBarProbePosition.AutoSize = false;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(-6, 9);
-            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(8, 11);
+            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(37, 435);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(36, 645);
             this.trackBarProbePosition.TabIndex = 22;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
@@ -284,21 +286,32 @@
             this.panelChannelOptions.Controls.Add(this.buttonClearSelections);
             this.panelChannelOptions.Controls.Add(this.buttonResetZoom);
             this.panelChannelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelChannelOptions.Location = new System.Drawing.Point(627, 2);
-            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelChannelOptions.Location = new System.Drawing.Point(922, 2);
+            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelChannelOptions.Name = "panelChannelOptions";
-            this.panelChannelOptions.Size = new System.Drawing.Size(205, 443);
+            this.panelChannelOptions.Size = new System.Drawing.Size(309, 662);
             this.panelChannelOptions.TabIndex = 1;
+            // 
+            // checkBoxInvertPolarity
+            // 
+            this.checkBoxInvertPolarity.AutoSize = true;
+            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(107, 193);
+            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
+            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(77, 20);
+            this.checkBoxInvertPolarity.TabIndex = 45;
+            this.checkBoxInvertPolarity.Text = "Enabled";
+            this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
             // 
             // textBoxGainCorrection
             // 
             this.textBoxGainCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxGainCorrection.Location = new System.Drawing.Point(80, 55);
-            this.textBoxGainCorrection.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxGainCorrection.Location = new System.Drawing.Point(107, 68);
+            this.textBoxGainCorrection.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxGainCorrection.Name = "textBoxGainCorrection";
             this.textBoxGainCorrection.ReadOnly = true;
-            this.textBoxGainCorrection.Size = new System.Drawing.Size(115, 20);
+            this.textBoxGainCorrection.Size = new System.Drawing.Size(188, 22);
             this.textBoxGainCorrection.TabIndex = 36;
             this.textBoxGainCorrection.TabStop = false;
             // 
@@ -306,10 +319,10 @@
             // 
             this.textBoxProbeCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(11, 24);
-            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(15, 30);
+            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxProbeCalibrationFile.Name = "textBoxProbeCalibrationFile";
-            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(150, 20);
+            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(235, 22);
             this.textBoxProbeCalibrationFile.TabIndex = 33;
             this.textBoxProbeCalibrationFile.TextChanged += new System.EventHandler(this.FileTextChanged);
             // 
@@ -319,10 +332,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxReference.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxReference.FormattingEnabled = true;
-            this.comboBoxReference.Location = new System.Drawing.Point(80, 89);
-            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.comboBoxReference.Location = new System.Drawing.Point(107, 110);
+            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
-            this.comboBoxReference.Size = new System.Drawing.Size(115, 21);
+            this.comboBoxReference.Size = new System.Drawing.Size(188, 24);
             this.comboBoxReference.TabIndex = 31;
             // 
             // comboBoxChannelPresets
@@ -331,10 +344,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxChannelPresets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxChannelPresets.FormattingEnabled = true;
-            this.comboBoxChannelPresets.Location = new System.Drawing.Point(80, 122);
-            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.comboBoxChannelPresets.Location = new System.Drawing.Point(107, 150);
+            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
-            this.comboBoxChannelPresets.Size = new System.Drawing.Size(115, 21);
+            this.comboBoxChannelPresets.Size = new System.Drawing.Size(188, 24);
             this.comboBoxChannelPresets.TabIndex = 24;
             // 
             // buttonCancel
@@ -342,10 +355,10 @@
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(743, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(1112, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 28);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -355,10 +368,10 @@
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonOkay.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOkay.Location = new System.Drawing.Point(656, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonOkay.Location = new System.Drawing.Point(995, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 28);
+            this.buttonOkay.Size = new System.Drawing.Size(111, 34);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
@@ -367,32 +380,35 @@
             // 
             this.tableLayoutPanel1.AutoSize = true;
             this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 75F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
-            this.tableLayoutPanel1.Controls.Add(this.panelChannelOptions, 1, 0);
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 315F));
+            this.tableLayoutPanel1.Controls.Add(this.panelTrackBar, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.panelProbe, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.panelChannelOptions, 2, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 16F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(834, 484);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 46F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1234, 712);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
+            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 3);
             this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 450);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 670);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(828, 31);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1226, 38);
             this.flowLayoutPanel1.TabIndex = 2;
             // 
             // statusStrip1
@@ -401,10 +417,10 @@
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabelGainCalibrationSN,
             this.toolStripGainCalSN});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 508);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 736);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 10, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(834, 25);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 13, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1234, 25);
             this.statusStrip1.TabIndex = 3;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -415,45 +431,23 @@
             this.toolStripGainCalSN.Text = "No file selected.";
             this.toolStripGainCalSN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // checkBoxInvertPolarity
-            // 
-            this.checkBoxInvertPolarity.AutoSize = true;
-            this.checkBoxInvertPolarity.Location = new System.Drawing.Point(80, 157);
-            this.checkBoxInvertPolarity.Margin = new System.Windows.Forms.Padding(2);
-            this.checkBoxInvertPolarity.Name = "checkBoxInvertPolarity";
-            this.checkBoxInvertPolarity.Size = new System.Drawing.Size(65, 17);
-            this.checkBoxInvertPolarity.TabIndex = 45;
-            this.checkBoxInvertPolarity.Text = "Enabled";
-            this.checkBoxInvertPolarity.UseVisualStyleBackColor = true;
-            // 
-            // invertPolarity
-            // 
-            invertPolarity.AutoSize = true;
-            invertPolarity.Location = new System.Drawing.Point(11, 152);
-            invertPolarity.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            invertPolarity.Name = "invertPolarity";
-            invertPolarity.Size = new System.Drawing.Size(44, 26);
-            invertPolarity.TabIndex = 44;
-            invertPolarity.Text = "Invert\r\nPolarity:";
-            // 
             // NeuropixelsV2eProbeConfigurationDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(834, 533);
+            this.ClientSize = new System.Drawing.Size(1234, 761);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.menuStrip);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip;
-            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV2eProbeConfigurationDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Probe Configuration";
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
-            this.panelProbe.ResumeLayout(false);
             this.panelTrackBar.ResumeLayout(false);
             this.panelTrackBar.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarProbePosition)).EndInit();

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -643,7 +643,6 @@ namespace OpenEphys.Onix1.Design
         private void ResetZoom()
         {
             ChannelConfiguration.ResetZoom();
-            ChannelConfiguration.DrawScale();
             ChannelConfiguration.RefreshZedGraph();
         }
 

--- a/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
@@ -25,6 +25,8 @@ namespace OpenEphys.Onix1.Design
             InitializeComponent();
             ProbeGroup = probeGroup;
 
+            OnDrawProbeGroup += CustomTextHandler;
+
             zedGraphChannels.ZoomButtons = MouseButtons.None;
             zedGraphChannels.ZoomButtons2 = MouseButtons.None;
 
@@ -33,6 +35,7 @@ namespace OpenEphys.Onix1.Design
             ZoomInBoundaryX = 5;
             ZoomInBoundaryY = 5;
 
+            DrawProbeGroup();
             RefreshZedGraph();
         }
 
@@ -106,34 +109,38 @@ namespace OpenEphys.Onix1.Design
             return s;
         }
 
+        void CustomTextHandler(object sender, EventArgs eventArgs)
+        {
+            // TODO: This could be optimized so we aren't serializing and comparing strings.
+            // Potential methods: reflection to compare all properties, or
+            // implementing IEquatable<T> and writing out all possible properties.
+            if (JsonConvert.SerializeObject(ProbeGroup) == JsonConvert.SerializeObject(new Rhs2116ProbeGroup()))
+                DrawCustomText();
+        }
+
         // NB: Currently there is only a text label drawn as the scale for this dialog, used to denote the
         // absolute orientation of the default probe group
-        internal override void DrawScale()
+        void DrawCustomText()
         {
-            const string scaleTag = "scale";
+            const string customTag = "custom";
 
-            zedGraphChannels.GraphPane.GraphObjList.RemoveAll(obj => obj.Tag is string tag && tag == scaleTag);
+            zedGraphChannels.GraphPane.GraphObjList.RemoveAll(obj => obj.Tag is string tag && tag == customTag);
 
-            bool isDefault = JsonConvert.SerializeObject(ProbeGroup) == JsonConvert.SerializeObject(new Rhs2116ProbeGroup());
+            var middle = GetProbeContourLeft(zedGraphChannels.GraphPane.GraphObjList)
+                + (GetProbeContourRight(zedGraphChannels.GraphPane.GraphObjList) - GetProbeContourLeft(zedGraphChannels.GraphPane.GraphObjList)) / 2;
+            var top = GetProbeContourTop(zedGraphChannels.GraphPane.GraphObjList);
 
-            if (isDefault)
+            TextObj textObj = new("Tether Side", middle, top + 0.5, CoordType.AxisXYScale, AlignH.Center, AlignV.Center)
             {
-                var middle = GetProbeContourLeft(zedGraphChannels.GraphPane.GraphObjList)
-                    + (GetProbeContourRight(zedGraphChannels.GraphPane.GraphObjList) - GetProbeContourLeft(zedGraphChannels.GraphPane.GraphObjList)) / 2;
-                var top = GetProbeContourTop(zedGraphChannels.GraphPane.GraphObjList);
+                ZOrder = ZOrder.A_InFront,
+                Tag = customTag
+            };
 
-                TextObj textObj = new("Tether Side", middle, top + 0.5, CoordType.AxisXYScale, AlignH.Center, AlignV.Center)
-                {
-                    ZOrder = ZOrder.A_InFront,
-                    Tag = scaleTag
-                };
+            SetTextObj(textObj);
 
-                SetTextObj(textObj);
+            textObj.FontSpec.Size = CalculateFontSize(4.0);
 
-                textObj.FontSpec.Size = CalculateFontSize(4.0);
-
-                zedGraphChannels.GraphPane.GraphObjList.Add(textObj);
-            }
+            zedGraphChannels.GraphPane.GraphObjList.Add(textObj);
         }
     }
 }

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.Designer.cs
@@ -38,11 +38,13 @@
             this.panelParameters = new System.Windows.Forms.Panel();
             this.textBoxStepSize = new System.Windows.Forms.TextBox();
             this.groupBoxCathode = new System.Windows.Forms.GroupBox();
+            this.textboxAmplitudeCathodic = new System.Windows.Forms.TextBox();
             this.labelAmplitudeCathodic = new System.Windows.Forms.Label();
             this.labelPulseWidthCathodic = new System.Windows.Forms.Label();
             this.textboxPulseWidthCathodic = new System.Windows.Forms.TextBox();
             this.textboxAmplitudeCathodicRequested = new System.Windows.Forms.TextBox();
             this.groupBoxAnode = new System.Windows.Forms.GroupBox();
+            this.textboxAmplitudeAnodic = new System.Windows.Forms.TextBox();
             this.labelAmplitudeAnodic = new System.Windows.Forms.Label();
             this.labelPulseWidthAnodic = new System.Windows.Forms.Label();
             this.textboxPulseWidthAnodic = new System.Windows.Forms.TextBox();
@@ -66,7 +68,6 @@
             this.zedGraphWaveform = new ZedGraph.ZedGraphControl();
             this.tabPageTable = new System.Windows.Forms.TabPage();
             this.dataGridViewStimulusTable = new System.Windows.Forms.DataGridView();
-            this.panelProbe = new System.Windows.Forms.Panel();
             this.menuStrip = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stimulusWaveformToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -76,8 +77,7 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.textboxAmplitudeAnodic = new System.Windows.Forms.TextBox();
-            this.textboxAmplitudeCathodic = new System.Windows.Forms.TextBox();
+            this.panelProbe = new System.Windows.Forms.Panel();
             this.statusStrip.SuspendLayout();
             this.panelParameters.SuspendLayout();
             this.groupBoxCathode.SuspendLayout();
@@ -126,14 +126,14 @@
             this.toolStripStatusIsValid.Image = global::OpenEphys.Onix1.Design.Properties.Resources.StatusReadyImage;
             this.toolStripStatusIsValid.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.toolStripStatusIsValid.Name = "toolStripStatusIsValid";
-            this.toolStripStatusIsValid.Size = new System.Drawing.Size(186, 20);
+            this.toolStripStatusIsValid.Size = new System.Drawing.Size(153, 21);
             this.toolStripStatusIsValid.Text = "Valid stimulus sequence";
             this.toolStripStatusIsValid.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // toolStripStatusSlotsUsed
             // 
             this.toolStripStatusSlotsUsed.Name = "toolStripStatusSlotsUsed";
-            this.toolStripStatusSlotsUsed.Size = new System.Drawing.Size(132, 20);
+            this.toolStripStatusSlotsUsed.Size = new System.Drawing.Size(104, 21);
             this.toolStripStatusSlotsUsed.Text = "100% of slots used";
             this.toolStripStatusSlotsUsed.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -204,6 +204,15 @@
             this.groupBoxCathode.Text = "Cathode";
             this.groupBoxCathode.Visible = false;
             // 
+            // textboxAmplitudeCathodic
+            // 
+            this.textboxAmplitudeCathodic.Location = new System.Drawing.Point(132, 39);
+            this.textboxAmplitudeCathodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.textboxAmplitudeCathodic.Name = "textboxAmplitudeCathodic";
+            this.textboxAmplitudeCathodic.ReadOnly = true;
+            this.textboxAmplitudeCathodic.Size = new System.Drawing.Size(55, 22);
+            this.textboxAmplitudeCathodic.TabIndex = 9;
+            // 
             // labelAmplitudeCathodic
             // 
             this.labelAmplitudeCathodic.AutoSize = true;
@@ -256,6 +265,15 @@
             this.groupBoxAnode.TabIndex = 2;
             this.groupBoxAnode.TabStop = false;
             this.groupBoxAnode.Text = "Anode";
+            // 
+            // textboxAmplitudeAnodic
+            // 
+            this.textboxAmplitudeAnodic.Location = new System.Drawing.Point(129, 39);
+            this.textboxAmplitudeAnodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.textboxAmplitudeAnodic.Name = "textboxAmplitudeAnodic";
+            this.textboxAmplitudeAnodic.ReadOnly = true;
+            this.textboxAmplitudeAnodic.Size = new System.Drawing.Size(55, 22);
+            this.textboxAmplitudeAnodic.TabIndex = 8;
             // 
             // labelAmplitudeAnodic
             // 
@@ -362,7 +380,7 @@
             this.checkBoxAnodicFirst.Location = new System.Drawing.Point(91, 33);
             this.checkBoxAnodicFirst.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxAnodicFirst.Name = "checkBoxAnodicFirst";
-            this.checkBoxAnodicFirst.Size = new System.Drawing.Size(99, 20);
+            this.checkBoxAnodicFirst.Size = new System.Drawing.Size(96, 20);
             this.checkBoxAnodicFirst.TabIndex = 16;
             this.checkBoxAnodicFirst.TabStop = false;
             this.checkBoxAnodicFirst.Text = "Anodic First";
@@ -428,7 +446,7 @@
             this.checkboxBiphasicSymmetrical.Location = new System.Drawing.Point(43, 14);
             this.checkboxBiphasicSymmetrical.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkboxBiphasicSymmetrical.Name = "checkboxBiphasicSymmetrical";
-            this.checkboxBiphasicSymmetrical.Size = new System.Drawing.Size(147, 20);
+            this.checkboxBiphasicSymmetrical.Size = new System.Drawing.Size(144, 20);
             this.checkboxBiphasicSymmetrical.TabIndex = 5;
             this.checkboxBiphasicSymmetrical.TabStop = false;
             this.checkboxBiphasicSymmetrical.Text = "Biphasic Symmetric";
@@ -464,7 +482,7 @@
             this.tabControlVisualization.Name = "tabControlVisualization";
             this.tableLayoutPanel1.SetRowSpan(this.tabControlVisualization, 2);
             this.tabControlVisualization.SelectedIndex = 0;
-            this.tabControlVisualization.Size = new System.Drawing.Size(1090, 675);
+            this.tabControlVisualization.Size = new System.Drawing.Size(1090, 679);
             this.tabControlVisualization.TabIndex = 6;
             // 
             // tabPageWaveform
@@ -474,7 +492,7 @@
             this.tabPageWaveform.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageWaveform.Name = "tabPageWaveform";
             this.tabPageWaveform.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageWaveform.Size = new System.Drawing.Size(1082, 646);
+            this.tabPageWaveform.Size = new System.Drawing.Size(1082, 650);
             this.tabPageWaveform.TabIndex = 0;
             this.tabPageWaveform.Text = "Stimulus Waveform";
             this.tabPageWaveform.UseVisualStyleBackColor = true;
@@ -492,7 +510,7 @@
             this.zedGraphWaveform.ScrollMinX = 0D;
             this.zedGraphWaveform.ScrollMinY = 0D;
             this.zedGraphWaveform.ScrollMinY2 = 0D;
-            this.zedGraphWaveform.Size = new System.Drawing.Size(1076, 642);
+            this.zedGraphWaveform.Size = new System.Drawing.Size(1076, 646);
             this.zedGraphWaveform.TabIndex = 4;
             this.zedGraphWaveform.UseExtendedPrintDialog = true;
             // 
@@ -503,7 +521,7 @@
             this.tabPageTable.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageTable.Name = "tabPageTable";
             this.tabPageTable.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabPageTable.Size = new System.Drawing.Size(1082, 644);
+            this.tabPageTable.Size = new System.Drawing.Size(1082, 646);
             this.tabPageTable.TabIndex = 1;
             this.tabPageTable.Text = "Table";
             this.tabPageTable.UseVisualStyleBackColor = true;
@@ -521,20 +539,11 @@
             this.dataGridViewStimulusTable.Name = "dataGridViewStimulusTable";
             this.dataGridViewStimulusTable.RowHeadersWidth = 62;
             this.dataGridViewStimulusTable.RowTemplate.Height = 28;
-            this.dataGridViewStimulusTable.Size = new System.Drawing.Size(1076, 640);
+            this.dataGridViewStimulusTable.Size = new System.Drawing.Size(1076, 642);
             this.dataGridViewStimulusTable.TabIndex = 0;
             this.dataGridViewStimulusTable.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.DataGridViewStimulusTable_CellEndEdit);
             this.dataGridViewStimulusTable.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.DataGridViewStimulusTable_DataBindingComplete);
             this.dataGridViewStimulusTable.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.DataGridViewStimulusTable_DataError);
-            // 
-            // panelProbe
-            // 
-            this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(1099, 2);
-            this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(445, 367);
-            this.panelProbe.TabIndex = 0;
             // 
             // menuStrip
             // 
@@ -544,7 +553,7 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 2, 0, 2);
-            this.menuStrip.Size = new System.Drawing.Size(1547, 28);
+            this.menuStrip.Size = new System.Drawing.Size(1547, 24);
             this.menuStrip.TabIndex = 7;
             this.menuStrip.Text = "menuStrip1";
             // 
@@ -553,7 +562,7 @@
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.stimulusWaveformToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // stimulusWaveformToolStripMenuItem
@@ -562,20 +571,20 @@
             this.openFileToolStripMenuItem,
             this.saveFileToolStripMenuItem});
             this.stimulusWaveformToolStripMenuItem.Name = "stimulusWaveformToolStripMenuItem";
-            this.stimulusWaveformToolStripMenuItem.Size = new System.Drawing.Size(220, 26);
+            this.stimulusWaveformToolStripMenuItem.Size = new System.Drawing.Size(178, 22);
             this.stimulusWaveformToolStripMenuItem.Text = "Stimulus Waveform";
             // 
             // openFileToolStripMenuItem
             // 
             this.openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
-            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(155, 26);
+            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(124, 22);
             this.openFileToolStripMenuItem.Text = "Open File";
             this.openFileToolStripMenuItem.Click += new System.EventHandler(this.MenuItemLoadFile_Click);
             // 
             // saveFileToolStripMenuItem
             // 
             this.saveFileToolStripMenuItem.Name = "saveFileToolStripMenuItem";
-            this.saveFileToolStripMenuItem.Size = new System.Drawing.Size(155, 26);
+            this.saveFileToolStripMenuItem.Size = new System.Drawing.Size(124, 22);
             this.saveFileToolStripMenuItem.Text = "Save File";
             this.saveFileToolStripMenuItem.Click += new System.EventHandler(this.MenuItemSaveFile_Click);
             // 
@@ -589,21 +598,21 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControlVisualization, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 28);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 308F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1547, 721);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1547, 725);
             this.tableLayoutPanel1.TabIndex = 8;
             // 
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.panelParameters);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Location = new System.Drawing.Point(1099, 373);
+            this.groupBox1.Location = new System.Drawing.Point(1099, 377);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
@@ -619,29 +628,20 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOk);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 681);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 685);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1541, 38);
             this.flowLayoutPanel1.TabIndex = 7;
             // 
-            // textboxAmplitudeAnodic
+            // panelProbe
             // 
-            this.textboxAmplitudeAnodic.Location = new System.Drawing.Point(129, 39);
-            this.textboxAmplitudeAnodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.textboxAmplitudeAnodic.Name = "textboxAmplitudeAnodic";
-            this.textboxAmplitudeAnodic.ReadOnly = true;
-            this.textboxAmplitudeAnodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeAnodic.TabIndex = 8;
-            // 
-            // textboxAmplitudeCathodic
-            // 
-            this.textboxAmplitudeCathodic.Location = new System.Drawing.Point(132, 39);
-            this.textboxAmplitudeCathodic.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.textboxAmplitudeCathodic.Name = "textboxAmplitudeCathodic";
-            this.textboxAmplitudeCathodic.ReadOnly = true;
-            this.textboxAmplitudeCathodic.Size = new System.Drawing.Size(55, 22);
-            this.textboxAmplitudeCathodic.TabIndex = 9;
+            this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelProbe.Location = new System.Drawing.Point(1099, 2);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.panelProbe.Name = "panelProbe";
+            this.panelProbe.Size = new System.Drawing.Size(445, 371);
+            this.panelProbe.TabIndex = 0;
             // 
             // Rhs2116StimulusSequenceDialog
             // 
@@ -720,7 +720,6 @@
         private System.Windows.Forms.MenuStrip menuStrip;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
         private ZedGraph.ZedGraphControl zedGraphWaveform;
-        private System.Windows.Forms.Panel panelProbe;
         private System.Windows.Forms.ToolStripMenuItem stimulusWaveformToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveFileToolStripMenuItem;
@@ -731,5 +730,6 @@
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.TextBox textboxAmplitudeCathodic;
         private System.Windows.Forms.TextBox textboxAmplitudeAnodic;
+        private System.Windows.Forms.Panel panelProbe;
     }
 }


### PR DESCRIPTION
This PR updates how scales are rendered and manipulated in channel configuration dialogs. Previously, they were drawn as objects in the same `GraphPane` as the `ProbeInterface` objects. Now, there is a secondary pane that is created to the right of the main pane that overrides the default Y-Axis labels and tics to simplify the logic required to maintain these scales over time.

The scale pane and the main pane are tied together so that they pan/zoom whenever the user pans/zooms in the main pane. Due to the separation in panes, all panning and zooming are disabled in the scale pane to avoid any issues.

Devices that utilize this new feature:
- `NeuropixelsV1e`
- `NeuropixelsV1f`
- `NeuropixelsV2e`
- `NeuropixelsV2eBeta`

For devices that do not have a scale, such as the `Rhs2116`, the original behavior is retained with a single pane to draw the probe object. 

Fixes #339 

**NeuropixelsV1e GIF**

![npxv1e-scale](https://github.com/user-attachments/assets/ca347af4-7ac9-4011-903f-6c88e762512b)

**NeuropixelsV2e GIF**

![npxv2e-scale](https://github.com/user-attachments/assets/153d87c1-9777-402f-8db1-ef2f4618483c)

**Rhs2116 GIF**

![rhs2116-probe](https://github.com/user-attachments/assets/033dbd46-6f70-4f82-ae10-88f2bb5bee71)
