### PR TITLE
Allow NeuropixelsV2 headstages to run without any probes

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -114,12 +114,6 @@ namespace OpenEphys.Onix1
                 var probeAMetadata = ReadProbeMetadata(serializer, NeuropixelsV2e.ProbeASelected);
                 var probeBMetadata = ReadProbeMetadata(serializer, NeuropixelsV2e.ProbeBSelected);
 
-                if (probeAMetadata.ProbeSerialNumber == null && probeBMetadata.ProbeSerialNumber == null)
-                {
-                    throw new InvalidOperationException("No probes were detected. Ensure that the " +
-                        "flex connection is properly seated.");
-                }
-
                 // issue full reset to both probes
                 ResetProbes(serializer, gpo10Config);
 
@@ -177,7 +171,7 @@ namespace OpenEphys.Onix1
                 // disconnect i2c bus from both probes to prevent digital interference during acquisition
                 SelectProbe(serializer, NeuropixelsV2e.NoProbeSelected);
 
-                var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB, invertPolarity);
+                var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB, invertPolarity, probeAMetadata, probeBMetadata);
                 var shutdown = Disposable.Create(() =>
                 {
                     serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, NeuropixelsV2e.DefaultGPO10Config);

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -131,12 +131,6 @@ namespace OpenEphys.Onix1
                 var probeAMetadata = ReadProbeMetadata(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeA);
                 var probeBMetadata = ReadProbeMetadata(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeB);
 
-                if (probeAMetadata.ProbeSerialNumber == null && probeBMetadata.ProbeSerialNumber == null)
-                {
-                    throw new InvalidOperationException("No probes were detected. Ensure that the " +
-                        "flex connection is properly seated.");
-                }
-
                 // REC_NRESET and NRESET go high on both probes to take the ASIC out of reset
                 // TODO: not sure if REC_NRESET and NRESET are tied together on flex
                 gpo10Config |= NeuropixelsV2eBeta.GPO10ResetMask | NeuropixelsV2eBeta.GPO10NResetMask;
@@ -217,7 +211,7 @@ namespace OpenEphys.Onix1
                 // Still its good to get them roughly (i.e. within 10 PCLKs) started at the same time.
                 SyncProbes(serializer, gpo10Config);
 
-                var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB, invertPolarity);
+                var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB, invertPolarity, probeAMetadata, probeBMetadata);
                 var shutdown = Disposable.Create(() =>
                 {
                     serializer.WriteByte((uint)DS90UB933SerializerI2CRegister.Gpio10, NeuropixelsV2eBeta.DefaultGPO10Config);

--- a/OpenEphys.Onix1/INeuropixelsV2eMetadata.cs
+++ b/OpenEphys.Onix1/INeuropixelsV2eMetadata.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenEphys.Onix1
+{
+    interface INeuropixelsV2eMetadata
+    {
+        public string ProbePartNumber { get; }
+
+        public ulong? ProbeSerialNumber { get; }
+
+        public string FlexPartNumber { get; }
+
+        public string FlexVersion { get; }
+    }
+}

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
@@ -51,6 +51,18 @@ namespace OpenEphys.Onix1
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
+                var metadata = ProbeIndex switch
+                {
+                    NeuropixelsV2Probe.ProbeA => info.ProbeMetadataA,
+                    NeuropixelsV2Probe.ProbeB => info.ProbeMetadataB,
+                    _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
+                };
+
+                if (metadata.ProbeSerialNumber == null)
+                {
+                    throw new InvalidOperationException($"{ProbeIndex} is not detected. Ensure that the flex connection is properly seated.");
+                }
+
                 var device = info.GetDeviceContext(typeof(NeuropixelsV2eBeta));
                 var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
                 var probeData = device.Context
@@ -62,7 +74,7 @@ namespace OpenEphys.Onix1
                 {
                     NeuropixelsV2Probe.ProbeA => (double)info.GainCorrectionA,
                     NeuropixelsV2Probe.ProbeB => (double)info.GainCorrectionB,
-                    _ => throw new ArgumentOutOfRangeException(nameof(ProbeIndex), $"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}"),
+                    _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
                 };
 
                 return Observable.Create<NeuropixelsV2eBetaDataFrame>(observer =>

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaMetadata.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaMetadata.cs
@@ -2,7 +2,7 @@
 
 namespace OpenEphys.Onix1
 {
-    class NeuropixelsV2eBetaMetadata
+    class NeuropixelsV2eBetaMetadata : INeuropixelsV2eMetadata
     {
         const uint OFFSET_FLEX_VERSION = 0x00;
         const uint OFFSET_FLEX_REVISION = 0x01;
@@ -39,6 +39,5 @@ namespace OpenEphys.Onix1
         public string FlexPartNumber { get; }
 
         public string FlexVersion { get; }
-
     }
 }

--- a/OpenEphys.Onix1/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eData.cs
@@ -55,6 +55,18 @@ namespace OpenEphys.Onix1
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
+                var metadata = ProbeIndex switch
+                {
+                    NeuropixelsV2Probe.ProbeA => info.ProbeMetadataA,
+                    NeuropixelsV2Probe.ProbeB => info.ProbeMetadataB,
+                    _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
+                };
+
+                if (metadata.ProbeSerialNumber == null)
+                {
+                    throw new InvalidOperationException($"{ProbeIndex} is not detected. Ensure that the flex connection is properly seated.");
+                }
+
                 var device = info.GetDeviceContext(typeof(NeuropixelsV2e));
                 var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
                 var probeData = device.Context
@@ -66,7 +78,7 @@ namespace OpenEphys.Onix1
                 {
                     NeuropixelsV2Probe.ProbeA => (double)info.GainCorrectionA,
                     NeuropixelsV2Probe.ProbeB => (double)info.GainCorrectionB,
-                    _ => throw new ArgumentOutOfRangeException(nameof(ProbeIndex), $"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}"),
+                    _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
                 };
 
                 return Observable.Create<NeuropixelsV2eDataFrame>(observer =>

--- a/OpenEphys.Onix1/NeuropixelsV2eDeviceInfo.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eDeviceInfo.cs
@@ -4,18 +4,24 @@ namespace OpenEphys.Onix1
 {
     class NeuropixelsV2eDeviceInfo : DeviceInfo
     {
-        public NeuropixelsV2eDeviceInfo(ContextTask context, Type deviceType, uint deviceAddress, double? gainCorrectionA, double? gainCorrectionB, bool invertPolarity)
+        public NeuropixelsV2eDeviceInfo(ContextTask context, Type deviceType, uint deviceAddress, double? gainCorrectionA, double? gainCorrectionB, bool invertPolarity, INeuropixelsV2eMetadata probeMetadataA, INeuropixelsV2eMetadata probeMetadataB)
             : base(context, deviceType, deviceAddress)
         {
             GainCorrectionA = gainCorrectionA;
             GainCorrectionB = gainCorrectionB;
             InvertPolarity = invertPolarity;
+            ProbeMetadataA = probeMetadataA;
+            ProbeMetadataB = probeMetadataB;
         }
 
         public double? GainCorrectionA { get; }
 
         public double? GainCorrectionB { get; }
 
-        public bool InvertPolarity {  get; }
+        public bool InvertPolarity { get; }
+
+        public INeuropixelsV2eMetadata ProbeMetadataA { get; }
+
+        public INeuropixelsV2eMetadata ProbeMetadataB { get; }
     }
 }

--- a/OpenEphys.Onix1/NeuropixelsV2eMetadata.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eMetadata.cs
@@ -2,7 +2,7 @@
 
 namespace OpenEphys.Onix1
 {
-    class NeuropixelsV2eMetadata
+    class NeuropixelsV2eMetadata : INeuropixelsV2eMetadata
     {
         const uint OFFSET_PROBE_SN = 0x00;
         const uint OFFSET_FLEX_VERSION = 0x10;
@@ -39,6 +39,5 @@ namespace OpenEphys.Onix1
         public string FlexPartNumber { get; }
 
         public string FlexVersion { get; }
-
     }
 }


### PR DESCRIPTION
This PR moves the check for a valid serial number from the Configure node to the data node, and removes the check that at least one probe has a valid serial number. This allows configuration to still continue, and the BNO data can be streamed.

The check for a valid serial number in the Data node ensures that if a data node is placed, it will confirm if the probe is connected at that time.

This is separate from issue #506, which will be addressed in a separate PR.

Fixes #505 

This PR is tested on a NeuropixelsV2e headstage, with no probes connected, and the BNO data is still configured and streaming. If a data node is placed for the Neuropixels probe, it will throw an exception that the probe is missing, but if no data nodes are placed except for the Bno055 node, it will work correctly.