### PR TITLE
Add support for stimulus reports on headstage-64

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.6.1</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64.cs
@@ -167,7 +167,7 @@ namespace OpenEphys.Onix1
                 // between cycles to fix.
                 const double MinVoltage = 3.3;
                 const double MaxVoltage = 6.0;
-                const double VoltageOffset = 3.4;
+                const double VoltageOffset = 4.0;
                 const double VoltageIncrement = 0.2;
 
                 // NB: Wait for 1 second to discharge the headstage in the case that they have e.g. just

--- a/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
@@ -71,6 +71,23 @@ namespace OpenEphys.Onix1
         public const uint MINRHEOR = 13; // The series resistor between the potentiometer (rheostat) and RSET bin on the CAT4016
         public const uint POTRES = 14; // The resistance value of the potentiometer connected in rheostat config to RSET on CAT4016
 
+        // NB: fit from Fig. 10 of CAT4016 datasheet
+        // x = (y/a)^(1/b)
+        // a = 3.833e+05
+        // b = -0.9632
+        internal static uint MilliampsToPotSetting(double currentMa)
+        {
+            double R = Math.Pow(currentMa / 3.833e+05, 1 / -0.9632);
+            uint s = (uint)Math.Round(256 * (R - MinRheostatResistanceOhms) / PotResistanceOhms);
+            return s > 255 ? 255 : s < 0 ? 0 :s;
+        }
+
+        internal static double PotSettingToMilliamps(uint potSetting)
+        {
+            var R = MinRheostatResistanceOhms + PotResistanceOhms * potSetting / 256; 
+            return 3.833e+05 * Math.Pow(R, -0.9632);
+        }
+
         internal class NameConverter : DeviceNameConverter
         {
             public NameConverter()

--- a/OpenEphys.Onix1/Headstage64ElectricalStimulatorData.cs
+++ b/OpenEphys.Onix1/Headstage64ElectricalStimulatorData.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Produces a sequence of <see
+    /// cref="Headstage64ElectricalStimulatorDataFrame">Headstage64ElectricalStimulatorDataFrames</see>
+    /// objects indicating the time and parameters of stimuli.
+    /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeadstage64ElectricalStimulator"/>, using a shared <c>DeviceName</c>.
+    /// </remarks>
+    [Description("Produces a sequence of stimulus reports containing time, trigger origin, and parameters of stimuli delivered by the headstage-64 onboard electrical stimulator.")]
+    public class Headstage64ElectricalStimulatorData : Source<Headstage64ElectricalStimulatorDataFrame>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(Headstage64ElectricalStimulator.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        [Category(DeviceFactory.ConfigurationCategory)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Generates a sequence of <see
+        /// cref="Headstage64ElectricalStimulatorDataFrame">Headstage64ElectricalStimulatorDataFrames</see>.
+        /// </summary>
+        /// <returns>A sequence of <see
+        /// cref="Headstage64ElectricalStimulatorDataFrame">Headstage64ElectricalStimulatorDataFrames</see>.</returns>
+        public override IObservable<Headstage64ElectricalStimulatorDataFrame> Generate()
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var device = deviceInfo.GetDeviceContext(typeof(Headstage64ElectricalStimulator));
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
+                    .Select(frame => new Headstage64ElectricalStimulatorDataFrame(frame));
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/Headstage64ElectricalStimulatorDataFrame.cs
+++ b/OpenEphys.Onix1/Headstage64ElectricalStimulatorDataFrame.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A headstage-64 onboard electrical stimulator report.
+    /// </summary>
+    /// <remarks>
+    /// These frames provide synchronized information about the stimulus timing, trigger source, and stimulus
+    /// parameters.
+    /// </remarks>
+    public class Headstage64ElectricalStimulatorDataFrame : DataFrame
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Headstage64ElectricalStimulatorDataFrame"/> class.
+        /// </summary>
+        /// <param name="frame">An ONI containing a headstage-64 onboard electrical stimulator report.</param>
+        public unsafe Headstage64ElectricalStimulatorDataFrame(oni.Frame frame)
+            : base(frame.Clock)
+        {
+            var payload = (Headstage64ElectricalStimulatorPayload*)frame.Data.ToPointer();
+            HubClock = payload->HubClock;
+            Origin = (Headstage64StimulatorTriggerOrigin)(payload->DelayAndOrigin & 0x000F);
+            Delay = (payload->DelayAndOrigin & 0xFFF0) >> 8;
+            RestCurrent = Headstage64ElectricalStimulator.CodeToMicroamps(payload->RestCurrent);
+            PhaseOneCurrent = Headstage64ElectricalStimulator.CodeToMicroamps(payload->PhaseOneCurrent);
+            PhaseTwoCurrent = Headstage64ElectricalStimulator.CodeToMicroamps(payload->PhaseTwoCurrent);
+            PhaseOneDuration = payload->PhaseOneDuration;
+            InterPhaseInterval = payload->InterPhaseInterval;
+            PhaseTwoDuration = payload->PhaseTwoDuration;
+            InterPulseInterval = payload->InterPulseInterval;
+            PulsesPerBurst = payload->PulsesPerBurst;
+            InterBurstInterval = payload->InterBurstInterval;
+            BurstsPerTrain = payload->BurstsPerTrain;
+        }
+
+        /// <summary>
+        /// Gets the stimulus trigger origin.
+        /// </summary>
+        public Headstage64StimulatorTriggerOrigin Origin {get; }
+
+        /// <summary>
+        /// Gets the delay, in microseconds, from the time of trigger receipt (the <see
+        /// cref="DataFrame.HubClock"/> value) to the physical application of the stimulus sequence.
+        /// </summary>
+        public uint Delay { get; }
+
+        /// <summary>
+        /// Gets the rest current in microamps.
+        /// </summary>
+        public double RestCurrent { get; }
+
+        /// <summary>
+        /// Gets the phase one current in microamps.
+        /// </summary>
+        public double PhaseOneCurrent { get; }
+
+        /// <summary>
+        /// Gets the phase two current in microamps.
+        /// </summary>
+        public double PhaseTwoCurrent { get; }
+
+        /// <summary>
+        /// Gets the phase one duration in microseconds.
+        /// </summary>
+        public uint PhaseOneDuration { get; }
+
+        /// <summary>
+        /// Gets the inter-phase interval duration in microseconds.
+        /// </summary>
+        public uint InterPhaseInterval { get; }
+
+        /// <summary>
+        /// Gets the phase two duration in microseconds.
+        /// </summary>
+        public uint PhaseTwoDuration { get; }
+
+        /// <summary>
+        /// Gets the inter-pulse interval duration in microseconds.
+        /// </summary>
+        public uint InterPulseInterval { get; }
+
+        /// <summary>
+        /// Gets the number of pulses per burst.
+        /// </summary>
+        public uint PulsesPerBurst { get; }
+
+        /// <summary>
+        /// Gets inter-burst interval duration in microseconds.
+        /// </summary>
+        public uint InterBurstInterval { get; }
+
+        /// <summary>
+        /// Gets the number of burst per train.
+        /// </summary>
+        public uint BurstsPerTrain { get; }
+
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct Headstage64ElectricalStimulatorPayload
+    {
+        public ulong HubClock;
+        public uint DelayAndOrigin;
+        public uint RestCurrent;
+        public uint PhaseOneCurrent;
+        public uint PhaseTwoCurrent;
+        public uint PhaseOneDuration;
+        public uint InterPhaseInterval;
+        public uint PhaseTwoDuration;
+        public uint InterPulseInterval;
+        public uint PulsesPerBurst;
+        public uint InterBurstInterval;
+        public uint BurstsPerTrain;
+    }
+
+    /// <summary>
+    /// Specifies the origin of the trigger.
+    /// </summary>
+    [Flags]
+    public enum Headstage64StimulatorTriggerOrigin : byte
+    {
+        /// <summary>
+        /// Specifies the source of the trigger is unknown.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// Specifies the source of the trigger is a local Gpio pin.
+        /// </summary>
+        Gpio = 0x1,
+
+        /// <summary>
+        /// Specifies the source of the trigger is a register.
+        /// </summary>
+        Register = 0x2,
+    }
+}

--- a/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
+++ b/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
@@ -233,17 +233,11 @@ namespace OpenEphys.Onix1
                         observer.OnError,
                         observer.OnCompleted);
 
-                    static uint uAToCode(double currentuA)
-                    {
-                        var k = 1 / (2 * Headstage64ElectricalStimulator.AbsMaxMicroAmps / (Math.Pow(2, Headstage64ElectricalStimulator.DacBitDepth) - 1)); // static
-                        return (uint)(k * (currentuA + Headstage64ElectricalStimulator.AbsMaxMicroAmps));
-                    }
-
                     return new CompositeDisposable(
-                        enable.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.ENABLE, value ? 1u : 0u)),
-                        phaseOneCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT1, uAToCode(value))),
-                        interPhaseCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.RESTCURR, uAToCode(value))),
-                        phaseTwoCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT2, uAToCode(value))),
+                        enable.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.STIMENABLE, value ? 1u : 0u)),
+                        phaseOneCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT1, Headstage64ElectricalStimulator.MicroampsToCode(value))),
+                        interPhaseCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.RESTCURR, Headstage64ElectricalStimulator.MicroampsToCode(value))),
+                        phaseTwoCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT2, Headstage64ElectricalStimulator.MicroampsToCode(value))),
                         triggerDelay.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.TRAINDELAY, value)),
                         phaseOneDuration.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.PULSEDUR1, value)),
                         interPhaseInterval.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.INTERPHASEINTERVAL, value)),

--- a/OpenEphys.Onix1/Headstage64OpticalStimulatorData.cs
+++ b/OpenEphys.Onix1/Headstage64OpticalStimulatorData.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Produces a sequence of <see
+    /// cref="Headstage64OpticalStimulatorDataFrame">Headstage64OpticalStimulatorDataFrames</see> indicating
+    /// the time and parameters of stimuli.
+    /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeadstage64OpticalStimulator"/>, using a shared <c>DeviceName</c>.
+    /// </remarks>
+    [Description("Produces a sequence of stimulus reports containing time, trigger origin, and parameters of stimuli delivered by the headstage-64 onboard optical stimulator.")]
+    public class Headstage64OpticalStimulatorData : Source<Headstage64OpticalStimulatorDataFrame>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(Headstage64OpticalStimulator.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        [Category(DeviceFactory.ConfigurationCategory)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Generates a sequence of <see
+        /// cref="Headstage64OpticalStimulatorDataFrame">Headstage64OpticalStimulatorDataFrames</see>.
+        /// </summary>
+        /// <returns>A sequence of <see
+        /// cref="Headstage64OpticalStimulatorDataFrame">Headstage64OpticalStimulatorDataFrames</see>.</returns>
+        public override IObservable<Headstage64OpticalStimulatorDataFrame> Generate()
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var device = deviceInfo.GetDeviceContext(typeof(Headstage64OpticalStimulator));
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
+                    .Select(frame => new Headstage64OpticalStimulatorDataFrame(frame));
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/Headstage64OpticalStimulatorDataFrame.cs
+++ b/OpenEphys.Onix1/Headstage64OpticalStimulatorDataFrame.cs
@@ -1,0 +1,126 @@
+﻿using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A headstage-64 onboard optical stimulator report.
+    /// </summary>
+    /// <remarks>
+    /// These frames provide synchronized information about the stimulus timing, trigger source, and stimulus
+    /// parameters.
+    /// </remarks>
+    public class Headstage64OpticalStimulatorDataFrame : DataFrame
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Headstage64OpticalStimulatorDataFrame"/> class.
+        /// </summary>
+        /// <param name="frame">An ONI containing a headstage-64 onboard optical stimulator report.</param>
+        public unsafe Headstage64OpticalStimulatorDataFrame(oni.Frame frame)
+            : base(frame.Clock)
+        {
+            var payload = (Headstage64OpticalStimulatorPayload*)frame.Data.ToPointer();
+            HubClock = payload->HubClock;
+            Origin = (Headstage64StimulatorTriggerOrigin)(payload->DelayAndOrigin & 0x000F);
+            Delay = (payload->DelayAndOrigin & 0xFFF0) >> 8;
+            ChannelOneRestCurrent = CodeToMilliamps(payload->MaxCurrent, (byte)(payload->RestMask & 0x00FF));
+            ChannelTwoRestCurrent = CodeToMilliamps(payload->MaxCurrent, (byte)((payload->RestMask & 0xFF00) >> 8));
+            ChannelOneCurrent = CodeToMilliamps(payload->MaxCurrent, (byte)(payload->PulseMask & 0x00FF));
+            ChannelTwoCurrent = CodeToMilliamps(payload->MaxCurrent, (byte)((payload->PulseMask & 0xFF00) >> 8));
+            PulseDuration = payload->PulseDuration / 1e3;
+            PulsePeriod = payload->PulsePeriod / 1e3;
+            PulsesPerBurst = payload->PulsesPerBurst;
+            InterBurstInterval = payload->InterBurstInterval / 1e3;
+            BurstsPerTrain = payload->BurstsPerTrain;
+        }
+
+        /// <summary>
+        /// Gets the stimulus trigger origin.
+        /// </summary>
+        public Headstage64StimulatorTriggerOrigin Origin {get; }
+
+        /// <summary>
+        /// Gets the delay, in microseconds, from the time of trigger receipt (the <see
+        /// cref="DataFrame.HubClock"/> value) to the physical application of the stimulus sequence.
+        /// </summary>
+        public uint Delay { get; }
+
+        /// <summary>
+        /// Gets the channel one rest current in milliamps.
+        /// </summary>
+        public double ChannelOneRestCurrent { get; }
+
+        /// <summary>
+        /// Gets the channel two rest current in milliamps.
+        /// </summary>
+        public double ChannelTwoRestCurrent { get; }
+
+        /// <summary>
+        /// Gets the channel one pulse current in milliamps.
+        /// </summary>
+        public double ChannelOneCurrent { get; }
+
+        /// <summary>
+        /// Gets the channel two pulse current in milliamps.
+        /// </summary>
+        public double ChannelTwoCurrent { get; }
+
+        /// <summary>
+        /// Gets the pulse duration in millseconds.
+        /// </summary>
+        public double PulseDuration { get; }
+
+        /// <summary>
+        /// Gets the pulse period in milliseconds.
+        /// </summary>
+        public double PulsePeriod { get; }
+
+        /// <summary>
+        /// Gets the number of pulses per burst.
+        /// </summary>
+        public uint PulsesPerBurst { get; }
+
+        /// <summary>
+        /// Gets inter-burst interval duration in milliseconds.
+        /// </summary>
+        public double InterBurstInterval { get; }
+
+        /// <summary>
+        /// Gets the number of burst per train.
+        /// </summary>
+        public uint BurstsPerTrain { get; }
+
+        static double CodeToMilliamps(uint potSetting, byte mask)
+        {
+            return Headstage64OpticalStimulator.PotSettingToMilliamps(potSetting) * 0.125 * BitsSetTable[mask];
+        }
+
+        // TODO: The use of hardware BitOperations.PopCount() hardware intrinsic is only available starting in
+        // .NET Core 3.0. If we upgrade we should use that instead
+        static readonly byte[] BitsSetTable = new byte[256]
+        {
+            0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,
+            1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,
+            1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,
+            2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,
+            1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,
+            2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,
+            2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,
+            3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8
+        };
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct Headstage64OpticalStimulatorPayload
+    {
+        public ulong HubClock;
+        public uint DelayAndOrigin;
+        public uint RestMask;
+        public uint MaxCurrent;
+        public uint PulseMask;
+        public uint PulseDuration;
+        public uint PulsePeriod;
+        public uint PulsesPerBurst;
+        public uint InterBurstInterval;
+        public uint BurstsPerTrain;
+    }
+}


### PR DESCRIPTION
- The electrical and optical stimulation devices on headstage-64 now send reports, if the data stream is enabled, for all delivered stimuli making it very easy to have sychronized stimulus timing information
- This is supported on version 3 of the of the devices
- We will need to resolve #503 in order to make these changes safe
- Fixes #384 