### PR TITLE
Ensure consistent units between labels and scale bar

### DIFF
--- a/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
@@ -10,7 +10,7 @@ namespace OpenEphys.Onix1.Design
     /// <summary>
     /// Partial class to create a channel configuration GUI for a <see cref="GenericStimulusSequenceDialog"/>.
     /// </summary>
-    public partial class GenericStimulusSequenceDialog : Form
+    public abstract partial class GenericStimulusSequenceDialog : Form
     {
         readonly int NumberOfChannels;
         readonly bool UseProbeGroup;
@@ -225,8 +225,8 @@ namespace OpenEphys.Onix1.Design
 
         internal virtual double GetPeakToPeakAmplitudeInMicroAmps() => throw new NotImplementedException();
 
-        internal string yAxisScaleUnits = "µA";
-        internal string xAxisScaleUnits = "ms";
+        private protected abstract string YAxisScaleUnits { get; }
+        private protected abstract string XAxisScaleUnits { get; }
 
         void DrawScale()
         {
@@ -280,13 +280,13 @@ namespace OpenEphys.Onix1.Design
 
             const double TextObjScaleFactor = 1.02;
 
-            TextObj timeScale = new(GetTimeScaleString(x) + " " + xAxisScaleUnits, zeroOffsetX + x * TextObjScaleFactor, zeroOffsetY, CoordType.AxisXYScale, AlignH.Left, AlignV.Center);
+            TextObj timeScale = new(GetTimeScaleString(x) + " " + XAxisScaleUnits, zeroOffsetX + x * TextObjScaleFactor, zeroOffsetY, CoordType.AxisXYScale, AlignH.Left, AlignV.Center);
             timeScale.FontSpec.Border.IsVisible = false;
             timeScale.FontSpec.Fill.IsVisible = false;
             timeScale.ZOrder = ZOrder.A_InFront;
             zedGraphWaveform.GraphPane.GraphObjList.Add(timeScale);
 
-            TextObj amplitudeScale = new(yScaleValue.ToString("0.##") + " " + yAxisScaleUnits, zeroOffsetX, zeroOffsetY + y * TextObjScaleFactor, CoordType.AxisXYScale, AlignH.Left, AlignV.Bottom);
+            TextObj amplitudeScale = new(yScaleValue.ToString("0.##") + " " + YAxisScaleUnits, zeroOffsetX, zeroOffsetY + y * TextObjScaleFactor, CoordType.AxisXYScale, AlignH.Left, AlignV.Bottom);
             amplitudeScale.FontSpec.Border.IsVisible = false;
             amplitudeScale.FontSpec.Fill.IsVisible = false;
             amplitudeScale.ZOrder = ZOrder.A_InFront;

--- a/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64ElectricalStimulatorSequenceDialog.cs
@@ -21,6 +21,9 @@ namespace OpenEphys.Onix1.Design
         readonly Dictionary<TextBox, TextBoxBinding<uint>> timeBindings;
         readonly Dictionary<TextBox, TextBoxBinding<uint>> countBindings;
 
+        private protected override string XAxisScaleUnits => "µs";
+        private protected override string YAxisScaleUnits => "µA";
+
         /// <summary>
         /// Opens a dialog allowing for easy changing of stimulus sequence parameters, with 
         /// visual feedback on what the resulting stimulus sequence looks like.
@@ -127,8 +130,7 @@ namespace OpenEphys.Onix1.Design
 
             toolStripStatusIsValid.BorderSides = ToolStripStatusLabelBorderSides.None;
 
-            xAxisScaleUnits = "µs";
-            SetXAxisTitle($"Time [{xAxisScaleUnits}]");
+            SetXAxisTitle($"Time [{XAxisScaleUnits}]");
             SetYAxisTitle("");
             RemoveYAxisLabels();
 

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
@@ -22,6 +22,9 @@ namespace OpenEphys.Onix1.Design
         readonly Dictionary<TextBox, TextBoxBinding<double>> timeBindings;
         readonly Dictionary<TextBox, TextBoxBinding<uint>> countBindings;
 
+        private protected override string XAxisScaleUnits => "ms";
+        private protected override string YAxisScaleUnits => "mA";
+
         /// <summary>
         /// Opens a dialog allowing for easy changing of stimulus sequence parameters, with 
         /// visual feedback on what the resulting stimulus sequence looks like.
@@ -131,9 +134,7 @@ namespace OpenEphys.Onix1.Design
 
             toolStripStatusIsValid.BorderSides = ToolStripStatusLabelBorderSides.None;
 
-            xAxisScaleUnits = "ms";
-            SetXAxisTitle($"Time [{xAxisScaleUnits}]");
-            yAxisScaleUnits = "mA";
+            SetXAxisTitle($"Time [{XAxisScaleUnits}]");
 
             DisableVerticalZoom();
 

--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -33,6 +33,9 @@ namespace OpenEphys.Onix1.Design
         internal readonly Rhs2116ChannelConfigurationDialog ChannelDialog;
         readonly Rhs2116StimulusSequenceOptions StimulusSequenceOptions;
 
+        private protected override string XAxisScaleUnits => "ms";
+        private protected override string YAxisScaleUnits => "µA";
+
         /// <summary>
         /// Opens a dialog allowing for easy changing of stimulus sequence parameters, with 
         /// visual feedback on what the resulting stimulus sequence looks like.


### PR DESCRIPTION
Previously there could be inconsistencies in the units between the labels and the scale bar, now these are consistent for optical and electrical stimulators.

<img width="890" height="528" alt="image" src="https://github.com/user-attachments/assets/31b517e5-0246-4663-b4c4-7355f57bd509" />

<img width="890" height="528" alt="image" src="https://github.com/user-attachments/assets/d33d6fb3-1be3-43d8-95ee-1bedc669bb7e" />

Fixes #544 