### PR TITLE
Refactor Rhs2116 design files

### DIFF
--- a/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.Designer.cs
@@ -44,14 +44,14 @@
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // tabControl
+            // tabControlProperties
             // 
             this.tabControl.Controls.Add(this.tabPageStimulusSequence);
             this.tabControl.Controls.Add(this.tabPageRhs2116);
             this.tabControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl.Location = new System.Drawing.Point(3, 2);
             this.tabControl.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.tabControl.Name = "tabControl";
+            this.tabControl.Name = "tabControlProperties";
             this.tabControl.SelectedIndex = 0;
             this.tabControl.Size = new System.Drawing.Size(1328, 741);
             this.tabControl.TabIndex = 0;

--- a/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.cs
+++ b/OpenEphys.Onix1.Design/HeadstageRhs2116Dialog.cs
@@ -15,22 +15,16 @@ namespace OpenEphys.Onix1.Design
         internal readonly Rhs2116StimulusSequenceDialog StimulusSequenceDialog;
         internal readonly GenericDeviceDialog Rhs2116Dialog;
 
-        internal Rhs2116ProbeGroup ProbeGroup;
-
         /// <summary>
         /// Initializes a new instance of a <see cref="HeadstageRhs2116Dialog"/>.
         /// </summary>
-        /// <param name="probeGroup">Current channel configuration settings for a <see cref="Rhs2116ProbeGroup"/>.</param>
-        /// <param name="sequence">Current stimulus sequence for a <see cref="Rhs2116StimulusSequencePair"/>.</param>
+        /// <param name="rhs2116Trigger">Current configuration settings for <see cref="ConfigureRhs2116Trigger"/>.</param>
         /// <param name="rhs2116">Current configuration settings for a single <see cref="ConfigureRhs2116"/>.</param>
-        public HeadstageRhs2116Dialog(Rhs2116ProbeGroup probeGroup, Rhs2116StimulusSequencePair sequence,
-            ConfigureRhs2116Pair rhs2116)
+        public HeadstageRhs2116Dialog(ConfigureRhs2116Trigger rhs2116Trigger, ConfigureRhs2116Pair rhs2116)
         {
             InitializeComponent();
 
-            ProbeGroup = new Rhs2116ProbeGroup(probeGroup);
-
-            StimulusSequenceDialog = new Rhs2116StimulusSequenceDialog(sequence, ProbeGroup);
+            StimulusSequenceDialog = new Rhs2116StimulusSequenceDialog(rhs2116Trigger);
 
             StimulusSequenceDialog.SetChildFormProperties(this).AddDialogToTab(tabPageStimulusSequence);
             this.AddMenuItemsFromDialogToFileOption(StimulusSequenceDialog);

--- a/OpenEphys.Onix1.Design/HeadstageRhs2116Editor.cs
+++ b/OpenEphys.Onix1.Design/HeadstageRhs2116Editor.cs
@@ -18,13 +18,11 @@ namespace OpenEphys.Onix1.Design
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
                 if (editorState != null && !editorState.WorkflowRunning && component is ConfigureHeadstageRhs2116 configureNode)
                 {
-                    using var editorDialog = new HeadstageRhs2116Dialog(configureNode.StimulusTrigger.ProbeGroup,
-                        configureNode.StimulusTrigger.StimulusSequence, configureNode.Rhs2116Pair);
+                    using var editorDialog = new HeadstageRhs2116Dialog(configureNode.StimulusTrigger, configureNode.Rhs2116Pair);
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
-                        configureNode.StimulusTrigger.StimulusSequence = editorDialog.StimulusSequenceDialog.Sequence;
-                        configureNode.StimulusTrigger.ProbeGroup = (Rhs2116ProbeGroup)editorDialog.StimulusSequenceDialog.ChannelDialog.ProbeGroup;
+                        configureNode.StimulusTrigger = editorDialog.StimulusSequenceDialog.Trigger;
                         DesignHelper.CopyProperties((ConfigureRhs2116Pair)editorDialog.Rhs2116Dialog.Device, configureNode.Rhs2116Pair, DesignHelper.PropertiesToIgnore);
 
                         return true;

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceEditor.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceEditor.cs
@@ -18,12 +18,11 @@ namespace OpenEphys.Onix1.Design
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
                 if (editorState != null && !editorState.WorkflowRunning && component is ConfigureRhs2116Trigger configureNode)
                 {
-                    using var editorDialog = new Rhs2116StimulusSequenceDialog(configureNode.StimulusSequence, configureNode.ProbeGroup);
+                    using var editorDialog = new Rhs2116StimulusSequenceDialog(configureNode);
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
-                        configureNode.StimulusSequence = editorDialog.Sequence;
-                        configureNode.ProbeGroup = (Rhs2116ProbeGroup)editorDialog.ChannelDialog.ProbeGroup;
+                        DesignHelper.CopyProperties(editorDialog.Trigger, configureNode);
 
                         return true;
                     }

--- a/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
@@ -34,6 +34,22 @@ namespace OpenEphys.Onix1
         }
 
         /// <summary>
+        /// Copy constructor for the <see cref="ConfigureRhs2116Trigger"/> class.
+        /// </summary>
+        /// <param name="rhs2116Trigger">Existing <see cref="ConfigureRhs2116Trigger"/> object.</param>
+        public ConfigureRhs2116Trigger(ConfigureRhs2116Trigger rhs2116Trigger)
+            : this()
+        {
+            Enable = rhs2116Trigger.Enable;
+            DeviceAddress = rhs2116Trigger.DeviceAddress;
+            DeviceName = rhs2116Trigger.DeviceName;
+            TriggerSource = rhs2116Trigger.TriggerSource;
+            ProbeGroup = rhs2116Trigger.ProbeGroup;
+            Armed = rhs2116Trigger.Armed;
+            StimulusSequence = new(rhs2116Trigger.StimulusSequence);
+        }
+
+        /// <summary>
         /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This PR is to facilitate #515, as the original implementation of the `Rhs2116` design files did not work well with the additions created there. Specifically, when adding a property grid to the `Rhs2116` dialogs, the object that was available was the `Rhs2116StimulusSequencePair`, and not the `ConfigureRhs2116Trigger`. 

This PR updates the `Rhs2116` design files to match the convention of the other design files, where the entire Configure node is passed to the Design library and then individual properties are accessed from there, instead of passing individual properties. By passing the entire configure node, the addition in #515 of a property grid will show the entire `ConfigureRhs2116Trigger` object in the pane, instead of just the stimulus sequence object.