### PR TITLE
Add check for gain calibration file for NeuropixelsV2e

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Drawing.Design;
+using System.IO;
 using System.Reactive.Disposables;
 using System.Xml.Serialization;
 using Bonsai;
@@ -228,6 +229,11 @@ namespace OpenEphys.Onix1
                 // configure probe A streaming
                 if (probeAMetadata.ProbeSerialNumber != null)
                 {
+                    if (!File.Exists(probeConfigurationA.GainCalibrationFileName))
+                    {
+                        throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeA} with serial number {probeAMetadata.ProbeSerialNumber}");
+                    }
+
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationA.GainCalibrationFileName);
 
                     if (!gainCorrection.HasValue)
@@ -251,6 +257,11 @@ namespace OpenEphys.Onix1
                 // configure probe B streaming
                 if (probeBMetadata.ProbeSerialNumber != null)
                 {
+                    if (!File.Exists(probeConfigurationB.GainCalibrationFileName))
+                    {
+                        throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeB} with serial number {probeBMetadata.ProbeSerialNumber}");
+                    }
+
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationB.GainCalibrationFileName);
 
                     if (!gainCorrection.HasValue)

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Drawing.Design;
+using System.IO;
 using System.Reactive.Disposables;
 using System.Xml.Serialization;
 using Bonsai;
@@ -255,6 +256,11 @@ namespace OpenEphys.Onix1
                             $" for {NeuropixelsV2Probe.ProbeA}.");
                     }
 
+                    if (!File.Exists(probeConfigurationA.GainCalibrationFileName))
+                    {
+                        throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeA} with serial number {probeAMetadata.ProbeSerialNumber}");
+                    }
+
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationA.GainCalibrationFileName);
 
                     if (!gainCorrection.HasValue)
@@ -282,6 +288,11 @@ namespace OpenEphys.Onix1
                     {
                         throw new InvalidOperationException($"Neuropixels 2.0-Beta probes do not provide a Ground reference selection. Please select a different reference" +
                             $" for {NeuropixelsV2Probe.ProbeB}.");
+                    }
+
+                    if (!File.Exists(probeConfigurationB.GainCalibrationFileName))
+                    {
+                        throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeB} with serial number {probeBMetadata.ProbeSerialNumber}");
                     }
 
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationB.GainCalibrationFileName);


### PR DESCRIPTION
This PR adds a check for the existence of the gain calibration file during run-time, and also provides a pop-up with the serial number of the probe connected if no gain calibration exists.

Fixes #587 