### PR TITLE
Modify headstage-64 port voltage scan algorithm

### DIFF
--- a/OpenEphys.Onix1/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64.cs
@@ -175,8 +175,6 @@ namespace OpenEphys.Onix1
 
                 // NB: Wait for 1 second to discharge the headstage in the case that they have e.g. just
                 // restarted the workflow automatically with nearly no delay from the last run.
-                //device.WriteRegister(PortController.PORTVOLTAGE, (uint)(MinVoltage * 10));
-                //Thread.Sleep(500);
                 device.WriteRegister(PortController.PORTVOLTAGE, 0);
                 Thread.Sleep(1000);
 


### PR DESCRIPTION
- I've made several changes to the algorithm to get functionality with tethers of different lengths and different POR behavior across headstages
- There arei two major changes:
  1. The scan starts with the application of 10V for 10-20 msec. This is long enought to turn on the LDOs across tethers and short enought not to result in overvoltage damge for short tethers
  2. Apply an offset voltage that is a linear function of the minimum lock voltage instead of a constant. m and b were found emperically using 0.7 and 2.5 m tether in order to get 5.2 at the headstage.