### PR TITLE
Ensure gain correction always exists for NeuropixelsV2e devices

### DIFF
--- a/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
@@ -51,16 +51,20 @@ namespace OpenEphys.Onix1
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
-                var metadata = ProbeIndex switch
+                var (metadata, gainCorrection) = ProbeIndex switch
                 {
-                    NeuropixelsV2Probe.ProbeA => info.ProbeMetadataA,
-                    NeuropixelsV2Probe.ProbeB => info.ProbeMetadataB,
+                    NeuropixelsV2Probe.ProbeA => (info.ProbeMetadataA, info.GainCorrectionA),
+                    NeuropixelsV2Probe.ProbeB => (info.ProbeMetadataB, info.GainCorrectionB),
                     _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
                 };
 
                 if (metadata.ProbeSerialNumber == null)
                 {
                     throw new InvalidOperationException($"{ProbeIndex} is not detected. Ensure that the flex connection is properly seated.");
+                }
+                else if (gainCorrection == null)
+                {
+                    throw new NullReferenceException($"Gain correction value is null for {ProbeIndex}.");
                 }
 
                 var device = info.GetDeviceContext(typeof(NeuropixelsV2eBeta));
@@ -69,13 +73,6 @@ namespace OpenEphys.Onix1
                     .GetDeviceFrames(passthrough.Address)
                     .Where(frame => NeuropixelsV2eBetaDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
                 var invertPolarity = info.InvertPolarity;
-
-                double gainCorrection = ProbeIndex switch
-                {
-                    NeuropixelsV2Probe.ProbeA => info.GainCorrectionA ?? throw new NullReferenceException($"Gain correction value is null for {ProbeIndex}."),
-                    NeuropixelsV2Probe.ProbeB => info.GainCorrectionB ?? throw new NullReferenceException($"Gain correction value is null for {ProbeIndex}."),
-                    _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
-                };
 
                 return Observable.Create<NeuropixelsV2eBetaDataFrame>(observer =>
                 {
@@ -89,7 +86,7 @@ namespace OpenEphys.Onix1
                         frame =>
                         {
                             var payload = (NeuropixelsV2BetaPayload*)frame.Data.ToPointer();
-                            NeuropixelsV2eBetaDataFrame.CopyAmplifierBuffer(payload->SuperFrame, amplifierBuffer, frameCounter, sampleIndex, gainCorrection, invertPolarity);
+                            NeuropixelsV2eBetaDataFrame.CopyAmplifierBuffer(payload->SuperFrame, amplifierBuffer, frameCounter, sampleIndex, gainCorrection.Value, invertPolarity);
                             hubClockBuffer[sampleIndex] = payload->HubClock;
                             clockBuffer[sampleIndex] = frame.Clock;
                             if (++sampleIndex >= bufferSize)

--- a/OpenEphys.Onix1/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eData.cs
@@ -55,16 +55,20 @@ namespace OpenEphys.Onix1
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
-                var metadata = ProbeIndex switch
+                var (metadata, gainCorrection) = ProbeIndex switch
                 {
-                    NeuropixelsV2Probe.ProbeA => info.ProbeMetadataA,
-                    NeuropixelsV2Probe.ProbeB => info.ProbeMetadataB,
+                    NeuropixelsV2Probe.ProbeA => (info.ProbeMetadataA, info.GainCorrectionA),
+                    NeuropixelsV2Probe.ProbeB => (info.ProbeMetadataB, info.GainCorrectionB),
                     _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
                 };
 
                 if (metadata.ProbeSerialNumber == null)
                 {
                     throw new InvalidOperationException($"{ProbeIndex} is not detected. Ensure that the flex connection is properly seated.");
+                }
+                else if (gainCorrection == null)
+                {
+                    throw new NullReferenceException($"Gain correction value is null for {ProbeIndex}.");
                 }
 
                 var device = info.GetDeviceContext(typeof(NeuropixelsV2e));
@@ -73,13 +77,6 @@ namespace OpenEphys.Onix1
                     .GetDeviceFrames(passthrough.Address)
                     .Where(frame => NeuropixelsV2eDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
                 var invertPolarity = info.InvertPolarity;
-
-                double gainCorrection = ProbeIndex switch
-                {
-                    NeuropixelsV2Probe.ProbeA => info.GainCorrectionA ?? throw new NullReferenceException($"Gain correction value is null for {ProbeIndex}."),
-                    NeuropixelsV2Probe.ProbeB => info.GainCorrectionB ?? throw new NullReferenceException($"Gain correction value is null for {ProbeIndex}."),
-                    _ => throw new InvalidEnumArgumentException($"Unexpected {nameof(ProbeIndex)} value: {ProbeIndex}")
-                };
 
                 return Observable.Create<NeuropixelsV2eDataFrame>(observer =>
                 {
@@ -92,7 +89,7 @@ namespace OpenEphys.Onix1
                         frame =>
                         {
                             var payload = (NeuropixelsV2Payload*)frame.Data.ToPointer();
-                            NeuropixelsV2eDataFrame.CopyAmplifierBuffer(payload->AmplifierData, amplifierBuffer, sampleIndex, gainCorrection, invertPolarity);
+                            NeuropixelsV2eDataFrame.CopyAmplifierBuffer(payload->AmplifierData, amplifierBuffer, sampleIndex, gainCorrection.Value, invertPolarity);
                             hubClockBuffer[sampleIndex] = payload->HubClock;
                             clockBuffer[sampleIndex] = frame.Clock;
                             if (++sampleIndex >= bufferSize)


### PR DESCRIPTION
This PR is based on the changes made in #535, and goes a step further to ensure that the gain correction is non-null, throwing an explicit exception if it is ever null so that the error message is useful.

However, during testing it was noted that #535 actually made it difficult to test this PR. If the issue-505 branch is removed, then these modifications correctly handle the case initially described in the issue where the gain correction value could be null. Nominally though, there should never be a case in the Data* nodes where the serial number exists but the gain correction value is null, since that condition is explicitly tested for in the Configure* nodes.

Fixes #506