### PR TITLE
Fix zoom and channel scaling in Headstage64 dialogs

### DIFF
--- a/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
@@ -97,7 +97,7 @@ namespace OpenEphys.Onix1.Design
 
         void OnZoom_Waveform(ZedGraphControl sender, ZoomState oldState, ZoomState newState)
         {
-            if (newState.Type == ZoomState.StateType.WheelZoom)
+            if (newState.Type == ZoomState.StateType.WheelZoom && sender.IsEnableHZoom && sender.IsEnableVZoom)
             {
                 CenterAxesOnCursor(sender);
             }

--- a/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
@@ -289,8 +289,8 @@ namespace OpenEphys.Onix1.Design
 
         internal override double GetPeakToPeakAmplitudeInMicroAmps()
         {
-            var peakToPeak = (Math.Max(Math.Max(ElectricalStimulator.PhaseOneCurrent, ElectricalStimulator.PhaseTwoCurrent), ElectricalStimulator.InterPhaseCurrent)
-                          + Math.Abs(Math.Min(Math.Min(ElectricalStimulator.PhaseOneCurrent, ElectricalStimulator.PhaseTwoCurrent), ElectricalStimulator.InterPhaseCurrent))) * ChannelScale;
+            var peakToPeak = Math.Max(Math.Max(ElectricalStimulator.PhaseOneCurrent, ElectricalStimulator.PhaseTwoCurrent), ElectricalStimulator.InterPhaseCurrent)
+                          + Math.Abs(Math.Min(Math.Min(ElectricalStimulator.PhaseOneCurrent, ElectricalStimulator.PhaseTwoCurrent), ElectricalStimulator.InterPhaseCurrent));
 
             return peakToPeak == 0 ? ZeroPeakToPeak : peakToPeak;
         }
@@ -299,7 +299,7 @@ namespace OpenEphys.Onix1.Design
         {
             PointPairList[] waveforms = new PointPairList[NumberOfChannels];
 
-            var peakToPeak = GetPeakToPeakAmplitudeInMicroAmps();
+            var peakToPeak = GetPeakToPeakAmplitudeInMicroAmps() * ChannelScale;
 
             if (ElectricalStimulator != null)
             {

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
@@ -212,14 +212,14 @@ namespace OpenEphys.Onix1.Design
 
         internal override double GetPeakToPeakAmplitudeInMicroAmps()
         {
-            return OpticalStimulator.MaxCurrent == 0 ? ZeroPeakToPeak : OpticalStimulator.MaxCurrent * ChannelScale;
+            return OpticalStimulator.MaxCurrent == 0 ? ZeroPeakToPeak : OpticalStimulator.MaxCurrent;
         }
 
         internal override PointPairList[] CreateStimulusWaveforms()
         {
             PointPairList[] waveforms = new PointPairList[NumberOfChannels];
 
-            var peakToPeak = GetPeakToPeakAmplitudeInMicroAmps();
+            var peakToPeak = GetPeakToPeakAmplitudeInMicroAmps() * ChannelScale;
 
             for (int channel = 0; channel < NumberOfChannels; channel++)
             {


### PR DESCRIPTION
While creating documentation for the Headstage64 GUIs, I found another error that slipped in, which is that the zoom and channel scaling for both dialogs were slightly shifted. This PR corrects both of those issues by checking if vertical zoom is enabled before zooming in on the center of the cursor, and by applying the ChannelScale correction at the correct place.

- For Headstage64 Optical/Electrical stimulators, vertical zoom is disabled, which can interfere with the default behavior of the StimulusSequenceDialog to zoom in on the center of the cursor
- The waveforms for both optical and electrical stimulators were not being properly scaled; the ChannelScale value was not applied at the correct location