### PR TITLE
Remove Probe property from NeuropixelsV2 probe configurations

### DIFF
--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -57,8 +57,8 @@ namespace OpenEphys.Onix1.Design
 
             ProbeConfigurations = new()
             {
-                { NeuropixelsV2Probe.ProbeA, new(configureNode.ProbeConfigurationA, isBeta) },
-                { NeuropixelsV2Probe.ProbeB, new(configureNode.ProbeConfigurationB, isBeta) }
+                { NeuropixelsV2Probe.ProbeA, new(configureNode.ProbeConfigurationA, isBeta, nameof(NeuropixelsV2Probe.ProbeA)) },
+                { NeuropixelsV2Probe.ProbeB, new(configureNode.ProbeConfigurationB, isBeta, nameof(NeuropixelsV2Probe.ProbeB)) }
             };
 
             foreach (var channelConfiguration in ProbeConfigurations)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -49,7 +49,8 @@ namespace OpenEphys.Onix1.Design
         /// </summary>
         /// <param name="configuration">A <see cref="NeuropixelsV2ProbeConfiguration"/> object holding the current configuration settings.</param>
         /// <param name="isBeta">Boolean denoting if this probe is a beta probe or not.</param>
-        public NeuropixelsV2eProbeConfigurationDialog(NeuropixelsV2ProbeConfiguration configuration, bool isBeta)
+        /// <param name="probeName">The name of the probe.</param>
+        public NeuropixelsV2eProbeConfigurationDialog(NeuropixelsV2ProbeConfiguration configuration, bool isBeta, string probeName)
         {
             InitializeComponent();
             Shown += FormShown;
@@ -59,12 +60,12 @@ namespace OpenEphys.Onix1.Design
 
             probeConfigurations = new()
             {
-                [ProbeType.SingleShank] = new NeuropixelsV2SingleShankProbeConfiguration(configuration.Probe,
+                [ProbeType.SingleShank] = new NeuropixelsV2SingleShankProbeConfiguration(
                         NeuropixelsV2SingleShankReference.External,
                         configuration.InvertPolarity,
                         configuration.GainCalibrationFileName,
                         configuration.ProbeInterfaceFileName),
-                [ProbeType.QuadShank] = new NeuropixelsV2QuadShankProbeConfiguration(configuration.Probe,
+                [ProbeType.QuadShank] = new NeuropixelsV2QuadShankProbeConfiguration(
                         NeuropixelsV2QuadShankReference.External,
                         configuration.InvertPolarity,
                         configuration.GainCalibrationFileName,
@@ -103,7 +104,7 @@ namespace OpenEphys.Onix1.Design
 
             CheckStatus();
 
-            Text += ": " + ProbeConfiguration.Probe.ToString();
+            Text += ": " + probeName;
         }
 
         ProbeType GetCurrentProbeType(NeuropixelsV2ProbeConfiguration configuration)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationEditor.cs
@@ -32,8 +32,9 @@ namespace OpenEphys.Onix1.Design
                     var instance = (IConfigureNeuropixelsV2)context.Instance;
 
                     bool isBeta = instance is ConfigureNeuropixelsV2eBeta;
+                    string probeName = configuration == instance.ProbeConfigurationA ? nameof(NeuropixelsV2Probe.ProbeA) : nameof(NeuropixelsV2Probe.ProbeB);
 
-                    using var editorDialog = new NeuropixelsV2eProbeConfigurationDialog(configuration, isBeta);
+                    using var editorDialog = new NeuropixelsV2eProbeConfigurationDialog(configuration, isBeta, probeName);
 
                     if (isBeta)
                     {

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -80,7 +80,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         [XmlElement(nameof(ProbeConfigurationA), typeof(NeuropixelsV2QuadShankProbeConfiguration))] // NB: Needed for backward compatibility
         [TypeConverter(typeof(GenericPropertyConverter))]
-        public NeuropixelsV2ProbeConfiguration ProbeConfigurationA { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2Probe.ProbeA, NeuropixelsV2QuadShankReference.External);
+        public NeuropixelsV2ProbeConfiguration ProbeConfigurationA { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2QuadShankReference.External);
 
         /// <summary>
         /// Prevent the <see cref="ProbeConfigurationA"/> property from being serialized.
@@ -133,7 +133,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         [XmlElement(nameof(ProbeConfigurationB), typeof(NeuropixelsV2QuadShankProbeConfiguration))] // NB: Needed for backward compatibility
         [TypeConverter(typeof(GenericPropertyConverter))]
-        public NeuropixelsV2ProbeConfiguration ProbeConfigurationB { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2Probe.ProbeB, NeuropixelsV2QuadShankReference.External);
+        public NeuropixelsV2ProbeConfiguration ProbeConfigurationB { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2QuadShankReference.External);
 
         /// <summary>
         /// Prevent the <see cref="ProbeConfigurationB"/> property from being serialized.

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -95,7 +95,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         [XmlElement(nameof(ProbeConfigurationA), typeof(NeuropixelsV2QuadShankProbeConfiguration))] // NB: Needed for backward compatibility
         [TypeConverter(typeof(GenericPropertyConverter))]
-        public NeuropixelsV2ProbeConfiguration ProbeConfigurationA { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2Probe.ProbeA, NeuropixelsV2QuadShankReference.External);
+        public NeuropixelsV2ProbeConfiguration ProbeConfigurationA { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2QuadShankReference.External);
 
         /// <summary>
         /// Prevent the <see cref="ProbeConfigurationA"/> property from being serialized.
@@ -148,7 +148,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         [XmlElement(nameof(ProbeConfigurationB), typeof(NeuropixelsV2QuadShankProbeConfiguration))] // NB: Needed for backward compatibility
         [TypeConverter(typeof(GenericPropertyConverter))]
-        public NeuropixelsV2ProbeConfiguration ProbeConfigurationB { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2Probe.ProbeB, NeuropixelsV2QuadShankReference.External);
+        public NeuropixelsV2ProbeConfiguration ProbeConfigurationB { get; set; } = new NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2QuadShankReference.External);
 
         /// <summary>
         /// Prevent the <see cref="ProbeConfigurationB"/> property from being serialized.

--- a/OpenEphys.Onix1/NeuropixelsV2ProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2ProbeConfiguration.cs
@@ -48,12 +48,6 @@ namespace OpenEphys.Onix1
     public abstract class NeuropixelsV2ProbeConfiguration
     {
         /// <summary>
-        /// Gets or sets the <see cref="NeuropixelsV2Probe"/> for this probe.
-        /// </summary>
-        [Browsable(false)]
-        public NeuropixelsV2Probe Probe { get; set; }
-
-        /// <summary>
         /// Gets or sets a value determining if the polarity of the electrode voltages acquired by the probe
         /// should be inverted.
         /// </summary>

--- a/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
@@ -59,11 +59,9 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Initializes a new instance of the <see cref="NeuropixelsV2QuadShankProbeConfiguration"/> class.
         /// </summary>
-        /// <param name="probe">The <see cref="NeuropixelsV2Probe"/> for this probe.</param>
         /// <param name="reference">The <see cref="NeuropixelsV2QuadShankReference"/> reference value.</param>
-        public NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2Probe probe, NeuropixelsV2QuadShankReference reference)
+        public NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2QuadShankReference reference)
         {
-            Probe = probe;
             Reference = reference;
             ProbeGroup = new NeuropixelsV2eQuadShankProbeGroup();
         }
@@ -76,7 +74,6 @@ namespace OpenEphys.Onix1
         {
             Reference = probeConfiguration.Reference;
             ProbeGroup = probeConfiguration.ProbeGroup.Clone();
-            Probe = probeConfiguration.Probe;
             InvertPolarity = probeConfiguration.InvertPolarity;
             GainCalibrationFileName = probeConfiguration.GainCalibrationFileName;
             probeInterfaceFileName = probeConfiguration.probeInterfaceFileName;
@@ -86,19 +83,16 @@ namespace OpenEphys.Onix1
         /// Initializes a new instance of the <see cref="NeuropixelsV2QuadShankProbeConfiguration"/> class with the given
         /// values.
         /// </summary>
-        /// <param name="probe">The <see cref="NeuropixelsV2Probe"/> for this probe.</param>
         /// <param name="reference">The <see cref="NeuropixelsV2QuadShankReference"/> reference value.</param>
         /// <param name="invertPolarity">Boolean defining if the signal polarity should be inverted.</param>
         /// <param name="gainCalibrationFileName">String defining the path to the gain calibration file.</param>
         /// <param name="probeInterfaceFileName">String defining the path to the ProbeInterface file.</param>
         public NeuropixelsV2QuadShankProbeConfiguration(
-            NeuropixelsV2Probe probe,
             NeuropixelsV2QuadShankReference reference,
             bool invertPolarity,
             string gainCalibrationFileName,
             string probeInterfaceFileName)
         {
-            Probe = probe;
             Reference = reference;
             InvertPolarity = invertPolarity;
             GainCalibrationFileName = gainCalibrationFileName;
@@ -110,7 +104,6 @@ namespace OpenEphys.Onix1
         /// <see cref="NeuropixelsV2eQuadShankProbeGroup"/> channel configuration. 
         /// </summary>
         /// <param name="probeGroup">The existing <see cref="NeuropixelsV2eQuadShankProbeGroup"/> instance to use.</param>
-        /// <param name="probe">The <see cref="NeuropixelsV2Probe"/> for this probe.</param>
         /// <param name="reference">The <see cref="NeuropixelsV2QuadShankReference"/> reference value.</param>
         /// <param name="invertPolarity">Boolean defining if the signal polarity should be inverted.</param>
         /// <param name="gainCalibrationFileName">String defining the path to the gain calibration file.</param>
@@ -118,7 +111,6 @@ namespace OpenEphys.Onix1
         [JsonConstructor]
         public NeuropixelsV2QuadShankProbeConfiguration(
             NeuropixelsV2eQuadShankProbeGroup probeGroup,
-            NeuropixelsV2Probe probe,
             NeuropixelsV2QuadShankReference reference,
             bool invertPolarity,
             string gainCalibrationFileName,
@@ -126,7 +118,6 @@ namespace OpenEphys.Onix1
         {
             ProbeGroup = probeGroup.Clone();
             Reference = reference;
-            Probe = probe;
             InvertPolarity = invertPolarity;
             GainCalibrationFileName = gainCalibrationFileName;
             ProbeInterfaceFileName = probeInterfaceFileName;

--- a/OpenEphys.Onix1/NeuropixelsV2SingleShankProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2SingleShankProbeConfiguration.cs
@@ -47,9 +47,8 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Initializes a new instance of the <see cref="NeuropixelsV2SingleShankProbeConfiguration"/> class.
         /// </summary>
-        public NeuropixelsV2SingleShankProbeConfiguration(NeuropixelsV2Probe probe, NeuropixelsV2SingleShankReference reference)
+        public NeuropixelsV2SingleShankProbeConfiguration(NeuropixelsV2SingleShankReference reference)
         {
-            Probe = probe;
             Reference = reference;
             ProbeGroup = new NeuropixelsV2eSingleShankProbeGroup();
         }
@@ -62,7 +61,6 @@ namespace OpenEphys.Onix1
         {
             Reference = probeConfiguration.Reference;
             ProbeGroup = probeConfiguration.ProbeGroup.Clone();
-            Probe = probeConfiguration.Probe;
             InvertPolarity = probeConfiguration.InvertPolarity;
             GainCalibrationFileName = probeConfiguration.GainCalibrationFileName;
             probeInterfaceFileName = probeConfiguration.probeInterfaceFileName;
@@ -73,17 +71,15 @@ namespace OpenEphys.Onix1
         /// values. 
         /// </summary>
         /// <param name="reference">The <see cref="NeuropixelsV2SingleShankReference"/> reference value.</param>
-        /// <param name="probe">The <see cref="NeuropixelsV2Probe"/> for this probe.</param>
         /// <param name="invertPolarity">Boolean defining if the signal polarity should be inverted.</param>
         /// <param name="gainCalibrationFileName">String defining the path to the gain calibration file.</param>
         /// <param name="probeInterfaceFileName">String defining the path to the ProbeInterface file.</param>
-        public NeuropixelsV2SingleShankProbeConfiguration(NeuropixelsV2Probe probe,
+        public NeuropixelsV2SingleShankProbeConfiguration(
             NeuropixelsV2SingleShankReference reference,
             bool invertPolarity,
             string gainCalibrationFileName,
             string probeInterfaceFileName)
         {
-            Probe = probe;
             Reference = reference;
             InvertPolarity = invertPolarity;
             GainCalibrationFileName = gainCalibrationFileName;
@@ -96,13 +92,11 @@ namespace OpenEphys.Onix1
         /// </summary>
         /// <param name="probeGroup">The existing <see cref="NeuropixelsV2eSingleShankProbeGroup"/> instance to use.</param>
         /// <param name="reference">The <see cref="NeuropixelsV2SingleShankReference"/> reference value.</param>
-        /// <param name="probe">The <see cref="NeuropixelsV2Probe"/> for this probe.</param>
         /// <param name="invertPolarity">Boolean defining if the signal polarity should be inverted.</param>
         /// <param name="gainCalibrationFileName">String defining the path to the gain calibration file.</param>
         /// <param name="probeInterfaceFileName">String defining the path to the ProbeInterface file.</param>
         [JsonConstructor]
         public NeuropixelsV2SingleShankProbeConfiguration(NeuropixelsV2eSingleShankProbeGroup probeGroup,
-            NeuropixelsV2Probe probe,
             NeuropixelsV2SingleShankReference reference,
             bool invertPolarity,
             string gainCalibrationFileName,
@@ -110,7 +104,6 @@ namespace OpenEphys.Onix1
         {
             ProbeGroup = probeGroup.Clone();
             Reference = reference;
-            Probe = probe;
             InvertPolarity = invertPolarity;
             GainCalibrationFileName = gainCalibrationFileName;
             ProbeInterfaceFileName = probeInterfaceFileName;


### PR DESCRIPTION
The `Probe` property in `NeuropixelsV2ProbeConfiguration` is meaningless in the context of the probe configuration, and should not have been added. It has now been removed, and the design library now checks which device property is being called to determine the probe name.