### PR TITLE
Ensure hardware is closed before ContextTask.Dispose() returns

### DIFF
--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -573,14 +573,17 @@ namespace OpenEphys.Onix1
         /// </summary>
         public void Dispose()
         {
+            Task disposeContextContinuation;
             lock (disposeLock)
                 lock (regLock)
                 {
                     disposed = true;
-                    acquisition.ContinueWith(_ => DisposeContext());
+                    disposeContextContinuation = acquisition.ContinueWith(_ => DisposeContext());
                     collectFramesCancellation?.Cancel();
+
                 }
 
+            disposeContextContinuation.GetAwaiter().GetResult();
             GC.SuppressFinalize(this);
         }
     }


### PR DESCRIPTION
- This prevents a possible race condidition between asynchronously closing and opening the same hardware that could occur during workflow restart
- Fixes #572 