### PR TITLE
Update ElectricalStimulator dialog to match OpticalStimulator behavior

### DIFF
--- a/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorOptions.Designer.cs
+++ b/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorOptions.Designer.cs
@@ -204,6 +204,7 @@
             this.textBoxBurstPulseCount.Name = "textBoxBurstPulseCount";
             this.textBoxBurstPulseCount.Size = new System.Drawing.Size(75, 22);
             this.textBoxBurstPulseCount.TabIndex = 2;
+            this.textBoxBurstPulseCount.TextChanged += new System.EventHandler(this.BurstPulseCountChanged);
             // 
             // labelBurstPulseCount
             // 
@@ -243,6 +244,7 @@
             this.textBoxTrainBurstCount.Name = "textBoxTrainBurstCount";
             this.textBoxTrainBurstCount.Size = new System.Drawing.Size(75, 22);
             this.textBoxTrainBurstCount.TabIndex = 4;
+            this.textBoxTrainBurstCount.TextChanged += new System.EventHandler(this.TrainBurstCountChanged);
             // 
             // labelTrainBurstCount
             // 

--- a/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorOptions.cs
+++ b/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorOptions.cs
@@ -37,5 +37,21 @@ namespace OpenEphys.Onix1.Design
             textBoxTrainBurstCount.Text = electricalStimulator.TrainBurstCount.ToString();
             textBoxTrainDelay.Text = electricalStimulator.TriggerDelay.ToString();
         }
+
+        void BurstPulseCountChanged(object sender, System.EventArgs e)
+        {
+            if (int.TryParse(textBoxBurstPulseCount.Text, out int result))
+            {
+                textBoxPulsePeriod.Enabled = result > 1;
+            }
+        }
+
+        void TrainBurstCountChanged(object sender, System.EventArgs e)
+        {
+            if (int.TryParse(textBoxTrainBurstCount.Text, out int result))
+            {
+                textBoxInterBurstInterval.Enabled = result > 1;
+            }
+        }
     }
 }

--- a/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
@@ -231,13 +231,9 @@ namespace OpenEphys.Onix1.Design
                 SetTextBoxBackgroundError(StimulusSequenceOptions.textBoxPhaseTwoDuration);
                 return false;
             }
-            else if (AnyCurrentIsSet(electricalStimulator) && electricalStimulator.InterPulseInterval == 0)
-            {
-                reason = "Pulse period has not been set.";
-                SetTextBoxBackgroundError(StimulusSequenceOptions.textBoxPulsePeriod);
-                return false;
-            }
-            else if (AnyCurrentIsSet(electricalStimulator) && electricalStimulator.InterPulseInterval < electricalStimulator.PhaseOneDuration + electricalStimulator.InterPhaseInterval + electricalStimulator.PhaseTwoDuration)
+            else if (AnyCurrentIsSet(electricalStimulator) && electricalStimulator.BurstPulseCount > 1
+                && (electricalStimulator.InterPulseInterval == 0
+                   || electricalStimulator.InterPulseInterval < electricalStimulator.PhaseOneDuration + electricalStimulator.InterPhaseInterval + electricalStimulator.PhaseTwoDuration))
             {
                 reason = "Pulse period is too short.";
                 SetTextBoxBackgroundError(StimulusSequenceOptions.textBoxPulsePeriod);

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.Designer.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.Designer.cs
@@ -74,6 +74,7 @@
             this.textBoxBurstsPerTrain.Name = "textBoxBurstsPerTrain";
             this.textBoxBurstsPerTrain.Size = new System.Drawing.Size(75, 22);
             this.textBoxBurstsPerTrain.TabIndex = 17;
+            this.textBoxBurstsPerTrain.TextChanged += new System.EventHandler(this.BurstsPerTrainChanged);
             // 
             // labelBurstsPerTrain
             // 
@@ -105,6 +106,7 @@
             this.textBoxPulsesPerBurst.Name = "textBoxPulsesPerBurst";
             this.textBoxPulsesPerBurst.Size = new System.Drawing.Size(75, 22);
             this.textBoxPulsesPerBurst.TabIndex = 13;
+            this.textBoxPulsesPerBurst.TextChanged += new System.EventHandler(this.PulsesPerBurstChanged);
             // 
             // labelPulsesPerBurst
             // 

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.cs
@@ -49,5 +49,21 @@ namespace OpenEphys.Onix1.Design
 
         internal readonly double channelOneScalingFactor;
         internal readonly double channelTwoScalingFactor;
+
+        void PulsesPerBurstChanged(object sender, System.EventArgs e)
+        {
+            if (int.TryParse(textBoxPulsesPerBurst.Text, out int result))
+            {
+                textBoxPulsePeriod.Enabled = result > 1;
+            }
+        }
+
+        void BurstsPerTrainChanged(object sender, System.EventArgs e)
+        {
+            if (int.TryParse(textBoxBurstsPerTrain.Text, out int result))
+            {
+                textBoxInterBurstInterval.Enabled = result > 1;
+            }
+        }
     }
 }

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
@@ -100,22 +100,12 @@ namespace OpenEphys.Onix1.Design
                 { StimulusSequenceOptions.textBoxPulsesPerBurst,
                     new TextBoxBinding<uint>(
                         StimulusSequenceOptions.textBoxPulsesPerBurst,
-                        value =>
-                        {
-                            OpticalStimulator.PulsesPerBurst = value;
-                            StimulusSequenceOptions.textBoxPulsePeriod.Enabled = OpticalStimulator.PulsesPerBurst > 1;
-                            return OpticalStimulator.PulsesPerBurst;
-                        },
+                        value => { OpticalStimulator.PulsesPerBurst = value; return OpticalStimulator.PulsesPerBurst; },
                         uint.Parse) },
                 { StimulusSequenceOptions.textBoxBurstsPerTrain,
                     new TextBoxBinding<uint>(
                         StimulusSequenceOptions.textBoxBurstsPerTrain,
-                        value =>
-                        {
-                            OpticalStimulator.BurstsPerTrain = value;
-                            StimulusSequenceOptions.textBoxInterBurstInterval.Enabled = OpticalStimulator.BurstsPerTrain > 1;
-                            return OpticalStimulator.BurstsPerTrain;
-                        },
+                        value => { OpticalStimulator.BurstsPerTrain = value; return OpticalStimulator.BurstsPerTrain; },
                         uint.Parse) }
             };
 
@@ -180,7 +170,7 @@ namespace OpenEphys.Onix1.Design
                 }
                 else
                 {
-                    throw new NotImplementedException($"No valid text box found when updating parameters in {nameof(Headstage64ElectricalStimulatorSequenceDialog)}");
+                    throw new NotImplementedException($"No valid text box found when updating parameters in {nameof(Headstage64OpticalStimulatorSequenceDialog)}");
                 }
 
                 SetTextBoxBackgroundDefault(textBox);


### PR DESCRIPTION
`OpticalStimulator` dialog was updated in 2c1c9eb67677b1535408a5525f3b71ebae7e03a0 to disable certain text boxes when the number of pulses/bursts was 1, since a period at that point is undefined.

However, the `ElectricalStimulator` was not updated at the same time. That has been corrected in this PR.

This PR also consolidates the estim/ostim dialogs so that the checks occur at the same place; in the Options dialog, at the smallest scope possible to ensure that the behavior is consistent no matter how the text boxes are updated (i.e., during construction, or during regular use).