### PR TITLE
Remove menu strip items from headstage64 dialog

### DIFF
--- a/OpenEphys.Onix1.Design/Headstage64Dialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64Dialog.cs
@@ -36,8 +36,7 @@ namespace OpenEphys.Onix1.Design
             OpticalStimulatorSequenceDialog = new(configureNode.OpticalStimulator);
             OpticalStimulatorSequenceDialog.SetChildFormProperties(this).AddDialogToTab(tabPageOpticalStimulator);
 
-            this.AddMenuItemsFromDialogToFileOption(ElectricalStimulatorSequenceDialog)
-                .AddMenuItemsFromDialogToFileOption(OpticalStimulatorSequenceDialog);
+            menuStrip1.Visible = false;
         }
     }
 }


### PR DESCRIPTION
The menu strip allowing users to load/save stimulus sequence waveforms was mistakenly left in the Headstage64 GUI.

This PR removes the file menu, as it would have been an empty strip after removing the load/save functionality. In the future, if any file menu items are needed, this strip can be enabled so that it is once again visible.

GUI without the menu strip:
<img width="884" height="523" alt="image" src="https://github.com/user-attachments/assets/84543211-44f0-4736-8beb-2e17558d65cc" />

Fixes #524 