### PR TITLE
Do not require a ProbeInterface file if NeuropixelsV1f device is disabled

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
@@ -148,16 +148,18 @@ namespace OpenEphys.Onix1
 
             return source.ConfigureAndLatchDevice(context =>
             {
-                if (string.IsNullOrEmpty(probeConfiguration.ProbeInterfaceFileName))
-                    throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV1f)}.{nameof(ProbeConfiguration)}.");
-
-                var probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                NeuropixelsV1eProbeGroup probeGroup = null;
 
                 var device = context.GetDeviceContext(deviceAddress, typeof(NeuropixelsV1f));
                 device.WriteRegister(NeuropixelsV1f.ENABLE, enable ? 1u : 0);
 
                 if (enable)
                 {
+                    if (string.IsNullOrEmpty(probeConfiguration.ProbeInterfaceFileName))
+                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV1f)}.{nameof(ProbeConfiguration)}.");
+
+                    probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+
                     var probeControl = new NeuropixelsV1fRegisterContext(device, probeConfiguration, probeGroup);
                     probeControl.InitializeProbe();
                     probeControl.WriteShiftRegisters();

--- a/OpenEphys.Onix1/NeuropixelsV1fData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1fData.cs
@@ -70,6 +70,10 @@ namespace OpenEphys.Onix1
                 {
                     var sampleIndex = 0;
                     var info = (NeuropixelsV1fDeviceInfo)deviceInfo;
+                    if (info.ProbeGroup == null)
+                    {
+                        throw new NullReferenceException($"No ProbeGroup found for {nameof(NeuropixelsV1f)}.");
+                    }
                     var device = info.GetDeviceContext(typeof(NeuropixelsV1f));
                     var spikeBuffer = new ushort[NeuropixelsV1.ChannelCount, spikeBufferSize];
                     var lfpBuffer = new ushort[NeuropixelsV1.ChannelCount, lfpBufferSize];

--- a/OpenEphys.Onix1/NeuropixelsV1fRegisterContext.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1fRegisterContext.cs
@@ -55,7 +55,6 @@ namespace OpenEphys.Onix1
             var gainCorrection = NeuropixelsV1Helper.TryParseGainCalibrationFile(configuration.GainCalibrationFileName,
                 configuration.SpikeAmplifierGain, configuration.LfpAmplifierGain, NeuropixelsV1.ElectrodeCount);
 
-
             if (!gainCorrection.HasValue)
             {
                 throw new ArgumentException($"The calibration file \"{configuration.GainCalibrationFileName}\" is invalid.");


### PR DESCRIPTION
This PR standardizes how `NeuropixelsV1f` devices operate. It is now in line with how the `NeuropixelsV2e` devices work, where the ProbeInterface file is only required if the device is enabled.

Fixes #607 