### PR TITLE
Fixed ConfigureHeadstage64OpticalStimulator properties

### DIFF
--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.Designer.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.Designer.cs
@@ -46,8 +46,8 @@
             this.trackBarChannelTwoPercent = new System.Windows.Forms.TrackBar();
             this.textBoxChannelTwoPercent = new System.Windows.Forms.TextBox();
             this.labelChannelTwoPercent = new System.Windows.Forms.Label();
-            this.textBoxPulsePeriod = new System.Windows.Forms.TextBox();
-            this.labelPulsePeriod = new System.Windows.Forms.Label();
+            this.textBoxPulseFrequencyHz = new System.Windows.Forms.TextBox();
+            this.labelPulseFrequencyHz = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarChannelOnePercent)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarChannelTwoPercent)).BeginInit();
             this.SuspendLayout();
@@ -208,29 +208,29 @@
             this.labelChannelTwoPercent.TabIndex = 4;
             this.labelChannelTwoPercent.Text = "Channel Two [%]";
             // 
-            // textBoxPulsePeriod
+            // textBoxPulseFrequencyHz
             // 
-            this.textBoxPulsePeriod.Location = new System.Drawing.Point(356, 146);
-            this.textBoxPulsePeriod.Name = "textBoxPulsePeriod";
-            this.textBoxPulsePeriod.Size = new System.Drawing.Size(75, 22);
-            this.textBoxPulsePeriod.TabIndex = 11;
+            this.textBoxPulseFrequencyHz.Location = new System.Drawing.Point(356, 146);
+            this.textBoxPulseFrequencyHz.Name = "textBoxPulseFrequencyHz";
+            this.textBoxPulseFrequencyHz.Size = new System.Drawing.Size(75, 22);
+            this.textBoxPulseFrequencyHz.TabIndex = 11;
             // 
-            // labelPulsePeriod
+            // labelPulseFrequencyHz
             // 
-            this.labelPulsePeriod.AutoSize = true;
-            this.labelPulsePeriod.Location = new System.Drawing.Point(216, 149);
-            this.labelPulsePeriod.Name = "labelPulsePeriod";
-            this.labelPulsePeriod.Size = new System.Drawing.Size(113, 16);
-            this.labelPulsePeriod.TabIndex = 10;
-            this.labelPulsePeriod.Text = "Pulse Period [ms]";
+            this.labelPulseFrequencyHz.AutoSize = true;
+            this.labelPulseFrequencyHz.Location = new System.Drawing.Point(216, 149);
+            this.labelPulseFrequencyHz.Name = "labelPulseFrequencyHz";
+            this.labelPulseFrequencyHz.Size = new System.Drawing.Size(102, 16);
+            this.labelPulseFrequencyHz.TabIndex = 10;
+            this.labelPulseFrequencyHz.Text = "Pulse Freq. [Hz]";
             // 
             // Headstage64OpticalStimulatorOptions
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(438, 289);
-            this.Controls.Add(this.textBoxPulsePeriod);
-            this.Controls.Add(this.labelPulsePeriod);
+            this.ClientSize = new System.Drawing.Size(439, 281);
+            this.Controls.Add(this.textBoxPulseFrequencyHz);
+            this.Controls.Add(this.labelPulseFrequencyHz);
             this.Controls.Add(this.trackBarChannelTwoPercent);
             this.Controls.Add(this.textBoxChannelTwoPercent);
             this.Controls.Add(this.labelChannelTwoPercent);
@@ -279,7 +279,7 @@
         private System.Windows.Forms.Label labelChannelTwoPercent;
         internal System.Windows.Forms.TrackBar trackBarChannelOnePercent;
         internal System.Windows.Forms.TrackBar trackBarChannelTwoPercent;
-        internal System.Windows.Forms.TextBox textBoxPulsePeriod;
-        private System.Windows.Forms.Label labelPulsePeriod;
+        internal System.Windows.Forms.TextBox textBoxPulseFrequencyHz;
+        private System.Windows.Forms.Label labelPulseFrequencyHz;
     }
 }

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorOptions.cs
@@ -32,8 +32,8 @@ namespace OpenEphys.Onix1.Design
         {
             textBoxMaxCurrent.Text = opticalStimulator.MaxCurrent.ToString();
             textBoxPulseDuration.Text = opticalStimulator.PulseDuration.ToString();
-            textBoxPulsePeriod.Text = opticalStimulator.PulsesPerSecond.ToString();
-            textBoxPulsePeriod.Enabled = opticalStimulator.PulsesPerBurst > 1;
+            textBoxPulseFrequencyHz.Text = opticalStimulator.PulsesPerSecond.ToString();
+            textBoxPulseFrequencyHz.Enabled = opticalStimulator.PulsesPerBurst > 1;
 
             textBoxChannelOnePercent.Text = opticalStimulator.ChannelOneCurrent.ToString();
             trackBarChannelOnePercent.Value = (int)(opticalStimulator.ChannelOneCurrent * channelOneScalingFactor);
@@ -54,7 +54,7 @@ namespace OpenEphys.Onix1.Design
         {
             if (int.TryParse(textBoxPulsesPerBurst.Text, out int result))
             {
-                textBoxPulsePeriod.Enabled = result > 1;
+                textBoxPulseFrequencyHz.Enabled = result > 1;
             }
         }
 

--- a/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Headstage64OpticalStimulatorSequenceDialog.cs
@@ -88,9 +88,9 @@ namespace OpenEphys.Onix1.Design
                         StimulusSequenceOptions.textBoxPulseDuration,
                         value => { OpticalStimulator.PulseDuration = value; return OpticalStimulator.PulseDuration; },
                         double.Parse) },
-                { StimulusSequenceOptions.textBoxPulsePeriod,
+                { StimulusSequenceOptions.textBoxPulseFrequencyHz,
                     new TextBoxBinding<double>(
-                        StimulusSequenceOptions.textBoxPulsePeriod,
+                        StimulusSequenceOptions.textBoxPulseFrequencyHz,
                         value => { OpticalStimulator.PulsesPerSecond = value; return OpticalStimulator.PulsesPerSecond; },
                         double.Parse) },
             };
@@ -244,7 +244,7 @@ namespace OpenEphys.Onix1.Design
 
                         if (j != OpticalStimulator.PulsesPerBurst - 1)
                         {
-                            waveforms[channel].Add(new PointPair(waveforms[channel].Last().X + OpticalStimulator.PulsesPerSecond - OpticalStimulator.PulseDuration, offset));
+                            waveforms[channel].Add(new PointPair(waveforms[channel].Last().X + 1000.0 / OpticalStimulator.PulsesPerSecond - OpticalStimulator.PulseDuration, offset));
                         }
                     }
 
@@ -283,9 +283,9 @@ namespace OpenEphys.Onix1.Design
                 reason = "Maximum current is invalid.";
                 return false;
             }
-            else if (sequence.PulsesPerBurst > 1 && sequence.PulsesPerSecond <= sequence.PulseDuration)
+            else if (sequence.PulsesPerBurst > 1 && 1000.0 / sequence.PulsesPerSecond <= sequence.PulseDuration)
             {
-                reason = "Pulse period is too short compared to the pulse duration.";
+                reason = "Pulse frequency is too low compared to the pulse duration.";
                 return false;
             }
 

--- a/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
@@ -165,27 +165,27 @@ namespace OpenEphys.Onix1
         /// </summary>
         [Description("The duration of each pulse (msec).")]
         [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
-        [Range(Headstage64OpticalStimulator.MinPulseDuration, Headstage64OpticalStimulator.MaxPulseDuration)]
+        [Range(Headstage64OpticalStimulator.MinPulseDurationMilliseconds, Headstage64OpticalStimulator.MaxPulseDurationMilliseconds)]
         [Precision(3, 1)]
         [Category(AcquisitionCategory)]
         public double PulseDuration
         {
             get => pulseDuration.Value;
-            set => pulseDuration.OnNext(Clamp(value, Headstage64OpticalStimulator.MinPulseDuration, Headstage64OpticalStimulator.MaxPulseDuration));
+            set => pulseDuration.OnNext(Clamp(value, Headstage64OpticalStimulator.MinPulseDurationMilliseconds, Headstage64OpticalStimulator.MaxPulseDurationMilliseconds));
         }
 
         /// <summary>
-        /// Gets or sets the pulse period within a burst in msec.
+        /// Gets or sets the pulse frequency within a burst in Hz.
         /// </summary>
-        [Description("The pulse period within a burst (msec).")]
+        [Description("The pulse frequency within a burst (Hz).")]
         [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
-        [Range(Headstage64OpticalStimulator.MinPulsePeriod, Headstage64OpticalStimulator.MaxPulsePeriod)]
+        [Range(Headstage64OpticalStimulator.MinPulseFrequencyHz, Headstage64OpticalStimulator.MaxPulseFrequencyHz)]
         [Precision(3, 1)]
         [Category(AcquisitionCategory)]
         public double PulsesPerSecond
         {
             get => pulsesPerSecond.Value;
-            set => pulsesPerSecond.OnNext(Clamp(value, Headstage64OpticalStimulator.MinPulsePeriod, Headstage64OpticalStimulator.MaxPulsePeriod));
+            set => pulsesPerSecond.OnNext(Clamp(value, Headstage64OpticalStimulator.MinPulseFrequencyHz, Headstage64OpticalStimulator.MaxPulseFrequencyHz));
         }
 
         /// <summary>
@@ -207,13 +207,13 @@ namespace OpenEphys.Onix1
         /// </summary>
         [Description("The duration of the inter-burst interval within a stimulus train (msec).")]
         [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
-        [Range(Headstage64OpticalStimulator.MinInterBurstInterval, Headstage64OpticalStimulator.MaxInterBurstInterval)]
+        [Range(Headstage64OpticalStimulator.MinInterBurstIntervalMilliseconds, Headstage64OpticalStimulator.MaxInterBurstIntervalMilliseconds)]
         [Precision(3, 1)]
         [Category(AcquisitionCategory)]
         public double InterBurstInterval
         {
             get => interBurstInterval.Value;
-            set => interBurstInterval.OnNext(Clamp(value, Headstage64OpticalStimulator.MinInterBurstInterval, Headstage64OpticalStimulator.MaxInterBurstInterval));
+            set => interBurstInterval.OnNext(Clamp(value, Headstage64OpticalStimulator.MinInterBurstIntervalMilliseconds, Headstage64OpticalStimulator.MaxInterBurstIntervalMilliseconds));
         }
 
         /// <summary>
@@ -346,14 +346,14 @@ namespace OpenEphys.Onix1
         public const double MaxChannelPercentage = 100.0;
         public const double ChannelPercentageStep = 12.5;
 
-        public const double MinPulseDuration = 0.001;
-        public const double MaxPulseDuration = 1000.0;
+        public const double MinPulseDurationMilliseconds = 0.001;
+        public const double MaxPulseDurationMilliseconds = 500.0;
 
-        public const double MinPulsePeriod = 0.01;
-        public const double MaxPulsePeriod = 10000.0;
+        public const double MinPulseFrequencyHz = 0.1;
+        public const double MaxPulseFrequencyHz = 10000.0;
 
-        public const double MinInterBurstInterval = 0.0;
-        public const double MaxInterBurstInterval = 10000.0;
+        public const double MinInterBurstIntervalMilliseconds = 0.0;
+        public const double MaxInterBurstIntervalMilliseconds = 10000.0;
 
         // managed registers
         public const uint ENABLE = 0; // Enable stimulus report stream


### PR DESCRIPTION
The pulse frequency was sometimes indicated as pulse period and other times as frequency with bad results.

This PR was pulled from PR #529 as it is not tied to the firmware updates but is a useful addition to the next release.

<img width="890" height="528" alt="image" src="https://github.com/user-attachments/assets/04b6d8ae-4885-4029-b8ed-8b85a0abd781" />

Note that the labels and scales are the incorrect units; that is fixed in a separate PR, #562. What I am showing here is that the Pulse Freq. [Hz] label is now correctly applied on the `PulsesPerSecond` property of the optical stimulator.

Fixes #542 