### PR TITLE
Refactor Rhs2116 to save ProbeInterface files externally

### DIFF
--- a/OpenEphys.Onix1/Rhs2116ProbeGroup.cs
+++ b/OpenEphys.Onix1/Rhs2116ProbeGroup.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using OpenEphys.ProbeInterface.NET;
 
@@ -80,6 +80,11 @@ namespace OpenEphys.Onix1
         public Rhs2116ProbeGroup(Rhs2116ProbeGroup probeGroup)
             : base(probeGroup)
         {
+        }
+
+        internal Rhs2116ProbeGroup Clone()
+        {
+            return new Rhs2116ProbeGroup(Specification, Version, Probes.Select(probe => new Probe(probe)).ToArray());
         }
 
         internal static ContactAnnotations DefaultContactAnnotations(int numberOfChannels, int probeIndex)


### PR DESCRIPTION
Similar to #522, this PR no longer saves the ProbeInterface configuration directly in the Bonsai file. Now, there is a `ProbeInterfaceFileName` property that points to where the file will be saved/loaded.

The file is only saved when the Bonsai file itself is saved (during serialization). The file is then lazily loaded when the Bonsai file itself is loaded. This allows the workflow to load fully before checking if there were any errors during initialization. 

Fixes #547 