### PR TITLE
Consolidate stimulus sequence verification logic

### DIFF
--- a/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
@@ -84,10 +84,35 @@ namespace OpenEphys.Onix1.Design
             }
         }
 
-        internal virtual bool CanCloseForm(out DialogResult result)
+        internal bool CanCloseForm(out DialogResult result, string stimulusName = "Stimulus")
         {
-            result = DialogResult.OK;
-            return true;
+            bool canClose = true;
+
+            if (!IsSequenceValid())
+            {
+                DialogResult resultContinue = MessageBox.Show($"Warning: {stimulusName} sequence is not valid. " +
+                    $"If you continue, the current settings for {stimulusName} will be discarded. " +
+                    "Press OK to discard all changes for this device, or press Cancel to continue editing the sequence.",
+                    $"Invalid {stimulusName} Sequence",
+                    MessageBoxButtons.OKCancel);
+
+                if (resultContinue == DialogResult.OK)
+                {
+                    result = DialogResult.Cancel;
+                }
+                else
+                {
+                    result = DialogResult.OK;
+                    canClose = false;
+                }
+            }
+            else
+            {
+                result = DialogResult.OK;
+            }
+
+            DialogResult = result;
+            return canClose;
         }
 
         internal void OnSelect(object sender, EventArgs e)
@@ -381,7 +406,7 @@ namespace OpenEphys.Onix1.Design
 
         internal virtual bool IsSequenceValid()
         {
-            return true;
+            throw new NotImplementedException();
         }
 
         internal virtual void SetStatusValidity()

--- a/OpenEphys.Onix1.Design/Headstage64Dialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/Headstage64Dialog.Designer.cs
@@ -88,7 +88,6 @@
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.buttonOK.Location = new System.Drawing.Point(881, 2);
             this.buttonOK.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOK.Name = "buttonOK";
@@ -96,6 +95,7 @@
             this.buttonOK.TabIndex = 5;
             this.buttonOK.Text = "OK";
             this.buttonOK.UseVisualStyleBackColor = true;
+            this.buttonOK.Click += new System.EventHandler(this.OnClickOk);
             // 
             // tabControl
             // 

--- a/OpenEphys.Onix1.Design/Headstage64Dialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64Dialog.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 
 namespace OpenEphys.Onix1.Design
 {
@@ -37,6 +38,20 @@ namespace OpenEphys.Onix1.Design
             OpticalStimulatorSequenceDialog.SetChildFormProperties(this).AddDialogToTab(tabPageOpticalStimulator);
 
             menuStrip1.Visible = false;
+        }
+
+        void OnClickOk(object sender, EventArgs e)
+        {
+            if (ElectricalStimulatorSequenceDialog.CanCloseForm(out DialogResult electricalResult, "Electrical Stimulator")
+                && OpticalStimulatorSequenceDialog.CanCloseForm(out DialogResult opticalResult, "Optical Stimulator"))
+            {
+                if (electricalResult == DialogResult.OK || opticalResult == DialogResult.OK)
+                    DialogResult = DialogResult.OK;
+                else
+                    DialogResult = DialogResult.Cancel;
+
+                Close();
+            }
         }
     }
 }

--- a/OpenEphys.Onix1.Design/Headstage64Editor.cs
+++ b/OpenEphys.Onix1.Design/Headstage64Editor.cs
@@ -25,8 +25,12 @@ namespace OpenEphys.Onix1.Design
                         DesignHelper.CopyProperties((ConfigureRhd2164)editorDialog.Rhd2164Dialog.Device, configureNode.Rhd2164, DesignHelper.PropertiesToIgnore);
                         DesignHelper.CopyProperties((ConfigureBno055)editorDialog.Bno055Dialog.Device, configureNode.Bno055, DesignHelper.PropertiesToIgnore);
                         DesignHelper.CopyProperties((ConfigureTS4231V1)editorDialog.TS4231V1Dialog.Device, configureNode.TS4231, DesignHelper.PropertiesToIgnore);
-                        configureNode.ElectricalStimulator = editorDialog.ElectricalStimulatorSequenceDialog.ElectricalStimulator;
-                        configureNode.OpticalStimulator = editorDialog.OpticalStimulatorSequenceDialog.OpticalStimulator;
+
+                        if (editorDialog.ElectricalStimulatorSequenceDialog.DialogResult == DialogResult.OK)
+                            configureNode.ElectricalStimulator = editorDialog.ElectricalStimulatorSequenceDialog.ElectricalStimulator;
+
+                        if (editorDialog.OpticalStimulatorSequenceDialog.DialogResult == DialogResult.OK)
+                            configureNode.OpticalStimulator = editorDialog.OpticalStimulatorSequenceDialog.OpticalStimulator;
 
                         return true;
                     }

--- a/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
@@ -252,41 +252,6 @@ namespace OpenEphys.Onix1.Design
             return true;
         }
 
-        internal override bool CanCloseForm(out DialogResult result)
-        {
-            if (ElectricalStimulator != null)
-            {
-                if (!IsSequenceValid(ElectricalStimulator, out string reason))
-                {
-                    DialogResult resultContinue = MessageBox.Show($"Warning: Stimulus sequence is not valid ({reason}). " +
-                        "If you continue, the current settings will be discarded. " +
-                        "Press OK to discard changes, or press Cancel to continue editing the sequence.", "Invalid Sequence",
-                        MessageBoxButtons.OKCancel);
-
-                    if (resultContinue == DialogResult.OK)
-                    {
-                        result = DialogResult.Cancel;
-                        return true;
-                    }
-                    else
-                    {
-                        result = DialogResult.OK;
-                        return false;
-                    }
-                }
-                else
-                {
-                    result = DialogResult.OK;
-                    return true;
-                }
-            }
-            else
-            {
-                result = DialogResult.Cancel;
-                return true;
-            }
-        }
-
         internal override double GetPeakToPeakAmplitudeInMicroAmps()
         {
             var peakToPeak = Math.Max(Math.Max(ElectricalStimulator.PhaseOneCurrent, ElectricalStimulator.PhaseTwoCurrent), ElectricalStimulator.InterPhaseCurrent)

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
@@ -305,40 +305,5 @@ namespace OpenEphys.Onix1.Design
                 toolStripStatusIsValid.Text = "Warning: " + reason;
             }
         }
-
-        internal override bool CanCloseForm(out DialogResult result)
-        {
-            if (OpticalStimulator != null)
-            {
-                if (!IsSequenceValid(OpticalStimulator, out string reason))
-                {
-                    DialogResult resultContinue = MessageBox.Show($"Warning: Stimulus sequence is not valid ({reason}). " +
-                        "If you continue, the current settings will be discarded. " +
-                        "Press OK to discard changes, or press Cancel to continue editing the sequence.", "Invalid Sequence",
-                        MessageBoxButtons.OKCancel);
-
-                    if (resultContinue == DialogResult.OK)
-                    {
-                        result = DialogResult.Cancel;
-                        return true;
-                    }
-                    else
-                    {
-                        result = DialogResult.OK;
-                        return false;
-                    }
-                }
-                else
-                {
-                    result = DialogResult.OK;
-                    return true;
-                }
-            }
-            else
-            {
-                result = DialogResult.Cancel;
-                return true;
-            }
-        }
     }
 }

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -115,41 +115,6 @@ namespace OpenEphys.Onix1.Design
             DrawStimulusWaveform();
         }
 
-        internal override bool CanCloseForm(out DialogResult result)
-        {
-            if (Sequence != null)
-            {
-                if (!Sequence.Valid)
-                {
-                    DialogResult resultContinue = MessageBox.Show("Warning: Stimulus sequence is not valid. " +
-                        "If you continue, the current settings will be discarded. " +
-                        "Press OK to discard changes, or press Cancel to continue editing the sequence.", "Invalid Sequence",
-                        MessageBoxButtons.OKCancel);
-
-                    if (resultContinue == DialogResult.OK)
-                    {
-                        result = DialogResult.Cancel;
-                        return true;
-                    }
-                    else
-                    {
-                        result = DialogResult.OK;
-                        return false;
-                    }
-                }
-                else
-                {
-                    result = DialogResult.OK;
-                    return true;
-                }
-            }
-            else
-            {
-                result = DialogResult.Cancel;
-                return true;
-            }
-        }
-
         internal void OnZoom(object sender, EventArgs e)
         {
             ChannelDialog.UpdateFontSize();


### PR DESCRIPTION
This PR moves the stimulus sequence verification logic from the inherited classes to the base class, to increase maintainability. It also adds the verification check when closing the Headstage64 dialog, which confirms that both the Electrical and Optical stimulus sequences are valid before continuing.

Fixes #528 