### PR TITLE
Disable showing spurious channel numbers for stimulus sequence dialogs

### DIFF
--- a/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/GenericStimulusSequenceDialog.cs
@@ -241,7 +241,7 @@ namespace OpenEphys.Onix1.Design
             var xScaleRange = CalculateScaleRange(zedGraphWaveform.GraphPane.XAxis.Scale);
             var yScaleRange = CalculateScaleRange(zedGraphWaveform.GraphPane.YAxis.Scale);
 
-            const double ScaleFactor = 0.025;
+            const double ScaleFactor = 0.05;
 
             var zeroOffsetX = zedGraphWaveform.GraphPane.XAxis.Scale.Min + xScaleRange * ScaleFactor;
             var zeroOffsetY = zedGraphWaveform.GraphPane.YAxis.Scale.Min + yScaleRange * ScaleFactor;
@@ -285,7 +285,7 @@ namespace OpenEphys.Onix1.Design
             timeScale.ZOrder = ZOrder.A_InFront;
             zedGraphWaveform.GraphPane.GraphObjList.Add(timeScale);
 
-            TextObj amplitudeScale = new(yScaleValue.ToString("0.##") + " µA", zeroOffsetX, zeroOffsetY + y * TextObjScaleFactor, CoordType.AxisXYScale, AlignH.Center, AlignV.Bottom);
+            TextObj amplitudeScale = new(yScaleValue.ToString("0.##") + " µA", zeroOffsetX, zeroOffsetY + y * TextObjScaleFactor, CoordType.AxisXYScale, AlignH.Left, AlignV.Bottom);
             amplitudeScale.FontSpec.Border.IsVisible = false;
             amplitudeScale.FontSpec.Fill.IsVisible = false;
             amplitudeScale.ZOrder = ZOrder.A_InFront;


### PR DESCRIPTION
This PR fixes #540, by removing any labels outside of the valid range of channel numbers. Additionally, when this was first implemented in #529, I also implemented a fix for zooming in and out of the stimulus sequence dialogs. That fix is also implemented here in a separate commit.

<img width="1002" height="691" alt="image" src="https://github.com/user-attachments/assets/2dc0f128-efaa-4848-9e0e-f084a93a4a18" />

Showing how even with vertical zoom disabled, everything is still centered on the mouse pointer
![zooming](https://github.com/user-attachments/assets/a5950568-ab79-4713-99d8-c2fbbbad3929)
