### PR TITLE
Add ConfigureDeviceWithoutReset stage to ConfigureContext()

### DIFF
--- a/OpenEphys.Onix1/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix1/ConfigureAnalogIO.cs
@@ -225,7 +225,7 @@ namespace OpenEphys.Onix1
         {
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(AnalogIO.ENABLE, Enable ? 1u : 0u);

--- a/OpenEphys.Onix1/ConfigureBno055.cs
+++ b/OpenEphys.Onix1/ConfigureBno055.cs
@@ -57,7 +57,7 @@ namespace OpenEphys.Onix1
         {
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(Bno055.ENABLE, Enable ? 1u : 0);

--- a/OpenEphys.Onix1/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix1/ConfigureDigitalIO.cs
@@ -106,7 +106,7 @@ namespace OpenEphys.Onix1
             var deviceAddress = DeviceAddress;
             var dt = deadTime;
             var sr = SampleRate;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(DigitalIO.ENABLE, Enable ? 1u : 0);

--- a/OpenEphys.Onix1/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix1/ConfigureHarpSyncInput.cs
@@ -81,7 +81,7 @@ namespace OpenEphys.Onix1
         {
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(HarpSyncInput.ENABLE, Enable ? 1u : 0);

--- a/OpenEphys.Onix1/ConfigureHeadstage64ElectricalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64ElectricalStimulator.cs
@@ -243,7 +243,7 @@ namespace OpenEphys.Onix1
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
 
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
 
@@ -263,7 +263,7 @@ namespace OpenEphys.Onix1
                     burstPulseCount.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.BURSTCOUNT, value)),
                     trainBurstCount.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.TRAINCOUNT, value)),
                     DeviceManager.RegisterDevice(deviceName, device, DeviceType));
-            }).ConfigureDeviceWithoutReset((context, observer) =>
+            }).ConfigureDirectDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
 

--- a/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
@@ -257,7 +257,7 @@ namespace OpenEphys.Onix1
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
 
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
 
@@ -308,7 +308,7 @@ namespace OpenEphys.Onix1
                         device.WriteRegister(Headstage64OpticalStimulator.TRAINDELAY, (uint)(1000 * value))),
                     DeviceManager.RegisterDevice(deviceName, device, DeviceType));
             })
-            .ConfigureDeviceWithoutReset((context, observer) =>
+            .ConfigureDirectDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
 

--- a/OpenEphys.Onix1/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix1/ConfigureHeartbeat.cs
@@ -63,7 +63,7 @@ namespace OpenEphys.Onix1
             var enable = Enable;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(Heartbeat.ENABLE, enable ? 1u : 0u);

--- a/OpenEphys.Onix1/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix1/ConfigureLoadTester.cs
@@ -85,7 +85,7 @@ namespace OpenEphys.Onix1
             var transmittedWords = TransmittedWords;
             var framesPerSecond = FramesPerSecond;
 
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(LoadTester.ENABLE, enable ? 1u : 0u);

--- a/OpenEphys.Onix1/ConfigureMemoryMonitor.cs
+++ b/OpenEphys.Onix1/ConfigureMemoryMonitor.cs
@@ -74,7 +74,7 @@ namespace OpenEphys.Onix1
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
             var samplesPerSecond = SamplesPerSecond;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(MemoryMonitor.ENABLE, enable ? 1u : 0u);

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -157,7 +157,7 @@ namespace OpenEphys.Onix1
             var deviceAddress = DeviceAddress;
             var ledEnabled = EnableLed;
             var invertPolarity = ProbeConfiguration.InvertPolarity;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
@@ -160,7 +160,7 @@ namespace OpenEphys.Onix1
             var invertPolarity = ProbeConfiguration.InvertPolarity;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, typeof(NeuropixelsV1f));
                 device.WriteRegister(NeuropixelsV1f.ENABLE, enable ? 1u : 0);

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -157,7 +157,7 @@ namespace OpenEphys.Onix1
             var probeConfigurationB = ProbeConfigurationB;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -169,7 +169,7 @@ namespace OpenEphys.Onix1
             var probeConfigurationB = ProbeConfigurationB;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));

--- a/OpenEphys.Onix1/ConfigureNric1384.cs
+++ b/OpenEphys.Onix1/ConfigureNric1384.cs
@@ -120,7 +120,7 @@ namespace OpenEphys.Onix1
             var enable = Enable;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, typeof(Nric1384));
                 device.WriteRegister(Nric1384.ENABLE, enable ? 1u : 0);

--- a/OpenEphys.Onix1/ConfigureOutputClock.cs
+++ b/OpenEphys.Onix1/ConfigureOutputClock.cs
@@ -137,7 +137,7 @@ namespace OpenEphys.Onix1
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
 
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
 

--- a/OpenEphys.Onix1/ConfigurePersistentHeartbeat.cs
+++ b/OpenEphys.Onix1/ConfigurePersistentHeartbeat.cs
@@ -52,7 +52,7 @@ namespace OpenEphys.Onix1
             //var enable = Enable;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 var subscription = beatsPerSecond.SubscribeSafe(observer, newValue =>

--- a/OpenEphys.Onix1/ConfigurePolledBno055.cs
+++ b/OpenEphys.Onix1/ConfigurePolledBno055.cs
@@ -93,7 +93,7 @@ namespace OpenEphys.Onix1
             var enable = Enable;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));

--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -45,10 +45,9 @@ namespace OpenEphys.Onix1
             var deviceAddress = DeviceAddress;
             var hubConfiguration = HubConfiguration;
             var portVoltage = PortVoltage;
-            return source.ConfigureHost(context =>
+            return source.ConfigureAndLatchController(context =>
             {
-                // configure passthrough mode on the port controller
-                // assuming the device address is the port number
+                // configure passthrough mode on the port controller assuming the device address is the port number
                 var portShift = ((int)deviceAddress - 1) * 2;
                 var passthroughState = (hubConfiguration == HubConfiguration.Passthrough ? 1 : 0) << portShift;
                 context.HubState = (PassthroughState)(((int)context.HubState & ~(1 << portShift)) | passthroughState);
@@ -56,7 +55,7 @@ namespace OpenEphys.Onix1
                 // leave in standard mode when finished
                 return Disposable.Create(() => context.HubState = (PassthroughState)((int)context.HubState & ~(1 << portShift)));
             })
-            .ConfigureLink(context =>
+            .ConfigureAndLatchLink(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 void dispose() { device.WriteRegister(PortController.PORTVOLTAGE, 0); }
@@ -94,7 +93,7 @@ namespace OpenEphys.Onix1
 
                 return Disposable.Create(dispose);
             })
-            .ConfigureDevice(context =>
+            .ConfigureAndLatchDevice(context =>
             {
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);

--- a/OpenEphys.Onix1/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix1/ConfigureRhd2164.cs
@@ -87,7 +87,7 @@ namespace OpenEphys.Onix1
             var enable = Enable;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 // config register format following Rhd2164 datasheet
                 // https://intantech.com/files/Intan_RHD2000_series_datasheet.pdf

--- a/OpenEphys.Onix1/ConfigureRhs2116.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116.cs
@@ -145,7 +145,7 @@ namespace OpenEphys.Onix1
             var enable = Enable;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 // config register format following Rhs2116 datasheet
                 // https://www.intantech.com/files/Intan_RHS2116_datasheet.pdf

--- a/OpenEphys.Onix1/ConfigureRhs2116Pair.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116Pair.cs
@@ -125,7 +125,7 @@ namespace OpenEphys.Onix1
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
 
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var rhs2116A = context.GetDeviceContext(deviceAddress + Rhs2116Pair.Rhs2116AAddressOffset, typeof(Rhs2116));
                 var rhs2116B = context.GetDeviceContext(deviceAddress + Rhs2116Pair.Rhs2116BAddressOffset, typeof(Rhs2116));

--- a/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
+++ b/OpenEphys.Onix1/ConfigureRhs2116Trigger.cs
@@ -257,7 +257,7 @@ namespace OpenEphys.Onix1
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
 
-            return source.ConfigureDevice((context, observer) =>
+            return source.ConfigureAndLatchDevice((context, observer) =>
             {
                 var rhs2116AAddress = HeadstageRhs2116.GetRhs2116ADeviceAddress(GenericHelper.GetHubAddressFromDeviceAddress(deviceAddress));
                 var rhs2116A = context.GetDeviceContext(rhs2116AAddress, typeof(Rhs2116));

--- a/OpenEphys.Onix1/ConfigureTS4231V1.cs
+++ b/OpenEphys.Onix1/ConfigureTS4231V1.cs
@@ -60,7 +60,7 @@ namespace OpenEphys.Onix1
         {
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(TS4231V1.ENABLE, Enable ? 1u : 0);

--- a/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
+++ b/OpenEphys.Onix1/ConfigureUclaMiniscopeV4Camera.cs
@@ -150,7 +150,7 @@ namespace OpenEphys.Onix1
             var frameRate = FrameRate;
             var interleaveLed = InterleaveLed;
 
-            return source.ConfigureDevice(context =>
+            return source.ConfigureAndLatchDevice(context =>
             {
                 try
                 {

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -21,12 +21,10 @@ namespace OpenEphys.Onix1
     /// this role for this library. Additionally, once data acquisition is started by the <see
     /// cref="StartAcquisition"/> operator, <see cref="ContextTask"/> performs the following:
     /// <list type="bullet">
-    /// <item><description>It automatically reads and distributes data from hardware using a dedicated acquisition
+    /// <item><description>Configures hardware settings and performs device configuration.</description></item>
+    /// <item><description>Reads and distributes data from devices that produce them using a dedicated acquisition
     /// thread.</description></item>
-    /// <item><description>It allows data to be written to devices that accept them.</description></item>
-    /// <item><description>It allows reading from and writing to device registers to control their operation (e.g. <see
-    /// cref="ConfigureBno055.Enable"/> or <see
-    /// cref="ConfigureRhd2164.AnalogHighCutoff"/>).</description></item>
+    /// <item><description>Allows data to be written to devices that accept them.</description></item>
     /// </list>
     /// Additionally, this operator exposes important information about the underlying ONI hardware such as
     /// the device table, clock rates, and block read and write sizes. <strong>In summary, <see
@@ -59,10 +57,10 @@ namespace OpenEphys.Onix1
         Task distributeFrames;
         Task acquisition = Task.CompletedTask;
         CancellationTokenSource collectFramesCancellation;
-        event Func<ContextTask, IDisposable> ConfigureHostEvent;
-        event Func<ContextTask, IDisposable> ConfigureLinkEvent;
-        event Func<ContextTask, IDisposable> ConfigureDeviceEvent;
-        event Func<ContextTask, IDisposable> ConfigureDeviceWithoutResetEvent;
+        event Func<ContextTask, IDisposable> ConfigureAndLatchControllerEvent;
+        event Func<ContextTask, IDisposable> ConfigureAndLatchLinkEvent;
+        event Func<ContextTask, IDisposable> ConfigureAndLatchDeviceEvent;
+        event Func<ContextTask, IDisposable> ConfigureDirectDeviceEvent;
 
         // FrameReceived observable sequence
         readonly Subject<oni.Frame> frameReceived = new();
@@ -212,87 +210,107 @@ namespace OpenEphys.Onix1
             }
         }
 
-        // NB: This is where actions that reconfigure the hub state, or otherwise
-        // change the device table should be executed
-        internal void ConfigureHost(Func<ContextTask, IDisposable> configure)
+        // NB: This is where actions that reconfigure the hub state, or otherwise change the device table
+        // should be queued.
+        internal void ConfigureAndLatchController(Func<ContextTask, IDisposable> configure)
         {
             lock (regLock)
             {
                 AssertConfigurationContext();
-                ConfigureHostEvent += configure;
+                ConfigureAndLatchControllerEvent += configure;
             }
         }
 
-        // NB: This is where actions that calibrate port voltage or otherwise
-        // check link lock state should be executed
-        internal void ConfigureLink(Func<ContextTask, IDisposable> configure)
+        // NB: This is where actions that calibrate port voltage or otherwise check link lock state should be
+        // queued. A hardware reset will be issued after these actions run, so they should not assume that
+        // the device table is finalized or that register state will be preserved.
+        internal void ConfigureAndLatchLink(Func<ContextTask, IDisposable> configure)
         {
             lock (regLock)
             {
                 AssertConfigurationContext();
-                ConfigureLinkEvent += configure;
+                ConfigureAndLatchLinkEvent += configure;
             }
         }
 
-        // NB: Actions queued using this method should assume that the device table
-        // is finalized and cannot be changed
-        internal void ConfigureDevice(Func<ContextTask, IDisposable> configure)
+        // NB: This is where actions that configure device registers that either require a reset to take
+        // effect or can survive a reset should be queued. Actions queued using this method should assume that
+        // the device table is finalized and cannot be changed. A hardware reset will be issued after these
+        // actions run, so registers that revert to a default value on reset will be not be preserved.
+        internal void ConfigureAndLatchDevice(Func<ContextTask, IDisposable> configure)
         {
             lock (regLock)
             {
                 AssertConfigurationContext();
-                ConfigureDeviceEvent += configure;
+                ConfigureAndLatchDeviceEvent += configure;
             }
         }
 
-        // NB: Actions queued using this method should assume that the device table
-        // is finalized and cannot be changed and that there will not be a reset issued
-        // after the actions complete
-        internal void ConfigureDeviceWithoutReset(Func<ContextTask, IDisposable> configure)
+        // NB: This is where actions that configure device registers that would be defaulted by a reset should
+        // be queued. Actions queued using this method should assume that the device table is finalized and
+        // cannot be changed. A hardware reset will be _not_ be issued after these actions run.
+        internal void ConfigureDirectDevice(Func<ContextTask, IDisposable> configure)
         {
             lock (regLock)
             {
                 AssertConfigurationContext();
-                ConfigureDeviceWithoutResetEvent += configure;
+                ConfigureDirectDeviceEvent += configure;
             }
         }
 
         private IDisposable ConfigureContext()
         {
-            var hostAction = Interlocked.Exchange(ref ConfigureHostEvent, null);
-            var linkAction = Interlocked.Exchange(ref ConfigureLinkEvent, null);
-            var deviceAction = Interlocked.Exchange(ref ConfigureDeviceEvent, null);
-            var deviceNoResetAction = Interlocked.Exchange(ref ConfigureDeviceWithoutResetEvent, null);
+            var controllerConfigureAndLatchAction = Interlocked.Exchange(ref ConfigureAndLatchControllerEvent, null);
+            var linkConfigureAndLatchAction = Interlocked.Exchange(ref ConfigureAndLatchLinkEvent, null);
+            var deviceConfigureAndLatchAction = Interlocked.Exchange(ref ConfigureAndLatchDeviceEvent, null);
+            var deviceConfigureDirectAction = Interlocked.Exchange(ref ConfigureDirectDeviceEvent, null);
             var disposable = new StackDisposable();
-            ConfigureResources(disposable, hostAction);
-            ConfigureResources(disposable, linkAction);
-            ConfigureResources(disposable, deviceAction);
-            ConfigureResources(disposable, deviceNoResetAction, false);
+            ConfigureAndLatch(disposable, controllerConfigureAndLatchAction);
+            ConfigureAndLatch(disposable, linkConfigureAndLatchAction);
+            ConfigureAndLatch(disposable, deviceConfigureAndLatchAction);
+            ConfigureDirect(disposable, deviceConfigureDirectAction); // NB: This should be called after all latching actions
             return disposable;
         }
 
-        void ConfigureResources(StackDisposable disposable, Func<ContextTask, IDisposable> action, bool issueReset=true)
+        void ConfigureAndLatch(StackDisposable disposable, Func<ContextTask, IDisposable> action)
         {
-            if (action != null)
+            if (action is null) return;
+
+            try
             {
-                var invocationList = action.GetInvocationList();
-                try
+                foreach (var selector in action.GetInvocationList().Cast<Func<ContextTask, IDisposable>>())
                 {
-                    foreach (var selector in invocationList.Cast<Func<ContextTask, IDisposable>>())
-                    {
-                        disposable.Push(selector(this));
-                    }
+                    // NB: perform configuration action and push resulting IDisposable onto stack
+                    disposable.Push(selector(this));
                 }
-                catch
+            }
+            catch
+            {
+                disposable.Dispose();
+                throw;
+            }
+            finally
+            {
+                 Reset();
+            }
+        }
+
+        void ConfigureDirect(StackDisposable disposable, Func<ContextTask, IDisposable> action)
+        {
+            if (action is null) return;
+
+            try
+            {
+                foreach (var selector in action.GetInvocationList().Cast<Func<ContextTask, IDisposable>>())
                 {
-                    disposable.Dispose();
-                    throw;
+                    // NB: perform configuration action and push resulting IDisposable onto stack
+                    disposable.Push(selector(this));
                 }
-                finally 
-                { 
-                    if (issueReset)
-                        Reset(); 
-                }
+            }
+            catch
+            {
+                disposable.Dispose();
+                throw;
             }
         }
 

--- a/OpenEphys.Onix1/ObservableExtensions.cs
+++ b/OpenEphys.Onix1/ObservableExtensions.cs
@@ -7,37 +7,37 @@ namespace OpenEphys.Onix1
 {
     internal static class ObservableExtensions
     {
-        public static IObservable<ContextTask> ConfigureHost(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
+        public static IObservable<ContextTask> ConfigureAndLatchController(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
         {
-            return source.ConfigureContext((context, action) => context.ConfigureHost(action), configure);
+            return source.ConfigureContext((context, action) => context.ConfigureAndLatchController(action), configure);
         }
 
-        public static IObservable<ContextTask> ConfigureLink(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
+        public static IObservable<ContextTask> ConfigureAndLatchLink(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
         {
-            return source.ConfigureContext((context, action) => context.ConfigureLink(action), configure);
+            return source.ConfigureContext((context, action) => context.ConfigureAndLatchLink(action), configure);
         }
 
-        public static IObservable<ContextTask> ConfigureDevice(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
+        public static IObservable<ContextTask> ConfigureAndLatchDevice(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
         {
-            return source.ConfigureContext((context, action) => context.ConfigureDevice(action), configure);
+            return source.ConfigureContext((context, action) => context.ConfigureAndLatchDevice(action), configure);
         }
 
-        public static IObservable<ContextTask> ConfigureDevice(this IObservable<ContextTask> source, Func<ContextTask, IObserver<ContextTask>, IDisposable> configure)
+        public static IObservable<ContextTask> ConfigureAndLatchDevice(this IObservable<ContextTask> source, Func<ContextTask, IObserver<ContextTask>, IDisposable> configure)
         {
             return Observable.Create<ContextTask>(observer => source
-                .ConfigureDevice(context => configure(context, observer))
+                .ConfigureAndLatchDevice(context => configure(context, observer))
                 .SubscribeSafe(observer));
         }
 
-        public static IObservable<ContextTask> ConfigureDeviceWithoutReset(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
+        public static IObservable<ContextTask> ConfigureDirectDevice(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
         {
-            return source.ConfigureContext((context, action) => context.ConfigureDeviceWithoutReset(action), configure);
+            return source.ConfigureContext((context, action) => context.ConfigureDirectDevice(action), configure);
         }
 
-        public static IObservable<ContextTask> ConfigureDeviceWithoutReset(this IObservable<ContextTask> source, Func<ContextTask, IObserver<ContextTask>, IDisposable> configure)
+        public static IObservable<ContextTask> ConfigureDirectDevice(this IObservable<ContextTask> source, Func<ContextTask, IObserver<ContextTask>, IDisposable> configure)
         {
             return Observable.Create<ContextTask>(observer => source
-                .ConfigureDeviceWithoutReset(context => configure(context, observer))
+                .ConfigureDirectDevice(context => configure(context, observer))
                 .SubscribeSafe(observer));
         }
 


### PR DESCRIPTION
- Device configuration operators now have access to a ConfigureDeviceWithoutReset operator that they can use to apply configuration actions that would be undone by a hardware reset
- This is used by ConfigureHeadstage64ElectricalStimulator and ConfigureHeadstage64Optical stimulator to prevent their Arm parameters from being defaulted following reset.
- Fixes #577 