### PR TITLE
Remove Range attribute for ConfigurePersistentHeartbeat.BeatsPerSecond

### DIFF
--- a/OpenEphys.Onix1/ConfigurePersistentHeartbeat.cs
+++ b/OpenEphys.Onix1/ConfigurePersistentHeartbeat.cs
@@ -28,7 +28,6 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Gets or sets the rate at which beats are produced in Hz.
         /// </summary>
-        [Range(100, 10e6)]
         [Category(AcquisitionCategory)]
         [Description("Rate at which beats are produced (Hz).")]
         public uint BeatsPerSecond


### PR DESCRIPTION
This PR was cherry-picked from PR #529.

- The range is a readonly register value that is device specific and not know at compile time