### PR TITLE
Fixes for Neuropixels GUIs

### DIFF
--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
@@ -30,7 +30,10 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ChannelConfigurationDialog));
+            this.panel = new System.Windows.Forms.Panel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.zedGraphChannels = new ZedGraph.ZedGraphControl();
+            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
             this.buttonResetZoom = new System.Windows.Forms.Button();
             this.menuStrip = new System.Windows.Forms.MenuStrip();
             this.fileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -41,12 +44,38 @@
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.dropDownImportFile = new System.Windows.Forms.ToolStripMenuItem();
             this.dropDownLoadDefault = new System.Windows.Forms.ToolStripMenuItem();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
-            this.menuStrip.SuspendLayout();
+            this.panel.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
+            this.menuStrip.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // panel
+            // 
+            this.panel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panel.Controls.Add(this.tableLayoutPanel1);
+            this.panel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel.Location = new System.Drawing.Point(0, 27);
+            this.panel.Name = "panel";
+            this.panel.Padding = new System.Windows.Forms.Padding(1);
+            this.panel.Size = new System.Drawing.Size(609, 547);
+            this.panel.TabIndex = 7;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.zedGraphChannels, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel2, 0, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(2, 2);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(603, 541);
+            this.tableLayoutPanel1.TabIndex = 6;
             // 
             // zedGraphChannels
             // 
@@ -62,11 +91,20 @@
             this.zedGraphChannels.ScrollMinX = 0D;
             this.zedGraphChannels.ScrollMinY = 0D;
             this.zedGraphChannels.ScrollMinY2 = 0D;
-            this.zedGraphChannels.Size = new System.Drawing.Size(599, 496);
+            this.zedGraphChannels.Size = new System.Drawing.Size(593, 487);
             this.zedGraphChannels.TabIndex = 4;
             this.zedGraphChannels.TabStop = false;
             this.zedGraphChannels.UseExtendedPrintDialog = true;
             this.zedGraphChannels.ZoomEvent += new ZedGraph.ZedGraphControl.ZoomEventHandler(this.ZoomEvent);
+            // 
+            // flowLayoutPanel2
+            // 
+            this.flowLayoutPanel2.Controls.Add(this.buttonResetZoom);
+            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 502);
+            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(597, 36);
+            this.flowLayoutPanel2.TabIndex = 5;
             // 
             // buttonResetZoom
             // 
@@ -83,6 +121,7 @@
             // 
             // menuStrip
             // 
+            this.menuStrip.AutoSize = false;
             this.menuStrip.BackColor = System.Drawing.SystemColors.Control;
             this.menuStrip.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -91,7 +130,7 @@
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
             this.menuStrip.ShowItemToolTips = true;
-            this.menuStrip.Size = new System.Drawing.Size(609, 24);
+            this.menuStrip.Size = new System.Drawing.Size(609, 27);
             this.menuStrip.TabIndex = 5;
             // 
             // fileMenuItem
@@ -105,7 +144,7 @@
             this.dropDownImportFile,
             this.dropDownLoadDefault});
             this.fileMenuItem.Name = "fileMenuItem";
-            this.fileMenuItem.Size = new System.Drawing.Size(37, 22);
+            this.fileMenuItem.Size = new System.Drawing.Size(37, 25);
             this.fileMenuItem.Text = "File";
             // 
             // dropDownOpenFile
@@ -162,37 +201,12 @@
             this.dropDownLoadDefault.ToolTipText = "Load the default configuration without changing the file path.";
             this.dropDownLoadDefault.Click += new System.EventHandler(this.MenuItemLoadDefaultConfig);
             // 
-            // tableLayoutPanel1
-            // 
-            this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.zedGraphChannels, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel2, 0, 1);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(609, 550);
-            this.tableLayoutPanel1.TabIndex = 6;
-            // 
-            // flowLayoutPanel2
-            // 
-            this.flowLayoutPanel2.Controls.Add(this.buttonResetZoom);
-            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 511);
-            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(603, 36);
-            this.flowLayoutPanel2.TabIndex = 5;
-            // 
             // ChannelConfigurationDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(609, 574);
-            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.panel);
             this.Controls.Add(this.menuStrip);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip;
@@ -200,13 +214,13 @@
             this.Name = "ChannelConfigurationDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Channel Configuration";
-            this.menuStrip.ResumeLayout(false);
-            this.menuStrip.PerformLayout();
+            this.panel.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.flowLayoutPanel2.ResumeLayout(false);
+            this.menuStrip.ResumeLayout(false);
+            this.menuStrip.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -218,11 +232,12 @@
         private System.Windows.Forms.ToolStripMenuItem dropDownSaveFileAs;
         private System.Windows.Forms.ToolStripMenuItem dropDownLoadDefault;
         private System.Windows.Forms.Button buttonResetZoom;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
         private System.Windows.Forms.ToolStripMenuItem dropDownOpenFile;
         private System.Windows.Forms.ToolStripMenuItem dropDownSaveFile;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        internal System.Windows.Forms.Panel panel;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }
 }

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -19,7 +19,7 @@ namespace OpenEphys.Onix1.Design
     {
         private protected Type probeGroupType;
 
-        enum SaveResult
+        internal enum SaveResult
         {
             Success,
             Failure,
@@ -73,6 +73,7 @@ namespace OpenEphys.Onix1.Design
         internal bool[] SelectedContacts { get; private set; } = null;
 
         internal static string DefaultFileName = $"pi_configuration{ProbeInterfaceHelper.ProbeInterfaceFileExtension}";
+        internal static string ProbeConfigurationConfirmMessage = "There are unsaved probe configuration changes that will be discarded, do you want to exit?";
 
         [Obsolete("Designer only.", true)]
         ChannelConfigurationDialog()
@@ -1137,19 +1138,16 @@ namespace OpenEphys.Onix1.Design
 
         void MenuItemOpenFile(object sender, EventArgs e)
         {
-            if (!string.IsNullOrEmpty(ProbeConfiguration.ProbeInterfaceFileName))
+            if (HasChanges)
             {
-                if (HasChanges)
-                {
-                    var result = MessageBox.Show(
-                    $"Warning: Opening a new file will discard the {ProbeName} configuration without saving. Do you want to continue?",
-                    $"{ProbeName}: Open File",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Warning);
+                var result = MessageBox.Show(
+                $"Warning: Opening a new file will discard the {ProbeName} configuration without saving. Do you want to continue?",
+                $"{ProbeName}: Open File",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
 
-                    if (result == DialogResult.No)
-                        return;
-                }
+                if (result == DialogResult.No)
+                    return;
             }
 
             if (OpenFileFromDialog())
@@ -1198,24 +1196,30 @@ namespace OpenEphys.Onix1.Design
             SaveFileAs();
         }
 
+        internal SaveResult SaveFile(string fileName)
+        {
+            var result = string.IsNullOrEmpty(fileName)
+                ? SaveFileAs()
+                : TrySaveFile(fileName, ProbeGroup);
+
+            if (result == SaveResult.Success)
+            {
+                HasChanges = false;
+            }
+
+            return result;
+        }
+
         SaveResult SaveFile()
         {
             var fileName = ProbeConfiguration.ProbeInterfaceFileName;
 
-            if (string.IsNullOrEmpty(fileName))
-            {
-                return SaveFileAs();
-            }
-
-            return TrySaveFile(fileName, ProbeGroup);
+            return SaveFile(fileName);
         }
 
         void MenuItemSaveFile(object sender, EventArgs e)
         {
-            if (SaveFile() == SaveResult.Success)
-            {
-                HasChanges = false;
-            }
+            SaveFile();
         }
 
         void ResizeSelectedContacts()
@@ -1593,6 +1597,11 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
+            if (this.HandleTopLevelDialogCancel(ref e))
+            {
+                return;
+            }
+
             if (HasChanges)
             {
                 var result = MessageBox.Show(

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -19,6 +19,13 @@ namespace OpenEphys.Onix1.Design
     {
         private protected Type probeGroupType;
 
+        enum SaveResult
+        {
+            Success,
+            Failure,
+            Cancelled
+        };
+
         internal event EventHandler OnResizeZedGraph;
         internal event EventHandler OnDrawProbeGroup;
         internal event EventHandler OnProbeConfigurationChanged;
@@ -367,18 +374,18 @@ namespace OpenEphys.Onix1.Design
             return false;
         }
 
-        internal static bool TrySaveFile(string fileName, ProbeGroup probeGroup)
+        static SaveResult TrySaveFile(string fileName, ProbeGroup probeGroup)
         {
             // NB: Catch all exceptions and show them as a MessageBox; uncaught exceptions will close the GUI without warning
             try
             {
                 JsonHelper.SerializeObject(probeGroup, fileName);
-                return true;
+                return SaveResult.Success;
             }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, "Error Saving ProbeInterface File");
-                return false;
+                return SaveResult.Failure;
             }
         }
 
@@ -1148,7 +1155,7 @@ namespace OpenEphys.Onix1.Design
             }
         }
 
-        bool SaveFileAs()
+        SaveResult SaveFileAs()
         {
             var fileName = GetFileName();
 
@@ -1164,19 +1171,23 @@ namespace OpenEphys.Onix1.Design
             sfd.FileName = Path.GetFileName(fileName);
             sfd.InitialDirectory = directory;
 
-            if (sfd.ShowDialog() == DialogResult.OK)
+            var sfdResult = sfd.ShowDialog();
+
+            if (sfdResult == DialogResult.OK)
             {
-                if (TrySaveFile(sfd.FileName, ProbeGroup))
+                var result = TrySaveFile(sfd.FileName, ProbeGroup);
+
+                if (result == SaveResult.Success)
                 {
                     ProbeConfiguration.ProbeInterfaceFileName = sfd.FileName;
                     ProbeConfigurationChanged();
                     HasChanges = false;
-
-                    return true;
                 }
+
+                return result;
             }
 
-            return false;
+            return SaveResult.Cancelled;
         }
 
         void MenuItemSaveFileAs(object sender, EventArgs e)
@@ -1184,7 +1195,7 @@ namespace OpenEphys.Onix1.Design
             SaveFileAs();
         }
 
-        bool SaveFile()
+        SaveResult SaveFile()
         {
             var fileName = ProbeConfiguration.ProbeInterfaceFileName;
 
@@ -1198,7 +1209,7 @@ namespace OpenEphys.Onix1.Design
 
         void MenuItemSaveFile(object sender, EventArgs e)
         {
-            if (SaveFile())
+            if (SaveFile() == SaveResult.Success)
             {
                 HasChanges = false;
             }
@@ -1579,53 +1590,84 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel || !HasChanges)
+            if (DialogResult == DialogResult.Cancel)
                 return;
 
-            var customMessageBox = new CustomMessageBox(
-                $"The ProbeInterface electrode configuration for {ProbeName} has unsaved changes; would you like to save the changes before closing?",
-                CustomMessageBox.CustomMessageBoxButtons.SaveSaveAsCancel,
-                $"Save {ProbeName} Configuration?");
-
-            var result = customMessageBox.ShowDialog();
-
-            if (result == DialogResult.Cancel)
+            if (HasChanges || string.IsNullOrEmpty(ProbeConfiguration.ProbeInterfaceFileName))
             {
-                e.Cancel = true;
-                return;
-            }
+                var customMessageBox = new CustomMessageBox(
+                    $"The ProbeInterface electrode configuration for {ProbeName} has unsaved changes; would you like to save the changes before closing?",
+                    CustomMessageBox.CustomMessageBoxButtons.SaveSaveAsCancel,
+                    $"Save {ProbeName} Configuration?");
 
-            if (customMessageBox.ClickedButton == CustomMessageBox.CustomMessageBoxButton.Button1) // NB: Save
-            {
-                while (!SaveFile())
+                var result = customMessageBox.ShowDialog();
+
+                if (result == DialogResult.Cancel)
                 {
-                    result = MessageBox.Show(
-                        $"Error: Failed to save {ProbeName} file. Do you want to try saving again?",
-                        $"Error Saving {ProbeName} File",
-                        MessageBoxButtons.YesNoCancel,
-                        MessageBoxIcon.Warning);
+                    e.Cancel = true;
+                    return;
+                }
 
-                    if (result == DialogResult.Cancel || result == DialogResult.No)
+                if (customMessageBox.ClickedButton == CustomMessageBox.CustomMessageBoxButton.Button1) // NB: Save
+                {
+                    while (true)
                     {
-                        e.Cancel = true;
-                        return;
+                        var saveResult = SaveFile();
+
+                        if (saveResult == SaveResult.Failure)
+                        {
+                            result = MessageBox.Show(
+                                $"Error: Failed to save {ProbeName} file. Do you want to try saving again?",
+                                $"Error Saving {ProbeName} File",
+                                MessageBoxButtons.YesNoCancel,
+                                MessageBoxIcon.Warning);
+
+                            if (result == DialogResult.Cancel || result == DialogResult.No)
+                            {
+                                e.Cancel = true;
+                                return;
+                            }
+                        }
+                        else if (saveResult == SaveResult.Cancelled)
+                        {
+                            e.Cancel = true;
+                            return;
+                        }
+                        else
+                        {
+                            return;
+                        }
                     }
                 }
-            }
-            else if (customMessageBox.ClickedButton == CustomMessageBox.CustomMessageBoxButton.Button2) // NB: Save As
-            {
-                while (!SaveFileAs())
+                else if (customMessageBox.ClickedButton == CustomMessageBox.CustomMessageBoxButton.Button2) // NB: Save As
                 {
-                    result = MessageBox.Show(
-                        $"Error: Failed to save {ProbeName} file. Do you want to try saving again?",
-                        $"Error Saving {ProbeName} File",
-                        MessageBoxButtons.YesNoCancel,
-                        MessageBoxIcon.Warning);
-
-                    if (result == DialogResult.Cancel || result == DialogResult.No)
+                    while (true)
                     {
-                        e.Cancel = true;
-                        return;
+                        var saveResult = SaveFileAs();
+
+                        if (saveResult == SaveResult.Failure)
+                        {
+                            result = MessageBox.Show(
+                            $"Error: Failed to save {ProbeName} file. Do you want to try saving again?",
+                            $"Error Saving {ProbeName} File",
+                            MessageBoxButtons.YesNoCancel,
+                            MessageBoxIcon.Warning);
+
+                            if (result == DialogResult.Cancel || result == DialogResult.No)
+                            {
+                                e.Cancel = true;
+                                return;
+                            }
+                        }
+                        else if (saveResult == SaveResult.Cancelled)
+                        {
+                            e.Cancel = true;
+                            return;
+                        }
+                        else
+                        {
+                            return;
+                        }
                     }
                 }
             }

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -1600,7 +1600,7 @@ namespace OpenEphys.Onix1.Design
             {
                 var customMessageBox = new CustomMessageBox(
                     $"The ProbeInterface electrode configuration for {ProbeName} has unsaved changes; would you like to save the changes before closing?",
-                    CustomMessageBox.CustomMessageBoxButtons.SaveSaveAsCancel,
+                    CustomMessageBox.CustomMessageBoxButtons.SaveDiscardCancel,
                     $"Save {ProbeName} Configuration?");
 
                 var result = customMessageBox.ShowDialog();
@@ -1624,37 +1624,6 @@ namespace OpenEphys.Onix1.Design
                                 $"Error Saving {ProbeName} File",
                                 MessageBoxButtons.YesNoCancel,
                                 MessageBoxIcon.Warning);
-
-                            if (result == DialogResult.Cancel || result == DialogResult.No)
-                            {
-                                e.Cancel = true;
-                                return;
-                            }
-                        }
-                        else if (saveResult == SaveResult.Cancelled)
-                        {
-                            e.Cancel = true;
-                            return;
-                        }
-                        else
-                        {
-                            return;
-                        }
-                    }
-                }
-                else if (customMessageBox.ClickedButton == CustomMessageBox.CustomMessageBoxButton.Button2) // NB: Save As
-                {
-                    while (true)
-                    {
-                        var saveResult = SaveFileAs();
-
-                        if (saveResult == SaveResult.Failure)
-                        {
-                            result = MessageBox.Show(
-                            $"Error: Failed to save {ProbeName} file. Do you want to try saving again?",
-                            $"Error Saving {ProbeName} File",
-                            MessageBoxButtons.YesNoCancel,
-                            MessageBoxIcon.Warning);
 
                             if (result == DialogResult.Cancel || result == DialogResult.No)
                             {

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -1,10 +1,10 @@
-﻿using Bonsai.IO;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using Bonsai.IO;
 using OpenEphys.ProbeInterface.NET;
 using ZedGraph;
 
@@ -24,6 +24,8 @@ namespace OpenEphys.Onix1.Design
         internal event EventHandler OnProbeConfigurationChanged;
         internal event EventHandler OnMoveProbeGroup;
         internal event EventHandler OnStateChange;
+        internal event EventHandler OnFileLoad;
+        internal event EventHandler OnFileImport;
 
         bool hasChanges = false;
 
@@ -188,6 +190,7 @@ namespace OpenEphys.Onix1.Design
         {
             ProbeGroup = DefaultChannelLayout();
             RedrawProbeGroup();
+            OnFileLoadHandler();
         }
 
         /// <summary>
@@ -379,14 +382,36 @@ namespace OpenEphys.Onix1.Design
             }
         }
 
-        internal virtual bool OpenNewFile(bool updateFileName = false)
+        static OpenFileDialog CreateOpenFileDialog(string fileName, string title)
         {
+            var directory = Path.GetDirectoryName(fileName);
+            if (string.IsNullOrEmpty(directory)) directory = ".";
+
             using OpenFileDialog ofd = new();
 
             ofd.Filter = ProbeInterfaceHelper.ProbeInterfaceFileNameFilter;
             ofd.FilterIndex = 1;
             ofd.Multiselect = false;
-            ofd.Title = $"{ProbeName}: Open File";
+            ofd.Title = title;
+            ofd.InitialDirectory = directory;
+
+            return ofd;
+        }
+
+        void OnFileLoadHandler()
+        {
+            OnFileLoad?.Invoke(this, EventArgs.Empty);
+        }
+
+        void OnFileImportHandler()
+        {
+            OnFileImport?.Invoke(this, EventArgs.Empty);
+        }
+
+        internal bool ImportFile()
+        {
+            var fileName = GetFileName();
+            var ofd = CreateOpenFileDialog(fileName, $"{ProbeName}: Open File");
 
             if (ofd.ShowDialog() == DialogResult.OK && File.Exists(ofd.FileName))
             {
@@ -394,14 +419,31 @@ namespace OpenEphys.Onix1.Design
 
                 if (result)
                 {
-                    if (updateFileName)
-                    {
-                        ProbeConfiguration.ProbeInterfaceFileName = ofd.FileName;
-                    }
+                    OnFileImportHandler();
+                }
+
+                return result;
+            }
+
+            return false;
+        }
+
+        internal bool OpenFile()
+        {
+            var fileName = GetFileName();
+            var ofd = CreateOpenFileDialog(fileName, $"{ProbeName}: Open File");
+
+            if (ofd.ShowDialog() == DialogResult.OK && File.Exists(ofd.FileName))
+            {
+                var result = TryUpdateProbeGroupFromFile(ofd.FileName);
+
+                if (result)
+                {
+                    ProbeConfiguration.ProbeInterfaceFileName = ofd.FileName;
+
+                    OnFileLoadHandler();
 
                     HasChanges = false;
-
-                    ProbeConfigurationChanged();
                 }
 
                 return result;
@@ -1053,10 +1095,9 @@ namespace OpenEphys.Onix1.Design
                 {
                     return;
                 }
-
             }
 
-            if (OpenNewFile())
+            if (ImportFile())
             {
                 RedrawProbeGroup();
                 HasChanges = true;
@@ -1100,7 +1141,7 @@ namespace OpenEphys.Onix1.Design
                 }
             }
 
-            if (OpenNewFile(updateFileName: true))
+            if (OpenFile())
             {
                 RedrawProbeGroup();
             }
@@ -1526,20 +1567,6 @@ namespace OpenEphys.Onix1.Design
 
         internal bool UpdateProbeConfiguration(IProbeInterfaceConfiguration configuration, Type probeGroupType)
         {
-            if (HasChanges && !string.IsNullOrEmpty(ProbeConfiguration.ProbeInterfaceFileName))
-            {
-                var result = MessageBox.Show(
-                    "Warning: Changing the probe configuration will overwrite the current configuration without saving. Do you want to continue?",
-                    "Changing Probe Configuration",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Warning);
-
-                if (result == DialogResult.No)
-                {
-                    return false;
-                }
-            }
-
             ProbeConfiguration = configuration;
             this.probeGroupType = probeGroupType;
             ProbeGroup = GetProbeGroup(configuration.ProbeInterfaceFileName);

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -1593,10 +1593,7 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel)
-                return;
-
-            if (HasChanges || string.IsNullOrEmpty(ProbeConfiguration.ProbeInterfaceFileName))
+            if (HasChanges)
             {
                 var customMessageBox = new CustomMessageBox(
                     $"The ProbeInterface electrode configuration for {ProbeName} has unsaved changes; would you like to save the changes before closing?",

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -1121,6 +1121,7 @@ namespace OpenEphys.Onix1.Design
             }
 
             LoadDefaultChannelLayout();
+            OnFileImportHandler();
             HasChanges = true;
         }
 

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -1097,7 +1097,7 @@ namespace OpenEphys.Onix1.Design
             {
                 var result = MessageBox.Show(
                     $"Warning: Importing a file will overwrite the {ProbeName} configuration. Do you want to continue?",
-                    "Import File",
+                    $"{ProbeName}: Import File",
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning);
 
@@ -1120,7 +1120,7 @@ namespace OpenEphys.Onix1.Design
             {
                 var result = MessageBox.Show(
                     $"Warning: Loading the default configuration will overwrite the {ProbeName} configuration. Do you want to continue?",
-                    "Load Default Configuration",
+                    $"{ProbeName}: Load Default Configuration",
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning);
 
@@ -1595,12 +1595,11 @@ namespace OpenEphys.Onix1.Design
         {
             if (HasChanges)
             {
-                var customMessageBox = new CustomMessageBox(
+                var result = MessageBox.Show(
                     $"The ProbeInterface electrode configuration for {ProbeName} has unsaved changes; would you like to save the changes before closing?",
-                    CustomMessageBox.CustomMessageBoxButtons.SaveDiscardCancel,
-                    $"Save {ProbeName} Configuration?");
-
-                var result = customMessageBox.ShowDialog();
+                    $"Save {ProbeName} Configuration?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Warning);
 
                 if (result == DialogResult.Cancel)
                 {
@@ -1608,7 +1607,7 @@ namespace OpenEphys.Onix1.Design
                     return;
                 }
 
-                if (customMessageBox.ClickedButton == CustomMessageBox.CustomMessageBoxButton.Button1) // NB: Save
+                if (result == DialogResult.Yes)
                 {
                     while (true)
                     {

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -61,7 +61,7 @@ namespace OpenEphys.Onix1.Design
 
         internal readonly List<int> ReferenceContacts = new();
 
-        string ProbeName { get; }
+        internal string ProbeName { get; }
 
         internal bool[] SelectedContacts { get; private set; } = null;
 

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -122,7 +122,6 @@ namespace OpenEphys.Onix1.Design
             if (string.IsNullOrEmpty(ProbeConfiguration.ProbeInterfaceFileName))
             {
                 ProbeGroup = DefaultChannelLayout();
-                HasChanges = true;
             }
             else
             {
@@ -435,25 +434,29 @@ namespace OpenEphys.Onix1.Design
             return false;
         }
 
-        internal bool OpenFile()
+        internal bool OpenFile(string fileName)
+        {
+            var result = TryUpdateProbeGroupFromFile(fileName);
+
+            if (result)
+            {
+                ProbeConfiguration.ProbeInterfaceFileName = fileName;
+                OnFileLoadHandler();
+
+                HasChanges = false;
+            }
+
+            return result;
+        }
+
+        internal bool OpenFileFromDialog()
         {
             var fileName = GetFileName();
             var ofd = CreateOpenFileDialog(fileName, $"{ProbeName}: Open File");
 
             if (ofd.ShowDialog() == DialogResult.OK && File.Exists(ofd.FileName))
             {
-                var result = TryUpdateProbeGroupFromFile(ofd.FileName);
-
-                if (result)
-                {
-                    ProbeConfiguration.ProbeInterfaceFileName = ofd.FileName;
-
-                    OnFileLoadHandler();
-
-                    HasChanges = false;
-                }
-
-                return result;
+                return OpenFile(ofd.FileName);
             }
 
             return false;
@@ -1149,7 +1152,7 @@ namespace OpenEphys.Onix1.Design
                 }
             }
 
-            if (OpenFile())
+            if (OpenFileFromDialog())
             {
                 RedrawProbeGroup();
             }

--- a/OpenEphys.Onix1.Design/CustomMessageBox.cs
+++ b/OpenEphys.Onix1.Design/CustomMessageBox.cs
@@ -38,7 +38,11 @@ namespace OpenEphys.Onix1.Design
             /// <summary>
             /// Specifies that there are three buttons, "Save", "Save As", and "Cancel"
             /// </summary>
-            SaveSaveAsCancel
+            SaveSaveAsCancel,
+            /// <summary>
+            /// Specifies that there are three buttons, "Save", "Discard", and "Cancel"
+            /// </summary>
+            SaveDiscardCancel
         }
 
         /// <summary>
@@ -111,6 +115,11 @@ namespace OpenEphys.Onix1.Design
                 case CustomMessageBoxButtons.SaveSaveAsCancel:
                     button1Text = "Save";
                     button2Text = "Save As";
+                    button3Text = "Cancel";
+                    break;
+                case CustomMessageBoxButtons.SaveDiscardCancel:
+                    button1Text = "Save";
+                    button2Text = "Discard";
                     button3Text = "Cancel";
                     break;
             }

--- a/OpenEphys.Onix1.Design/DesignHelper.cs
+++ b/OpenEphys.Onix1.Design/DesignHelper.cs
@@ -103,5 +103,38 @@ namespace OpenEphys.Onix1.Design
         {
             CopyPropertiesCore(source, target, propertiesToIgnore, shallowCopy: false);
         }
+
+        public static void CloseWithResult(this Form form, Form parent)
+        {
+            form.DialogResult = parent.DialogResult;
+            form.Close();
+        }
+
+        const string GenericConfirmMessage = "Are you sure you want to exit the dialog? Any changes made will be discarded.";
+
+        public static DialogResult ConfirmClosing(string msg = GenericConfirmMessage)
+        {
+            return MessageBox.Show(
+                    msg,
+                    "Confirm Exit",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Warning);
+        }
+
+        public static bool HandleTopLevelDialogCancel(this Form form, ref FormClosingEventArgs e, string msg = GenericConfirmMessage)
+        {
+            if (form.TopLevel && form.DialogResult == DialogResult.Cancel)
+            {
+                var result = ConfirmClosing(msg);
+                if (result == DialogResult.No)
+                {
+                    e.Cancel = true;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ChannelConfigurationDialog.cs
@@ -13,7 +13,6 @@ namespace OpenEphys.Onix1.Design
     public partial class NeuropixelsV1ChannelConfigurationDialog : ScaledChannelConfigurationDialog
     {
         internal event EventHandler OnZoom;
-        internal event EventHandler OnFileLoad;
 
         readonly IReadOnlyList<int> ReferenceContactsList = new List<int> { 191, 575, 959 };
 
@@ -39,29 +38,6 @@ namespace OpenEphys.Onix1.Design
         internal override ProbeGroup DefaultChannelLayout()
         {
             return new NeuropixelsV1eProbeGroup();
-        }
-
-        internal override void LoadDefaultChannelLayout()
-        {
-            base.LoadDefaultChannelLayout();
-            OnFileOpenHandler();
-        }
-
-        internal override bool OpenNewFile(bool updateFileName = false)
-        {
-            if (base.OpenNewFile(updateFileName))
-            {
-                OnFileOpenHandler();
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private void OnFileOpenHandler()
-        {
-            OnFileLoad?.Invoke(this, EventArgs.Empty);
         }
 
         internal override void ZoomEvent(ZedGraphControl sender, ZoomState oldState, ZoomState newState)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.cs
@@ -13,7 +13,11 @@ namespace OpenEphys.Onix1.Design
 
         internal readonly NeuropixelsV1ProbeConfigurationDialog ProbeConfigurationDialog;
 
-        internal bool HasChanges => ProbeConfigurationDialog.HasChanges;
+        internal bool HasChanges
+        {
+            get => ProbeConfigurationDialog.HasChanges;
+            set => ProbeConfigurationDialog.HasChanges = value;
+        }
 
         IConfigureNeuropixelsV1 configureNeuropixelsV1;
 
@@ -95,7 +99,12 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            ProbeConfigurationDialog.Close();
+            if (HasChanges && this.HandleTopLevelDialogCancel(ref e, ChannelConfigurationDialog.ProbeConfigurationConfirmMessage))
+            {
+                return;
+            }
+
+            ProbeConfigurationDialog.CloseWithResult(this);
 
             if (!ProbeConfigurationDialog.IsDisposed)
             {

--- a/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1Dialog.cs
@@ -95,9 +95,6 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel)
-                return;
-
             ProbeConfigurationDialog.Close();
 
             if (!ProbeConfigurationDialog.IsDisposed)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -94,22 +94,30 @@ namespace OpenEphys.Onix1.Design
                         }
                     }
 
-                    if (HasChanges && !string.IsNullOrEmpty(e.OldValue as string))
+                    string fileName = e.ChangedItem.Value as string;
+
+                    if (HasChanges && File.Exists(fileName))
                     {
                         var result = MessageBox.Show(
-                            $"Warning: Changing the filename will discard the unsaved {ChannelConfiguration.ProbeName} configuration changes for \"{e.OldValue}\". Do you want to continue?",
+                            $"Warning: Changing the filename will discard the unsaved {ChannelConfiguration.ProbeName} configuration changes. Do you want to save the current configuration before continuing?",
                             "Change File Name?",
-                            MessageBoxButtons.YesNo,
+                            MessageBoxButtons.YesNoCancel,
                             MessageBoxIcon.Warning);
 
-                        if (result == DialogResult.No)
+                        if (result == DialogResult.Cancel)
                         {
                             RevertFileNameValue(sender as PropertyGrid, e);
                             return;
                         }
+                        else if (result == DialogResult.Yes)
+                        {
+                            if (ChannelConfiguration.SaveFile(e.OldValue as string) == ChannelConfigurationDialog.SaveResult.Cancelled)
+                            {
+                                return;
+                            }
+                        }
                     }
 
-                    string fileName = e.ChangedItem.Value as string;
                     if (File.Exists(fileName))
                     {
                         if (!ChannelConfiguration.OpenFile(fileName))

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -15,7 +15,7 @@ namespace OpenEphys.Onix1.Design
     {
         internal event EventHandler OnStateChange;
 
-        readonly NeuropixelsV1ChannelConfigurationDialog ChannelConfiguration;
+        internal readonly NeuropixelsV1ChannelConfigurationDialog ChannelConfiguration;
 
         NeuropixelsV1Adc[] Adcs = null;
 
@@ -39,7 +39,7 @@ namespace OpenEphys.Onix1.Design
         internal bool HasChanges
         {
             get => ChannelConfiguration.HasChanges;
-            private set => ChannelConfiguration.HasChanges = value;
+            set => ChannelConfiguration.HasChanges = value;
         }
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace OpenEphys.Onix1.Design
             HasChanges = true;
         }
 
-        private void CheckForExistingChannelPreset()
+        internal void CheckForExistingChannelPreset()
         {
             var channelMap = ProbeGroup.ChannelMap;
 
@@ -411,7 +411,14 @@ namespace OpenEphys.Onix1.Design
                                         ? gainCorrection.Value.LfpGainCorrectionFactor.ToString()
                                         : "";
 
-            ChannelConfiguration.Visible = adcCalibration.HasValue && gainCorrection.HasValue;
+            bool isChannelConfigVisible = adcCalibration.HasValue && gainCorrection.HasValue;
+            ChannelConfiguration.Visible = isChannelConfigVisible;
+            comboBoxChannelPresets.Enabled = isChannelConfigVisible;
+
+            if (!isChannelConfigVisible)
+            {
+                DeselectContacts();
+            }
 
             if (toolStripAdcCalSN.Text == NoFileSelected)
                 toolStripLabelAdcCalibrationSN.Image = Properties.Resources.StatusWarningImage;
@@ -577,7 +584,12 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            ChannelConfiguration.Close();
+            if (HasChanges && this.HandleTopLevelDialogCancel(ref e, ChannelConfigurationDialog.ProbeConfigurationConfirmMessage))
+            {
+                return;
+            }
+
+            ChannelConfiguration.CloseWithResult(this);
 
             if (!ChannelConfiguration.IsDisposed)
             {

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -77,6 +77,54 @@ namespace OpenEphys.Onix1.Design
 
             ChannelConfiguration.BringToFront();
             propertyGrid.SelectedObject = probeConfiguration;
+            propertyGrid.PropertyValueChanged += (sender, e) =>
+            {
+                if (e.ChangedItem.Label == nameof(NeuropixelsV1ProbeConfiguration.ProbeInterfaceFileName))
+                {
+                    static void RevertFileNameValue(PropertyGrid propertyGrid, PropertyValueChangedEventArgs e)
+                    {
+                        var gridItem = propertyGrid.SelectedGridItem;
+                        var parent = gridItem.Parent;
+                        var parentType = parent.Value.GetType();
+                        var propertyInfo = parentType.GetProperty(e.ChangedItem.PropertyDescriptor.Name);
+                        if (propertyInfo != null && propertyInfo.CanWrite)
+                        {
+                            propertyInfo.SetValue(parent.Value, e.OldValue);
+                            propertyGrid.Refresh();
+                        }
+                    }
+
+                    if (HasChanges && !string.IsNullOrEmpty(e.OldValue as string))
+                    {
+                        var result = MessageBox.Show(
+                            $"Warning: Changing the filename will discard the unsaved {ChannelConfiguration.ProbeName} configuration changes for \"{e.OldValue}\". Do you want to continue?",
+                            "Change File Name?",
+                            MessageBoxButtons.YesNo,
+                            MessageBoxIcon.Warning);
+
+                        if (result == DialogResult.No)
+                        {
+                            RevertFileNameValue(sender as PropertyGrid, e);
+                            return;
+                        }
+                    }
+
+                    string fileName = e.ChangedItem.Value as string;
+                    if (File.Exists(fileName))
+                    {
+                        if (!ChannelConfiguration.OpenFile(fileName))
+                        {
+                            RevertFileNameValue(sender as PropertyGrid, e);
+                        }
+                    }
+                    else
+                    {
+                        HasChanges = true;
+                    }
+                }
+
+                CheckStatus();
+            };
             bindingSource.DataSource = probeConfiguration;
 
             // NB: Needed to capture mouse scroll wheel updates

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -60,6 +60,7 @@ namespace OpenEphys.Onix1.Design
 
             ChannelConfiguration.OnZoom += UpdateTrackBarLocation;
             ChannelConfiguration.OnFileLoad += OnFileLoadEvent;
+            ChannelConfiguration.OnFileImport += (sender, e) => CheckForExistingChannelPreset();
             ChannelConfiguration.OnStateChange += (sender, e) =>
             {
                 if (HasChanges)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1ProbeConfigurationDialog.cs
@@ -569,9 +569,6 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel || (Adcs == null && string.IsNullOrEmpty(textBoxLfpCorrection.Text)))
-                return;
-
             ChannelConfiguration.Close();
 
             if (!ChannelConfiguration.IsDisposed)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
@@ -76,7 +76,12 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            DialogNeuropixelsV1e.Close();
+            if (DialogNeuropixelsV1e.HasChanges && this.HandleTopLevelDialogCancel(ref e, ChannelConfigurationDialog.ProbeConfigurationConfirmMessage))
+            {
+                return;
+            }
+
+            DialogNeuropixelsV1e.CloseWithResult(this);
 
             if (!DialogNeuropixelsV1e.IsDisposed)
             {

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.cs
@@ -76,9 +76,6 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel)
-                return;
-
             DialogNeuropixelsV1e.Close();
 
             if (!DialogNeuropixelsV1e.IsDisposed)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
@@ -97,9 +97,6 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel)
-                return;
-
             DialogNeuropixelsV1A.Close();
 
             if (!DialogNeuropixelsV1A.IsDisposed)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
@@ -14,17 +14,17 @@ namespace OpenEphys.Onix1.Design
         /// <summary>
         /// Gets the <see cref="NeuropixelsV1Dialog"/> for ProbeA.
         /// </summary>
-        public readonly NeuropixelsV1Dialog DialogNeuropixelsV1A;
+        internal NeuropixelsV1Dialog DialogNeuropixelsV1A { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="NeuropixelsV1Dialog"/> for ProbeB.
         /// </summary>
-        public readonly NeuropixelsV1Dialog DialogNeuropixelsV1B;
+        internal NeuropixelsV1Dialog DialogNeuropixelsV1B { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="GenericDeviceDialog"/> for the Bno055.
         /// </summary>
-        public readonly GenericDeviceDialog DialogBno055;
+        internal GenericDeviceDialog DialogBno055 { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of a <see cref="NeuropixelsV1fHeadstageDialog"/>.
@@ -36,49 +36,39 @@ namespace OpenEphys.Onix1.Design
         {
             InitializeComponent();
 
-            DialogNeuropixelsV1A = new(configureNeuropixelsV1A, nameof(ConfigureHeadstageNeuropixelsV1f.NeuropixelsV1A), true)
-            {
-                Tag = configureNeuropixelsV1A.ProbeName
-            };
+            DialogNeuropixelsV1A = CreateNeuropixelsV1Dialog(this, configureNeuropixelsV1A, nameof(ConfigureHeadstageNeuropixelsV1f.NeuropixelsV1A), panelNeuropixelsV1A, tabPageNeuropixelsV1A);
 
-            DialogNeuropixelsV1A.SetChildFormProperties(this).AddDialogToPanel(panelNeuropixelsV1A);
-
-            DialogNeuropixelsV1A.OnStateChange += (sender, e) =>
-            {
-                if (DialogNeuropixelsV1A.HasChanges)
-                {
-                    tabPageNeuropixelsV1A.Text += '*';
-                }
-                else
-                {
-                    tabPageNeuropixelsV1A.Text = tabPageNeuropixelsV1A.Text.TrimEnd('*');
-                }
-            };
-
-            DialogNeuropixelsV1B = new(configureNeuropixelsV1B, nameof(ConfigureHeadstageNeuropixelsV1f.NeuropixelsV1B), true)
-            {
-                Tag = configureNeuropixelsV1B.ProbeName
-            };
-
-            DialogNeuropixelsV1B.SetChildFormProperties(this).AddDialogToPanel(panelNeuropixelsV1B);
-
-            DialogNeuropixelsV1B.OnStateChange += (sender, e) =>
-            {
-                if (DialogNeuropixelsV1B.HasChanges)
-                {
-                    tabPageNeuropixelsV1B.Text += '*';
-                }
-                else
-                {
-                    tabPageNeuropixelsV1B.Text = tabPageNeuropixelsV1B.Text.TrimEnd('*');
-                }
-            };
+            DialogNeuropixelsV1B = CreateNeuropixelsV1Dialog(this, configureNeuropixelsV1B, nameof(ConfigureHeadstageNeuropixelsV1f.NeuropixelsV1B), panelNeuropixelsV1B, tabPageNeuropixelsV1B);
 
             DialogBno055 = new(configureBno055, true);
 
             DialogBno055.SetChildFormProperties(this).AddDialogToPanel(panelBno055);
 
             FormClosing += DialogClosing;
+        }
+
+        static NeuropixelsV1Dialog CreateNeuropixelsV1Dialog(NeuropixelsV1fHeadstageDialog headstageDialog, ConfigureNeuropixelsV1f configureNeuropixelsV1, string probeName, Panel panel, TabPage tabPage)
+        {
+            var dialog = new NeuropixelsV1Dialog(configureNeuropixelsV1, probeName, true)
+            {
+                Tag = configureNeuropixelsV1.ProbeName
+            };
+
+            dialog.SetChildFormProperties(headstageDialog).AddDialogToPanel(panel);
+
+            dialog.OnStateChange += (sender, e) =>
+            {
+                if (dialog.HasChanges)
+                {
+                    tabPage.Text += '*';
+                }
+                else
+                {
+                    tabPage.Text = tabPage.Text.TrimEnd('*');
+                }
+            };
+
+            return dialog;
         }
 
         private void Okay_Click(object sender, System.EventArgs e)
@@ -123,6 +113,11 @@ namespace OpenEphys.Onix1.Design
             if (!DialogNeuropixelsV1B.IsDisposed)
             {
                 e.Cancel = true;
+
+                // NB: Initialize the previously disposed dialog when the user cancels closing the dialog
+                panelNeuropixelsV1A.Controls.Remove(DialogNeuropixelsV1A);
+                DialogNeuropixelsV1A = CreateNeuropixelsV1Dialog(this, DialogNeuropixelsV1A.ConfigureNode as ConfigureNeuropixelsV1f, nameof(ConfigureHeadstageNeuropixelsV1f.NeuropixelsV1A), panelNeuropixelsV1A, tabPageNeuropixelsV1A);
+
                 return;
             }
         }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1fHeadstageDialog.cs
@@ -26,6 +26,8 @@ namespace OpenEphys.Onix1.Design
         /// </summary>
         internal GenericDeviceDialog DialogBno055 { get; private set; }
 
+        bool HasChanges => DialogNeuropixelsV1A.HasChanges || DialogNeuropixelsV1B.HasChanges;
+
         /// <summary>
         /// Initializes a new instance of a <see cref="NeuropixelsV1fHeadstageDialog"/>.
         /// </summary>
@@ -60,7 +62,10 @@ namespace OpenEphys.Onix1.Design
             {
                 if (dialog.HasChanges)
                 {
-                    tabPage.Text += '*';
+                    if (!tabPage.Text.Contains("*"))
+                    {
+                        tabPage.Text += '*';
+                    }
                 }
                 else
                 {
@@ -97,7 +102,12 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            DialogNeuropixelsV1A.Close();
+            if (HasChanges && this.HandleTopLevelDialogCancel(ref e, ChannelConfigurationDialog.ProbeConfigurationConfirmMessage))
+            {
+                return;
+            }
+
+            DialogNeuropixelsV1A.CloseWithResult(this);
 
             if (!DialogNeuropixelsV1A.IsDisposed)
             {
@@ -105,15 +115,19 @@ namespace OpenEphys.Onix1.Design
                 return;
             }
 
-            DialogNeuropixelsV1B.Close();
+            DialogNeuropixelsV1B.CloseWithResult(this);
 
             if (!DialogNeuropixelsV1B.IsDisposed)
             {
                 e.Cancel = true;
 
                 // NB: Initialize the previously disposed dialog when the user cancels closing the dialog
+                var dialog = DialogNeuropixelsV1A;
                 panelNeuropixelsV1A.Controls.Remove(DialogNeuropixelsV1A);
                 DialogNeuropixelsV1A = CreateNeuropixelsV1Dialog(this, DialogNeuropixelsV1A.ConfigureNode as ConfigureNeuropixelsV1f, nameof(ConfigureHeadstageNeuropixelsV1f.NeuropixelsV1A), panelNeuropixelsV1A, tabPageNeuropixelsV1A);
+                DialogNeuropixelsV1A.ProbeConfigurationDialog.ChannelConfiguration.ProbeGroup = dialog.ProbeConfigurationDialog.ChannelConfiguration.ProbeGroup;
+                DialogNeuropixelsV1A.ProbeConfigurationDialog.ChannelConfiguration.RedrawProbeGroup();
+                DialogNeuropixelsV1A.ProbeConfigurationDialog.CheckForExistingChannelPreset();
 
                 return;
             }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
@@ -12,7 +12,6 @@ namespace OpenEphys.Onix1.Design
     public partial class NeuropixelsV2eChannelConfigurationDialog : ScaledChannelConfigurationDialog
     {
         internal event EventHandler OnZoom;
-        internal event EventHandler OnFileLoad;
 
         /// <summary>
         /// Initializes a new instance of <see cref="NeuropixelsV2eChannelConfigurationDialog"/>.
@@ -50,23 +49,6 @@ namespace OpenEphys.Onix1.Design
                 MessageBox.Show("Unable to Load Default Configuration", ex.Message);
                 return;
             }
-        }
-
-        internal override bool OpenNewFile(bool updateFileName = false)
-        {
-            if (base.OpenNewFile(updateFileName))
-            {
-                OnFileOpenHandler();
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private void OnFileOpenHandler()
-        {
-            OnFileLoad?.Invoke(this, EventArgs.Empty);
         }
 
         internal override void ZoomEvent(ZedGraphControl sender, ZoomState oldState, ZoomState newState)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
@@ -28,8 +28,8 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.label1 = new System.Windows.Forms.Label();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NeuropixelsV2eDialog));
+            this.label1 = new System.Windows.Forms.Label();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonOkay = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
@@ -45,6 +45,16 @@
             this.panelConfigurationDialogs.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(0, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(910, 656);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Select a probe configuration property to view the currently enabled electrodes.";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // buttonCancel
             // 
@@ -98,7 +108,7 @@
             // splitContainer.Panel2
             // 
             this.splitContainer.Panel2.Controls.Add(this.panelConfigurationDialogs);
-            this.splitContainer.Size = new System.Drawing.Size(1133, 632);
+            this.splitContainer.Size = new System.Drawing.Size(1133, 656);
             this.splitContainer.SplitterDistance = 219;
             this.splitContainer.TabIndex = 3;
             // 
@@ -107,7 +117,7 @@
             this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.propertyGrid.Location = new System.Drawing.Point(0, 0);
             this.propertyGrid.Name = "propertyGrid";
-            this.propertyGrid.Size = new System.Drawing.Size(219, 632);
+            this.propertyGrid.Size = new System.Drawing.Size(219, 656);
             this.propertyGrid.TabIndex = 0;
             this.propertyGrid.SelectedGridItemChanged += new System.Windows.Forms.SelectedGridItemChangedEventHandler(this.PropertyGridChanged);
             // 
@@ -118,7 +128,7 @@
             this.panelConfigurationDialogs.Location = new System.Drawing.Point(0, 0);
             this.panelConfigurationDialogs.Margin = new System.Windows.Forms.Padding(0);
             this.panelConfigurationDialogs.Name = "panelConfigurationDialogs";
-            this.panelConfigurationDialogs.Size = new System.Drawing.Size(910, 632);
+            this.panelConfigurationDialogs.Size = new System.Drawing.Size(910, 656);
             this.panelConfigurationDialogs.TabIndex = 0;
             // 
             // flowLayoutPanel1
@@ -132,16 +142,6 @@
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(1131, 41);
             this.flowLayoutPanel1.TabIndex = 2;
-            // 
-            // label1
-            // 
-            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Location = new System.Drawing.Point(0, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(910, 632);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Select a probe configuration property to view the currently enabled electrodes.";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // NeuropixelsV2eDialog
             // 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -15,7 +16,7 @@ namespace OpenEphys.Onix1.Design
 
         internal readonly Dictionary<NeuropixelsV2Probe, NeuropixelsV2eProbeConfigurationDialog> ProbeConfigurationDialogs;
 
-        internal bool HasChanges => ProbeConfigurationDialogs.Values.Any(dialog => dialog.HasChanges && !string.IsNullOrEmpty(dialog.ProbeConfiguration.ProbeInterfaceFileName));
+        internal bool HasChanges => ProbeConfigurationDialogs.Values.Any(dialog => dialog.HasChanges);
 
         internal NeuropixelsV2ProbeConfiguration ProbeConfigurationA
         {
@@ -76,6 +77,57 @@ namespace OpenEphys.Onix1.Design
             ConfigureNeuropixelsV2 = configureNode;
             propertyGrid.PropertyValueChanged += (sender, e) =>
             {
+                if (e.ChangedItem.Label == nameof(NeuropixelsV2ProbeConfiguration.ProbeInterfaceFileName))
+                {
+                    static void RevertFileNameValue(PropertyGrid propertyGrid, PropertyValueChangedEventArgs e)
+                    {
+                        var gridItem = propertyGrid.SelectedGridItem;
+                        var parent = gridItem.Parent;
+                        var parentType = parent.Value.GetType();
+                        var propertyInfo = parentType.GetProperty(e.ChangedItem.PropertyDescriptor.Name);
+                        if (propertyInfo != null && propertyInfo.CanWrite)
+                        {
+                            propertyInfo.SetValue(parent.Value, e.OldValue);
+                            propertyGrid.Refresh();
+                        }
+                    }
+
+                    var probeConfigDialog = 
+                        e.ChangedItem.Parent.Label == nameof(ConfigureNeuropixelsV2e.ProbeConfigurationA)
+                        ? ProbeConfigurationDialogs[NeuropixelsV2Probe.ProbeA]
+                        : e.ChangedItem.Parent.Label == nameof(ConfigureNeuropixelsV2e.ProbeConfigurationB) 
+                          ? ProbeConfigurationDialogs[NeuropixelsV2Probe.ProbeB]
+                          : throw new NullReferenceException("Unable to find the probe configuration.");
+
+                    if (probeConfigDialog.HasChanges && !string.IsNullOrEmpty(e.OldValue as string))
+                    {
+                        var result = MessageBox.Show(
+                            $"Warning: Changing the filename will discard the unsaved {probeConfigDialog.ProbeName} configuration changes for \"{e.OldValue}\". Do you want to continue?",
+                            "Change File Name?",
+                            MessageBoxButtons.YesNo,
+                            MessageBoxIcon.Warning);
+
+                        if (result == DialogResult.No)
+                        {
+                            RevertFileNameValue(sender as PropertyGrid, e);
+                            return;
+                        }
+                    }
+
+                    string fileName = e.ChangedItem.Value as string;
+                    if (File.Exists(fileName))
+                    {
+                        if (!probeConfigDialog.OpenProbeInterfaceFile(fileName))
+                        {
+                            RevertFileNameValue(sender as PropertyGrid, e);
+                        }
+                    }
+                    else
+                    {
+                        probeConfigDialog.HasChanges = true;
+                    }
+                }
+
                 foreach (var dialog in ProbeConfigurationDialogs.Values)
                 {
                     dialog.CheckStatus();

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -12,31 +12,13 @@ namespace OpenEphys.Onix1.Design
     /// </summary>
     public partial class NeuropixelsV2eDialog : Form
     {
+        readonly bool IsBeta = false;
+
         internal event EventHandler OnStateChange;
 
         internal readonly Dictionary<NeuropixelsV2Probe, NeuropixelsV2eProbeConfigurationDialog> ProbeConfigurationDialogs;
 
         internal bool HasChanges => ProbeConfigurationDialogs.Values.Any(dialog => dialog.HasChanges);
-
-        internal NeuropixelsV2ProbeConfiguration ProbeConfigurationA
-        {
-            get
-            {
-                return ProbeConfigurationDialogs.TryGetValue(NeuropixelsV2Probe.ProbeA, out var probeConfigurationDialog)
-                    ? probeConfigurationDialog.ProbeConfiguration
-                    : throw new NullReferenceException("Unable to find the probe configuration for Probe A.");
-            }
-        }
-
-        internal NeuropixelsV2ProbeConfiguration ProbeConfigurationB
-        {
-            get
-            {
-                return ProbeConfigurationDialogs.TryGetValue(NeuropixelsV2Probe.ProbeB, out var probeConfigurationDialog)
-                    ? probeConfigurationDialog.ProbeConfiguration
-                    : throw new NullReferenceException("Unable to find the probe configuration for Probe B.");
-            }
-        }
 
         IConfigureNeuropixelsV2 configureNeuropixelsV2;
 
@@ -92,10 +74,10 @@ namespace OpenEphys.Onix1.Design
                         }
                     }
 
-                    var probeConfigDialog = 
+                    var probeConfigDialog =
                         e.ChangedItem.Parent.Label == nameof(ConfigureNeuropixelsV2e.ProbeConfigurationA)
                         ? ProbeConfigurationDialogs[NeuropixelsV2Probe.ProbeA]
-                        : e.ChangedItem.Parent.Label == nameof(ConfigureNeuropixelsV2e.ProbeConfigurationB) 
+                        : e.ChangedItem.Parent.Label == nameof(ConfigureNeuropixelsV2e.ProbeConfigurationB)
                           ? ProbeConfigurationDialogs[NeuropixelsV2Probe.ProbeB]
                           : throw new NullReferenceException("Unable to find the probe configuration.");
 
@@ -134,58 +116,44 @@ namespace OpenEphys.Onix1.Design
                 }
             };
 
-            bool isBeta = false;
-
             if (configureNode is ConfigureNeuropixelsV2eBeta configureV2eBeta)
             {
                 Text = Text.Replace("NeuropixelsV2e ", "NeuropixelsV2eBeta ");
-                isBeta = true;
+                IsBeta = true;
             }
 
             ProbeConfigurationDialogs = new()
             {
-                { NeuropixelsV2Probe.ProbeA, new(configureNode.ProbeConfigurationA, isBeta, nameof(NeuropixelsV2Probe.ProbeA)) },
-                { NeuropixelsV2Probe.ProbeB, new(configureNode.ProbeConfigurationB, isBeta, nameof(NeuropixelsV2Probe.ProbeB)) }
+                { NeuropixelsV2Probe.ProbeA, new(configureNode.ProbeConfigurationA, IsBeta, nameof(NeuropixelsV2Probe.ProbeA)) },
+                { NeuropixelsV2Probe.ProbeB, new(configureNode.ProbeConfigurationB, IsBeta, nameof(NeuropixelsV2Probe.ProbeB)) }
             };
 
-            foreach (var probeConfigurationDialog in ProbeConfigurationDialogs)
-            {
-                string probeName = probeConfigurationDialog.Key.ToString();
+            InitializeProbeConfigurationDialogs(this, ProbeConfigurationDialogs, propertyGrid);
+        }
 
-                probeConfigurationDialog.Value.SetChildFormProperties(this);
+        static void InitializeProbeConfigurationDialogs(NeuropixelsV2eDialog dialog, Dictionary<NeuropixelsV2Probe, NeuropixelsV2eProbeConfigurationDialog> probeConfigDialogs, PropertyGrid propertyGrid)
+        {
+            foreach (var probeConfigurationDialog in probeConfigDialogs)
+            {
+                probeConfigurationDialog.Value.SetChildFormProperties(dialog);
                 probeConfigurationDialog.Value.OnStateChange += (sender, args) =>
                 {
-                    if (HasChanges)
+                    if (dialog.HasChanges)
                     {
-                        if (!Text.EndsWith("*"))
+                        if (!dialog.Text.EndsWith("*"))
                         {
-                            Text += '*';
+                            dialog.Text += '*';
                         }
                     }
                     else
                     {
-                        Text = Text.TrimEnd('*');
+                        dialog.Text = dialog.Text.TrimEnd('*');
                     }
 
-                    OnStateChange?.Invoke(this, EventArgs.Empty);
+                    dialog.OnStateChange?.Invoke(dialog, EventArgs.Empty);
                 };
 
-                probeConfigurationDialog.Value.OnProbeConfigurationChange += (sender, args) =>
-                {
-                    if (sender is NeuropixelsV2eProbeConfigurationDialog dialog)
-                    {
-                        if (probeConfigurationDialog.Key == NeuropixelsV2Probe.ProbeA)
-                        {
-                            configureNeuropixelsV2.ProbeConfigurationA = dialog.ProbeConfiguration;
-                        }
-                        else if (probeConfigurationDialog.Key == NeuropixelsV2Probe.ProbeB)
-                        {
-                            configureNeuropixelsV2.ProbeConfigurationB = dialog.ProbeConfiguration;
-                        }
-                    }
-
-                    propertyGrid.Refresh();
-                };
+                probeConfigurationDialog.Value.OnProbeConfigurationChange += dialog.ProbeConfigurationChanged;
 
                 probeConfigurationDialog.Value.OnPropertyValueChanged += (sender, args) => propertyGrid.Refresh();
 
@@ -193,6 +161,23 @@ namespace OpenEphys.Onix1.Design
 
                 probeConfigurationDialog.Value.PanelBorderColor = propertyGrid.ViewBorderColor;
             }
+        }
+
+        void ProbeConfigurationChanged(object sender, EventArgs e)
+        {
+            if (sender is NeuropixelsV2eProbeConfigurationDialog dialog)
+            {
+                if (dialog == ProbeConfigurationDialogs[NeuropixelsV2Probe.ProbeA])
+                {
+                    configureNeuropixelsV2.ProbeConfigurationA = dialog.ProbeConfiguration;
+                }
+                else if (dialog == ProbeConfigurationDialogs[NeuropixelsV2Probe.ProbeB])
+                {
+                    configureNeuropixelsV2.ProbeConfigurationB = dialog.ProbeConfiguration;
+                }
+            }
+
+            propertyGrid.Refresh();
         }
 
         private void FormShown(object sender, EventArgs e)
@@ -308,6 +293,33 @@ namespace OpenEphys.Onix1.Design
                 if (!dialog.IsDisposed)
                 {
                     cancel = true;
+
+                    // NB: Initialize any dialogs that were previously disposed of when the user cancels closing the dialog
+                    Queue<KeyValuePair<NeuropixelsV2Probe, NeuropixelsV2eProbeConfigurationDialog>> queue = new();
+
+                    foreach (var keyValuePair in ProbeConfigurationDialogs)
+                    {
+                        if (keyValuePair.Value.IsDisposed)
+                        {
+                            queue.Enqueue(keyValuePair);
+                        }
+                    }
+
+                    if (queue.Count > 0)
+                    {
+                        foreach (var keyValuePair in queue)
+                        {
+                            ProbeConfigurationDialogs[keyValuePair.Key] = new NeuropixelsV2eProbeConfigurationDialog(
+                                keyValuePair.Value.ProbeConfiguration,
+                                IsBeta,
+                                keyValuePair.Value.ProbeName);
+                        }
+
+                        InitializeProbeConfigurationDialogs(this, ProbeConfigurationDialogs, propertyGrid);
+
+                        PropertyGridChanged(sender, new(propertyGrid.SelectedGridItem, propertyGrid.SelectedGridItem));
+                    }
+
                     break;
                 }
             }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -74,6 +74,13 @@ namespace OpenEphys.Onix1.Design
             }
 
             ConfigureNeuropixelsV2 = configureNode;
+            propertyGrid.PropertyValueChanged += (sender, e) =>
+            {
+                foreach (var dialog in ProbeConfigurationDialogs.Values)
+                {
+                    dialog.CheckStatus();
+                }
+            };
 
             bool isBeta = false;
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -281,9 +281,6 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel)
-                return;
-
             bool cancel = false;
 
             foreach (var dialog in ProbeConfigurationDialogs.Values)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -166,9 +166,16 @@ namespace OpenEphys.Onix1.Design
         {
             foreach (var probeConfigurationDialog in ProbeConfigurationDialogs)
             {
-                if (propertyGrid.SelectedGridItem.Value as NeuropixelsV2ProbeConfiguration == probeConfigurationDialog.Value.ProbeConfiguration && probeConfigurationDialog.Value.ProcessMenuShortcut(keyData))
+                var gridItem = propertyGrid.SelectedGridItem;
+
+                while (gridItem != null)
                 {
-                    return true;
+                    if (gridItem.Value as NeuropixelsV2ProbeConfiguration == probeConfigurationDialog.Value.ProbeConfiguration && probeConfigurationDialog.Value.ProcessMenuShortcut(keyData))
+                    {
+                        return true;
+                    }
+
+                    gridItem = gridItem.Parent;
                 }
             }
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -138,6 +138,8 @@ namespace OpenEphys.Onix1.Design
                 probeConfigurationDialog.Value.OnPropertyValueChanged += (sender, args) => propertyGrid.Refresh();
 
                 probeConfigurationDialog.Value.HidePropertiesTab();
+
+                probeConfigurationDialog.Value.PanelBorderColor = propertyGrid.ViewBorderColor;
             }
         }
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -81,22 +81,30 @@ namespace OpenEphys.Onix1.Design
                           ? ProbeConfigurationDialogs[NeuropixelsV2Probe.ProbeB]
                           : throw new NullReferenceException("Unable to find the probe configuration.");
 
-                    if (probeConfigDialog.HasChanges && !string.IsNullOrEmpty(e.OldValue as string))
+                    string fileName = e.ChangedItem.Value as string;
+
+                    if (probeConfigDialog.HasChanges && File.Exists(fileName))
                     {
                         var result = MessageBox.Show(
-                            $"Warning: Changing the filename will discard the unsaved {probeConfigDialog.ProbeName} configuration changes for \"{e.OldValue}\". Do you want to continue?",
+                            $"Warning: Changing the filename will discard the unsaved {probeConfigDialog.ProbeName} configuration changes. Do you want to save the current configuration before continuing?",
                             "Change File Name?",
-                            MessageBoxButtons.YesNo,
+                            MessageBoxButtons.YesNoCancel,
                             MessageBoxIcon.Warning);
 
-                        if (result == DialogResult.No)
+                        if (result == DialogResult.Cancel)
                         {
                             RevertFileNameValue(sender as PropertyGrid, e);
                             return;
                         }
+                        else if (result == DialogResult.Yes)
+                        {
+                            if (probeConfigDialog.SaveProbeInterfaceFile(e.OldValue as string) == ChannelConfigurationDialog.SaveResult.Cancelled)
+                            {
+                                return;
+                            }
+                        }
                     }
 
-                    string fileName = e.ChangedItem.Value as string;
                     if (File.Exists(fileName))
                     {
                         if (!probeConfigDialog.OpenProbeInterfaceFile(fileName))
@@ -140,6 +148,12 @@ namespace OpenEphys.Onix1.Design
                 {
                     if (dialog.HasChanges)
                     {
+                        if (!probeConfigurationDialog.Value.IsChannelConfigurationVisible)
+                        {
+                            probeConfigurationDialog.Value.HasChanges = false;
+                            return;
+                        }
+
                         if (!dialog.Text.EndsWith("*"))
                         {
                             dialog.Text += '*';

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -219,6 +219,7 @@ namespace OpenEphys.Onix1.Design
             //     Otherwise, remove the probe configuration dialogs to show the default text box.
             if (e.NewSelection != null)
             {
+                SuspendLayout();
                 if (e.NewSelection.Value is NeuropixelsV2ProbeConfiguration probeConfiguration)
                 {
                     ShowProbeConfigurationDialog(probeConfiguration);
@@ -237,6 +238,7 @@ namespace OpenEphys.Onix1.Design
                         }
                     }
                 }
+                ResumeLayout();
             }
         }
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -148,12 +148,6 @@ namespace OpenEphys.Onix1.Design
                 {
                     if (dialog.HasChanges)
                     {
-                        if (!probeConfigurationDialog.Value.IsChannelConfigurationVisible)
-                        {
-                            probeConfigurationDialog.Value.HasChanges = false;
-                            return;
-                        }
-
                         if (!dialog.Text.EndsWith("*"))
                         {
                             dialog.Text += '*';
@@ -295,11 +289,16 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
+            if (HasChanges && this.HandleTopLevelDialogCancel(ref e, ChannelConfigurationDialog.ProbeConfigurationConfirmMessage))
+            {
+                return;
+            }
+
             bool cancel = false;
 
             foreach (var dialog in ProbeConfigurationDialogs.Values)
             {
-                dialog.Close();
+                dialog.CloseWithResult(this);
 
                 if (!dialog.IsDisposed)
                 {
@@ -324,6 +323,9 @@ namespace OpenEphys.Onix1.Design
                                 keyValuePair.Value.ProbeConfiguration,
                                 IsBeta,
                                 keyValuePair.Value.ProbeName);
+                            ProbeConfigurationDialogs[keyValuePair.Key].ChannelConfiguration.ProbeGroup = keyValuePair.Value.ChannelConfiguration.ProbeGroup;
+                            ProbeConfigurationDialogs[keyValuePair.Key].ChannelConfiguration.RedrawProbeGroup();
+                            ProbeConfigurationDialogs[keyValuePair.Key].CheckForExistingChannelPreset();
                         }
 
                         InitializeProbeConfigurationDialogs(this, ProbeConfigurationDialogs, propertyGrid);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
@@ -79,7 +79,12 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            DialogNeuropixelsV2e.Close();
+            if (DialogNeuropixelsV2e.HasChanges && this.HandleTopLevelDialogCancel(ref e, ChannelConfigurationDialog.ProbeConfigurationConfirmMessage))
+            {
+                return;
+            }
+
+            DialogNeuropixelsV2e.CloseWithResult(this);
 
             if (!DialogNeuropixelsV2e.IsDisposed)
             {

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
@@ -79,9 +79,6 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel)
-                return;
-
             DialogNeuropixelsV2e.Close();
 
             if (!DialogNeuropixelsV2e.IsDisposed)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
@@ -113,9 +113,9 @@
             probeCalibrationFile.Location = new System.Drawing.Point(15, 11);
             probeCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             probeCalibrationFile.Name = "probeCalibrationFile";
-            probeCalibrationFile.Size = new System.Drawing.Size(139, 16);
+            probeCalibrationFile.Size = new System.Drawing.Size(130, 16);
             probeCalibrationFile.TabIndex = 0;
-            probeCalibrationFile.Text = "Probe Calibration File:";
+            probeCalibrationFile.Text = "Gain Calibration File:";
             // 
             // Reference
             // 
@@ -288,7 +288,7 @@
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 660F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 680F));
             this.tableLayoutPanel2.Size = new System.Drawing.Size(827, 680);
             this.tableLayoutPanel2.TabIndex = 3;
             // 
@@ -480,6 +480,7 @@
             this.statusStrip1.Location = new System.Drawing.Point(0, 732);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 13, 0);
+            this.statusStrip1.ShowItemToolTips = true;
             this.statusStrip1.Size = new System.Drawing.Size(1234, 29);
             this.statusStrip1.TabIndex = 3;
             this.statusStrip1.Text = "statusStrip1";

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -206,6 +206,8 @@ namespace OpenEphys.Onix1.Design
 
         void UpdateProbeConfiguration()
         {
+            SuspendLayout();
+
             var probeType = (ProbeType)comboBoxProbeType.SelectedItem;
 
             if (!ChannelConfiguration.UpdateProbeConfiguration(probeConfigurations[probeType], GetProbeGroupType(probeType)))
@@ -235,6 +237,9 @@ namespace OpenEphys.Onix1.Design
 
             ProbeConfigurationChanged();
             CheckStatus();
+
+            ResumeLayout();
+            Refresh();
         }
 
         internal Color PanelBorderColor { get; set; } = Color.Black;

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -98,6 +98,7 @@ namespace OpenEphys.Onix1.Design
             ChannelConfiguration.BringToFront();
 
             propertyGrid.SelectedObject = configuration;
+            propertyGrid.PropertyValueChanged += (sender, e) => CheckStatus();
             bindingSource.DataSource = configuration;
 
             comboBoxProbeType.DataSource = Enum.GetValues(typeof(ProbeType));
@@ -302,7 +303,7 @@ namespace OpenEphys.Onix1.Design
             UpdateProbeConfiguration();
         }
 
-        private void CheckStatus()
+        internal void CheckStatus()
         {
             const string NoFileSelected = "No file selected.";
             const string InvalidFile = "Invalid file.";

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -185,7 +185,7 @@ namespace OpenEphys.Onix1.Design
             {
                 var result = MessageBox.Show(
                     $"Warning: Changing the probe type will discard the unsaved {ChannelConfiguration.ProbeName} configuration. Do you want to continue?",
-                    "Import File",
+                    $"{ProbeName}: Changing Probe Type",
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning);
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix1.Design
         internal bool HasChanges
         {
             get => ChannelConfiguration.HasChanges;
-            private set => ChannelConfiguration.HasChanges = value;
+            set => ChannelConfiguration.HasChanges = value;
         }
 
         internal NeuropixelsV2ProbeConfiguration ProbeConfiguration
@@ -36,6 +36,8 @@ namespace OpenEphys.Onix1.Design
             get => ChannelConfiguration.ProbeGroup as NeuropixelsV2eProbeGroup;
             set => ChannelConfiguration.ProbeGroup = value;
         }
+
+        internal string ProbeName => ChannelConfiguration.ProbeName;
 
         INeuropixelsV2ProbeInfo ProbeInfo { get; set; }
 
@@ -471,6 +473,11 @@ namespace OpenEphys.Onix1.Design
         internal bool ProcessMenuShortcut(Keys keyData)
         {
             return ChannelConfiguration.Visible && ChannelConfiguration.ProcessMenuShortcut(keyData);
+        }
+
+        internal bool OpenProbeInterfaceFile(string fileName)
+        {
+            return ChannelConfiguration.OpenFile(fileName);
         }
 
         void DialogClosing(object sender, FormClosingEventArgs e)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -13,7 +13,7 @@ namespace OpenEphys.Onix1.Design
     /// </summary>
     public partial class NeuropixelsV2eProbeConfigurationDialog : Form
     {
-        readonly NeuropixelsV2eChannelConfigurationDialog ChannelConfiguration;
+        internal readonly NeuropixelsV2eChannelConfigurationDialog ChannelConfiguration;
 
         internal event EventHandler OnStateChange;
         internal event EventHandler OnProbeConfigurationChange;
@@ -331,7 +331,7 @@ namespace OpenEphys.Onix1.Design
             HasChanges = true;
         }
 
-        void CheckForExistingChannelPreset()
+        internal void CheckForExistingChannelPreset()
         {
             comboBoxChannelPresets.SelectedItem = ProbeInfo.CheckForExistingChannelPreset(ProbeGroup.ChannelMap);
         }
@@ -363,7 +363,14 @@ namespace OpenEphys.Onix1.Design
                 return;
             }
 
-            ChannelConfiguration.Visible = gainCorrection.HasValue;
+            bool isChannelConfigVisible = gainCorrection.HasValue;
+            ChannelConfiguration.Visible = isChannelConfigVisible;
+            comboBoxChannelPresets.Enabled = isChannelConfigVisible;
+
+            if (!isChannelConfigVisible)
+            {
+                DeselectContacts();
+            }
 
             textBoxGainCorrection.Text = gainCorrection.HasValue
                                          ? gainCorrection.Value.GainCorrectionFactor.ToString()
@@ -475,6 +482,11 @@ namespace OpenEphys.Onix1.Design
             return ChannelConfiguration.Visible && ChannelConfiguration.ProcessMenuShortcut(keyData);
         }
 
+        internal ChannelConfigurationDialog.SaveResult SaveProbeInterfaceFile(string fileName)
+        {
+            return ChannelConfiguration.SaveFile(fileName);
+        }
+
         internal bool OpenProbeInterfaceFile(string fileName)
         {
             return ChannelConfiguration.OpenFile(fileName);
@@ -482,7 +494,12 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            ChannelConfiguration.Close();
+            if (HasChanges && this.HandleTopLevelDialogCancel(ref e, ChannelConfigurationDialog.ProbeConfigurationConfirmMessage))
+            {
+                return;
+            }
+
+            ChannelConfiguration.CloseWithResult(this);
 
             if (!ChannelConfiguration.IsDisposed)
             {

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -76,6 +76,7 @@ namespace OpenEphys.Onix1.Design
 
             ChannelConfiguration.OnZoom += UpdateTrackBarLocation;
             ChannelConfiguration.OnFileLoad += OnFileLoadEvent;
+            ChannelConfiguration.OnFileImport += (sender, e) => CheckForExistingChannelPreset();
             ChannelConfiguration.OnProbeConfigurationChanged += (sender, e) =>
             {
                 ProbeConfigurationChanged();

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -482,9 +482,6 @@ namespace OpenEphys.Onix1.Design
 
         void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            if (DialogResult == DialogResult.Cancel || (string.IsNullOrEmpty(ProbeConfiguration.ProbeInterfaceFileName) && string.IsNullOrEmpty(ProbeConfiguration.GainCalibrationFileName)))
-                return;
-
             ChannelConfiguration.Close();
 
             if (!ChannelConfiguration.IsDisposed)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -170,8 +170,30 @@ namespace OpenEphys.Onix1.Design
             OnPropertyValueChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        private void ProbeTypeChanged(object sender, EventArgs e)
+        void RevertProbeType()
         {
+            comboBoxProbeType.SelectedIndexChanged -= ProbeTypeChanged;
+            comboBoxProbeType.SelectedItem = GetCurrentProbeType(ProbeConfiguration);
+            comboBoxProbeType.SelectedIndexChanged += ProbeTypeChanged;
+        }
+
+        void ProbeTypeChanged(object sender, EventArgs e)
+        {
+            if (HasChanges)
+            {
+                var result = MessageBox.Show(
+                    $"Warning: Changing the probe type will discard the unsaved {ChannelConfiguration.ProbeName} configuration. Do you want to continue?",
+                    "Import File",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Warning);
+
+                if (result == DialogResult.No)
+                {
+                    RevertProbeType();
+                    return;
+                }
+            }
+
             UpdateProbeConfiguration();
         }
 
@@ -213,9 +235,7 @@ namespace OpenEphys.Onix1.Design
             if (!ChannelConfiguration.UpdateProbeConfiguration(probeConfigurations[probeType], GetProbeGroupType(probeType)))
             {
                 // NB: If the update fails, revert to the previous probe type selection to avoid inconsistencies in the GUI
-                comboBoxProbeType.SelectedIndexChanged -= ProbeTypeChanged;
-                comboBoxProbeType.SelectedItem = GetCurrentProbeType(ProbeConfiguration);
-                comboBoxProbeType.SelectedIndexChanged += ProbeTypeChanged;
+                RevertProbeType();
                 return;
             }
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -124,37 +124,11 @@ namespace OpenEphys.Onix1.Design
                 nameof(configuration.Reference),
                 false,
                 DataSourceUpdateMode.OnPropertyChanged);
-            comboBoxReference.SelectedIndexChanged += (sender, e) =>
-            {
-                // NB: Needed to capture mouse scroll wheel updates
-                var control = sender as Control;
-
-                foreach (Binding binding in control.DataBindings)
-                {
-                    binding.WriteValue();
-                }
-
-                bindingSource.ResetCurrentItem();
-                PropertyValueChanged();
-            };
+            comboBoxReference.SelectedIndexChanged += SelectedReferenceChanged;
 
             comboBoxChannelPresets.DataSource = ProbeInfo.GetComboBoxChannelPresets();
             CheckForExistingChannelPreset();
-            comboBoxChannelPresets.SelectedIndexChanged += (sender, e) =>
-            {
-                try
-                {
-                    Enum channelPreset = ((ComboBox)sender).SelectedItem as Enum ?? throw new InvalidEnumArgumentException("Invalid argument given for the channel preset.");
-                    ProbeGroup.SelectElectrodes(ProbeInfo.GetChannelPreset(channelPreset));
-                }
-                catch (InvalidEnumArgumentException ex)
-                {
-                    MessageBox.Show(ex.Message, "Invalid Preset Chosen");
-                    return;
-                }
-
-                UpdateProbeGroup();
-            };
+            comboBoxChannelPresets.SelectedIndexChanged += SelectedChannelPresetChanged;
 
             checkBoxInvertPolarity.DataBindings.Add("Checked",
                 bindingSource,
@@ -248,6 +222,11 @@ namespace OpenEphys.Onix1.Design
             CheckForExistingChannelPreset();
             comboBoxChannelPresets.SelectedIndexChanged += SelectedChannelPresetChanged;
 
+            comboBoxReference.SelectedIndexChanged -= SelectedReferenceChanged;
+            comboBoxReference.DataSource = ProbeInfo.GetReferenceEnumValues();
+            comboBoxReference.SelectedItem = ProbeConfiguration.Reference;
+            comboBoxReference.SelectedIndexChanged += SelectedReferenceChanged;
+
             bindingSource.DataSource = ProbeConfiguration;
             propertyGrid.SelectedObject = ProbeConfiguration;
 
@@ -273,14 +252,32 @@ namespace OpenEphys.Onix1.Design
 
         private void SelectedReferenceChanged(object sender, EventArgs e)
         {
-            ProbeConfiguration.Reference = (Enum)((ComboBox)sender).SelectedItem;
+            var comboBox = sender as ComboBox;
+            ProbeConfiguration.Reference = (Enum)comboBox.SelectedItem;
+
+            foreach (Binding binding in comboBox.DataBindings)
+            {
+                binding.WriteValue();
+            }
+
+            bindingSource.ResetCurrentItem();
+            PropertyValueChanged();
         }
 
-        private void SelectedChannelPresetChanged(object sender, EventArgs e)
+        void SelectedChannelPresetChanged(object sender, EventArgs e)
         {
-            Enum channelPreset = ((ComboBox)sender).SelectedItem as Enum ?? throw new InvalidEnumArgumentException("Invalid argument given for the channel preset.");
+            try
+            {
+                Enum channelPreset = ((ComboBox)sender).SelectedItem as Enum ?? throw new InvalidEnumArgumentException("Invalid argument given for the channel preset.");
+                SetChannelPreset(channelPreset);
+            }
+            catch (InvalidEnumArgumentException ex)
+            {
+                MessageBox.Show(ex.Message, "Invalid Preset Chosen");
+                return;
+            }
 
-            SetChannelPreset(channelPreset);
+            UpdateProbeGroup();
         }
 
         void SetChannelPreset(Enum channelPreset)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -236,12 +237,22 @@ namespace OpenEphys.Onix1.Design
             CheckStatus();
         }
 
+        internal Color PanelBorderColor { get; set; } = Color.Black;
+
         private void FormShown(object sender, EventArgs e)
         {
             if (!TopLevel)
             {
                 tableLayoutPanel1.Controls.Remove(flowLayoutPanel1);
                 tableLayoutPanel1.RowCount = 1;
+
+                ChannelConfiguration.panel.BorderStyle = BorderStyle.None;
+                ChannelConfiguration.panel.Paint += (sender, e) =>
+                {
+                    var panel = sender as Panel;
+                    var graphics = e.Graphics;
+                    ControlPaint.DrawBorder(graphics, panel.ClientRectangle, PanelBorderColor, ButtonBorderStyle.Solid);
+                };
             }
 
             splitContainer1.SplitterDistance = splitContainer1.Size.Width - splitContainer1.Panel2MinSize;

--- a/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
@@ -13,7 +13,6 @@ namespace OpenEphys.Onix1.Design
     {
         internal event EventHandler OnSelect;
         internal event EventHandler OnZoom;
-        internal event EventHandler OnFileLoad;
 
         /// <summary>
         /// Initializes a new instance of <see cref="Rhs2116ChannelConfigurationDialog"/>.
@@ -37,33 +36,9 @@ namespace OpenEphys.Onix1.Design
             RefreshZedGraph();
         }
 
-        internal override void LoadDefaultChannelLayout()
-        {
-            base.LoadDefaultChannelLayout();
-
-            OnFileOpenHandler();
-        }
-
         internal override ProbeGroup DefaultChannelLayout()
         {
             return new Rhs2116ProbeGroup();
-        }
-
-        internal override bool OpenNewFile(bool updateFileName = false)
-        {
-            if (base.OpenNewFile(updateFileName))
-            {
-                OnFileOpenHandler();
-
-                return true;
-            }
-
-            return false;
-        }
-
-        void OnFileOpenHandler()
-        {
-            OnFileLoad?.Invoke(this, EventArgs.Empty);
         }
 
         internal override void SelectedContactChanged()

--- a/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/Rhs2116ChannelConfigurationDialog.cs
@@ -32,6 +32,8 @@ namespace OpenEphys.Onix1.Design
             ZoomInBoundaryX = 2;
             ZoomInBoundaryY = 2;
 
+            panel.BorderStyle = BorderStyle.None;
+
             DrawProbeGroup();
             RefreshZedGraph();
         }

--- a/OpenEphys.Onix1.Design/ScaledChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ScaledChannelConfigurationDialog.cs
@@ -141,7 +141,7 @@ namespace OpenEphys.Onix1.Design
 
         internal override void ResizeAxes()
         {
-            const float ScalingFactor = 1.15f;
+            const float ScalingFactor = 1.10f;
             RectangleF rect = zedGraphChannels.MasterPane.Rect;
 
             float width = rect.Width;

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using System.Reactive.Disposables;
 using System.Threading;
 using Bonsai;
@@ -145,10 +146,12 @@ namespace OpenEphys.Onix1
 
             return source.ConfigureAndLatchDevice(context =>
             {
-                if (string.IsNullOrEmpty(probeConfiguration.ProbeInterfaceFileName))
-                    throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV1e)}.{nameof(ProbeConfiguration)}.");
+                NeuropixelsV1eProbeGroup probeGroup = new();
 
-                var probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                if (File.Exists(probeConfiguration.ProbeInterfaceFileName))
+                {
+                    probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                }
 
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using Bonsai;
 
 namespace OpenEphys.Onix1
@@ -155,10 +156,10 @@ namespace OpenEphys.Onix1
 
                 if (enable)
                 {
-                    if (string.IsNullOrEmpty(probeConfiguration.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV1f)}.{nameof(ProbeConfiguration)}.");
-
-                    probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                    if (File.Exists(probeConfiguration.ProbeInterfaceFileName))
+                    {
+                        probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                    }
 
                     var probeControl = new NeuropixelsV1fRegisterContext(device, probeConfiguration, probeGroup);
                     probeControl.InitializeProbe();

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -99,7 +99,7 @@ namespace OpenEphys.Onix1
         {
             return false;
         }
-        
+
         /// <summary>
         /// Gets or sets the <see cref="ProbeConfigurationA"/> property.
         /// </summary>
@@ -189,8 +189,8 @@ namespace OpenEphys.Onix1
 
             return source.ConfigureAndLatchDevice(context =>
             {
-                NeuropixelsV2eProbeGroup probeGroupA = null;
-                NeuropixelsV2eProbeGroup probeGroupB = null;
+                NeuropixelsV2eProbeGroup probeGroupA = new NeuropixelsV2eQuadShankProbeGroup();
+                NeuropixelsV2eProbeGroup probeGroupB = new NeuropixelsV2eQuadShankProbeGroup();
 
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
@@ -226,10 +226,10 @@ namespace OpenEphys.Onix1
 
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationA.GainCalibrationFileName);
 
-                    if (string.IsNullOrEmpty(probeConfigurationA.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2e)}.{nameof(ProbeConfigurationA)}.");
-
-                    probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, probeConfigurationA.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    if (File.Exists(probeConfigurationA.ProbeInterfaceFileName))
+                    {
+                        probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, probeConfigurationA.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    }
 
                     if (!gainCorrection.HasValue)
                     {
@@ -259,10 +259,10 @@ namespace OpenEphys.Onix1
 
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationB.GainCalibrationFileName);
 
-                    if (string.IsNullOrEmpty(probeConfigurationB.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2e)}.{nameof(ProbeConfigurationB)}.");
-
-                    probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, probeConfigurationB.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    if (File.Exists(probeConfigurationB.ProbeInterfaceFileName))
+                    {
+                        probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, probeConfigurationB.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    }
 
                     if (!gainCorrection.HasValue)
                     {

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -200,8 +200,8 @@ namespace OpenEphys.Onix1
 
             return source.ConfigureAndLatchDevice(context =>
             {
-                NeuropixelsV2eProbeGroup probeGroupA = null;
-                NeuropixelsV2eProbeGroup probeGroupB = null;
+                NeuropixelsV2eProbeGroup probeGroupA = new NeuropixelsV2eQuadShankProbeGroup();
+                NeuropixelsV2eProbeGroup probeGroupB = new NeuropixelsV2eQuadShankProbeGroup();
 
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
@@ -245,9 +245,11 @@ namespace OpenEphys.Onix1
                             $" for {NeuropixelsV2Probe.ProbeA}.");
                     }
 
-                    if (string.IsNullOrEmpty(probeConfigurationA.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2eBeta)}.{nameof(probeConfigurationA)}.");
-                        
+                    if (File.Exists(probeConfigurationA.ProbeInterfaceFileName))
+                    {
+                        probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
+                    }
+
                     if (!File.Exists(probeConfigurationA.GainCalibrationFileName))
                     {
                         throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeA} with serial number {probeAMetadata.ProbeSerialNumber}");
@@ -268,8 +270,6 @@ namespace OpenEphys.Onix1
 
                     gainCorrectionA = gainCorrection.Value.GainCorrectionFactor;
 
-                    probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
-
                     SelectProbe(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeA);
                     probeControl.WriteConfiguration(probeConfigurationA, probeGroupA);
                     ConfigureProbeStreaming(probeControl);
@@ -284,9 +284,11 @@ namespace OpenEphys.Onix1
                             $" for {NeuropixelsV2Probe.ProbeB}.");
                     }
 
-                    if (string.IsNullOrEmpty(probeConfigurationB.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2eBeta)}.{nameof(probeConfigurationB)}.");
-                        
+                    if (File.Exists(probeConfigurationB.ProbeInterfaceFileName))
+                    {
+                        probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
+                    }
+
                     if (!File.Exists(probeConfigurationB.GainCalibrationFileName))
                     {
                         throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeB} with serial number {probeBMetadata.ProbeSerialNumber}");
@@ -306,8 +308,6 @@ namespace OpenEphys.Onix1
                     }
 
                     gainCorrectionB = gainCorrection.Value.GainCorrectionFactor;
-
-                    probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
 
                     SelectProbe(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeB);
                     probeControl.WriteConfiguration(probeConfigurationB, probeGroupB);

--- a/OpenEphys.Onix1/JsonHelper.cs
+++ b/OpenEphys.Onix1/JsonHelper.cs
@@ -49,7 +49,7 @@ namespace OpenEphys.Onix1
         public static void SerializeObject(object obj, string filepath)
         {
             if (string.IsNullOrEmpty(filepath))
-                return;
+                throw new IOException("A filepath is required to serialize the object.");
 
             var serializerSettings = new JsonSerializerSettings()
             {


### PR DESCRIPTION
While testing the dialogs, several blocking issues were discovered regarding the performance of the dialogs, specifically the NeuropixelsV2 dialogs. These changes were introduced in PR #583, and were the result of incorrectly resolving merge conflicts. Not enough care was taken in testing that PR to ensure that previous functionality (specifically from PR #588) was maintained, which is my fault.

This PR resolves the following issues, as well as implementing some QoL improvements to minimize flickering.
- Keyboard shortcuts were no longer functional for NeuropixelsV2 dialogs
- Events were being handled by more than one handler, and one of them was an anonymous method that could not be detached to avoid side effects
- Small UI improvements:
  - Changed the label "Probe Calibration File" to "Gain Calibration File" for consistency and clarity
  - Tooltips were not showing up for the ProbeInterface file name
  - Added a border around the ChannelConfigurationDialog to visually distinguish the menu strip from surrounding controls
- File Opening and File Importing were being handled by the same function with a flag, leading to undesired behavior and incorrect events being triggered
- Changing probe types would lead to any unsaved changes being silently discarded

Fixes #610 