### PR TITLE
Add category to BurstCurrent property

### DIFF
--- a/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
@@ -227,6 +227,7 @@ namespace OpenEphys.Onix1
         /// This value should be kept below 50 mA to prevent excess head accumulation on the headstage.
         /// </remarks>
         [Description("The total direct current required during the application of a burst (mA). Should be less than 50 mA.")]
+        [Category(AcquisitionCategory)]
         public double BurstCurrent
         {
             get


### PR DESCRIPTION
The BurstCurrent property is visible in the editor, and is currently listed under the `Misc` category because none is given. Since the property can be updated during acquisition, as it is a function of other properties that are `Acquisition` properties, it should have the acquisition category attribute added.