### PR TITLE
Add basic troubleshooting step when lock cannot be acquired

### DIFF
--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -86,7 +86,7 @@ namespace OpenEphys.Onix1
                     var message = portVoltage.Requested.HasValue ?
                         $"Unable to acquire communication lock on {portString}. Confirm the headstage port is turned on." :
                         $"Unable to acquire communication lock on {portString}. Confirm the headstage port is turned on."
-                        + $"\n\nYou may need to manually specify a PortVoltage greater than {PortVoltage.Applied} volts, the maximum automatic value for this device.";
+                        + $"\n\nIf the problem persists, you may need to manually specify a PortVoltage greater than {PortVoltage.Applied} volts, the maximum automatic value for this device.";
 
                     dispose();
                     throw new InvalidOperationException(message);


### PR DESCRIPTION
For all port controllers, if communication lock cannot be acquired add a line with the basic step of "Confirm the headstage port is turned on". 

Fixes #496 