### PR TITLE
Correct method call for Rhs2116Trigger

### DIFF
--- a/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
@@ -147,7 +147,7 @@ namespace OpenEphys.Onix1
                     if (string.IsNullOrEmpty(probeInterfaceFileName))
                         return new Rhs2116ProbeGroup();
 
-                    return ProbeInterfaceHelper.LoadExternalProbeInterfaceFile<Rhs2116ProbeGroup>(probeInterfaceFileName);
+                    return ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeInterfaceFileName, typeof(Rhs2116ProbeGroup)) as Rhs2116ProbeGroup;
                 });
             }
         }


### PR DESCRIPTION
Due to the order of PRs being merged, a compiler error was introduced that was not caught before merging. This PR allows the main branch to compile and generate a NuGet package.