### PR TITLE
Hide channel configuration menu strip in Rhs2116 dialog

### DIFF
--- a/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116StimulusSequenceDialog.cs
@@ -166,6 +166,7 @@ namespace OpenEphys.Onix1.Design
             fileToolStripMenuItem.DropDownItems.Add(new ToolStripSeparator());
             ChannelDialog.dropDownImportFile.Text = "Import Probe Configuration";
             fileToolStripMenuItem.DropDownItems.Add(ChannelDialog.dropDownImportFile);
+            ChannelDialog.HideFileMenu();
 
             StimulusSequenceOptions.Show();
 


### PR DESCRIPTION
Discovered during documentation that the menu strip was no longer hidden in the channel configuration dialog for `Rhs2116`. This PR now hides that strip, as it does not belong in this specific context.