### PR TITLE
Change NPX 2.0 quad-shank probe center-to-center spacing for shanks

### DIFF
--- a/OpenEphys.Onix1/NeuropixelsV2eQuadShankProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eQuadShankProbeGroup.cs
@@ -112,7 +112,7 @@ namespace OpenEphys.Onix1
         private static float ContactPositionX(int index)
         {
             var shank = index / NeuropixelsV2.ElectrodePerShank;
-            var offset = shankOffsetX + (shankWidthX + shankPitchX) * shank + 11;
+            var offset = shankOffsetX + shankPitchX * shank + 11;
 
             return (index % 2) switch
             {
@@ -141,15 +141,15 @@ namespace OpenEphys.Onix1
 
             for (int i = 0; i < numberOfShanks; i++)
             {
-                probePlanarContour[2 + i * 5] = new float[2] { shankOffsetX + (shankWidthX + shankPitchX) * i, shankLengthY };
-                probePlanarContour[3 + i * 5] = new float[2] { shankOffsetX + (shankWidthX + shankPitchX) * i, shankBaseY };
-                probePlanarContour[4 + i * 5] = new float[2] { shankOffsetX + (shankWidthX + shankPitchX) * i + shankWidthX / 2, shankTipY };
-                probePlanarContour[5 + i * 5] = new float[2] { shankOffsetX + (shankWidthX + shankPitchX) * i + shankWidthX, shankBaseY };
-                probePlanarContour[6 + i * 5] = new float[2] { shankOffsetX + (shankWidthX + shankPitchX) * i + shankWidthX, shankLengthY };
+                probePlanarContour[2 + i * 5] = new float[2] { shankOffsetX + shankPitchX * i, shankLengthY };
+                probePlanarContour[3 + i * 5] = new float[2] { shankOffsetX + shankPitchX * i, shankBaseY };
+                probePlanarContour[4 + i * 5] = new float[2] { shankOffsetX + shankPitchX * i + shankWidthX / 2, shankTipY };
+                probePlanarContour[5 + i * 5] = new float[2] { shankOffsetX + shankPitchX * i + shankWidthX, shankBaseY };
+                probePlanarContour[6 + i * 5] = new float[2] { shankOffsetX + shankPitchX * i + shankWidthX, shankLengthY };
             }
 
-            probePlanarContour[22] = new float[2] { shankOffsetX * 2 + (shankWidthX + shankPitchX) * (numberOfShanks - 1) + shankWidthX, shankLengthY };
-            probePlanarContour[23] = new float[2] { shankOffsetX * 2 + (shankWidthX + shankPitchX) * (numberOfShanks - 1) + shankWidthX, probeLengthY };
+            probePlanarContour[22] = new float[2] { shankOffsetX * 2 + shankPitchX * (numberOfShanks - 1) + shankWidthX, shankLengthY };
+            probePlanarContour[23] = new float[2] { shankOffsetX * 2 + shankPitchX * (numberOfShanks - 1) + shankWidthX, probeLengthY };
             probePlanarContour[24] = new float[2] { 0f, probeLengthY };
 
             return probePlanarContour;


### PR DESCRIPTION
Corrected the spacing so it is 250 µm center-to-center for shanks, instead of 320 µm like it was before.

This is to match the same electrode spacing seen in the [probeinterface_library repo](https://github.com/SpikeInterface/probeinterface_library/blob/main/imec/NP2013/NP2013.json)

Fixes #566 