### PR TITLE
Add minimum version to NeuropixelsV1f

### DIFF
--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageEditor.cs
@@ -6,7 +6,7 @@ using System;
 namespace OpenEphys.Onix1.Design
 {
     /// <summary>
-    /// Class that opens a new dialog for a <see cref="ConfigureHeadstageNeuropixelsV1e"/>.
+    /// Class that opens a new dialog for a <see cref="ConfigureHeadstageNeuropixelsV1f"/>.
     /// </summary>
     public class NeuropixelsV1fHeadstageEditor : WorkflowComponentEditor
     {

--- a/OpenEphys.Onix1/ConfigureBno055.cs
+++ b/OpenEphys.Onix1/ConfigureBno055.cs
@@ -69,7 +69,7 @@ namespace OpenEphys.Onix1
     static class Bno055
     {
         public const int ID = 9;
-        public const uint MinimumVersion = 2;
+        public const uint MinimumVersion = 1;
 
         // constants
         public const float EulerAngleScale = 1f / 16; // 1 degree = 16 LSB

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
@@ -182,6 +182,7 @@ namespace OpenEphys.Onix1
     static class NeuropixelsV1f
     {
         public const int ID = 11;
+        public const uint MinimumVersion = 1;
 
         public const int I2cAddress = 0x70;
         public const int EepromI2cAddress = 0x55;

--- a/OpenEphys.Onix1/ConfigureTS4231V1.cs
+++ b/OpenEphys.Onix1/ConfigureTS4231V1.cs
@@ -72,7 +72,7 @@ namespace OpenEphys.Onix1
     static class TS4231V1
     {
         public const int ID = 25;
-        public const uint MinimumVersion = 2;
+        public const uint MinimumVersion = 1;
 
         // managed registers
         public const uint ENABLE = 0x0; // Enable or disable the data output stream


### PR DESCRIPTION
During testing, we discovered a potential issue after PR #512 was merged; the `NeuropixelsV1f` device did not have a minimum version, leading to an error when acquisition is started:

<img width="401" height="154" alt="image" src="https://github.com/user-attachments/assets/c6d3cbbf-a5a1-4523-95c2-e8f4ad73f5bc" />

This PR adds in the minimum version to the static class, but then we get a secondary error:

<img width="1851" height="1001" alt="image" src="https://github.com/user-attachments/assets/30d51825-591c-4ce2-907b-e932977c7ba1" />

It appears that the BNO on this device is outdated. If this is only an issue of the BNO on this particular device, then we can review and merge this PR; however, if all V1f headstages all contain the older version of the BNO, v0.7.0 would mean that all V1f devices would no longer be able to record data.