### PR TITLE
Allow Neuropixels probes to run without a ProbeInterface file

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using System.Reactive.Disposables;
 using System.Threading;
 using Bonsai;
@@ -145,10 +146,12 @@ namespace OpenEphys.Onix1
 
             return source.ConfigureAndLatchDevice(context =>
             {
-                if (string.IsNullOrEmpty(probeConfiguration.ProbeInterfaceFileName))
-                    throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV1e)}.{nameof(ProbeConfiguration)}.");
+                NeuropixelsV1eProbeGroup probeGroup = new();
 
-                var probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                if (File.Exists(probeConfiguration.ProbeInterfaceFileName))
+                {
+                    probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                }
 
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1f.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using Bonsai;
 
 namespace OpenEphys.Onix1
@@ -155,10 +156,10 @@ namespace OpenEphys.Onix1
 
                 if (enable)
                 {
-                    if (string.IsNullOrEmpty(probeConfiguration.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV1f)}.{nameof(ProbeConfiguration)}.");
-
-                    probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                    if (File.Exists(probeConfiguration.ProbeInterfaceFileName))
+                    {
+                        probeGroup = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfiguration.ProbeInterfaceFileName, typeof(NeuropixelsV1eProbeGroup)) as NeuropixelsV1eProbeGroup;
+                    }
 
                     var probeControl = new NeuropixelsV1fRegisterContext(device, probeConfiguration, probeGroup);
                     probeControl.InitializeProbe();

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -99,7 +99,7 @@ namespace OpenEphys.Onix1
         {
             return false;
         }
-        
+
         /// <summary>
         /// Gets or sets the <see cref="ProbeConfigurationA"/> property.
         /// </summary>
@@ -189,8 +189,8 @@ namespace OpenEphys.Onix1
 
             return source.ConfigureAndLatchDevice(context =>
             {
-                NeuropixelsV2eProbeGroup probeGroupA = null;
-                NeuropixelsV2eProbeGroup probeGroupB = null;
+                NeuropixelsV2eProbeGroup probeGroupA = new NeuropixelsV2eQuadShankProbeGroup();
+                NeuropixelsV2eProbeGroup probeGroupB = new NeuropixelsV2eQuadShankProbeGroup();
 
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
@@ -226,10 +226,10 @@ namespace OpenEphys.Onix1
 
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationA.GainCalibrationFileName);
 
-                    if (string.IsNullOrEmpty(probeConfigurationA.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2e)}.{nameof(ProbeConfigurationA)}.");
-
-                    probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, probeConfigurationA.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    if (File.Exists(probeConfigurationA.ProbeInterfaceFileName))
+                    {
+                        probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, probeConfigurationA.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    }
 
                     if (!gainCorrection.HasValue)
                     {
@@ -259,10 +259,10 @@ namespace OpenEphys.Onix1
 
                     var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(probeConfigurationB.GainCalibrationFileName);
 
-                    if (string.IsNullOrEmpty(probeConfigurationB.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2e)}.{nameof(ProbeConfigurationB)}.");
-
-                    probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, probeConfigurationB.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    if (File.Exists(probeConfigurationB.ProbeInterfaceFileName))
+                    {
+                        probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, probeConfigurationB.GetProbeGroupType()) as NeuropixelsV2eProbeGroup;
+                    }
 
                     if (!gainCorrection.HasValue)
                     {

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -200,8 +200,8 @@ namespace OpenEphys.Onix1
 
             return source.ConfigureAndLatchDevice(context =>
             {
-                NeuropixelsV2eProbeGroup probeGroupA = null;
-                NeuropixelsV2eProbeGroup probeGroupB = null;
+                NeuropixelsV2eProbeGroup probeGroupA = new NeuropixelsV2eQuadShankProbeGroup();
+                NeuropixelsV2eProbeGroup probeGroupB = new NeuropixelsV2eQuadShankProbeGroup();
 
                 // configure device via the DS90UB9x deserializer device
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
@@ -245,9 +245,11 @@ namespace OpenEphys.Onix1
                             $" for {NeuropixelsV2Probe.ProbeA}.");
                     }
 
-                    if (string.IsNullOrEmpty(probeConfigurationA.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2eBeta)}.{nameof(probeConfigurationA)}.");
-                        
+                    if (File.Exists(probeConfigurationA.ProbeInterfaceFileName))
+                    {
+                        probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
+                    }
+
                     if (!File.Exists(probeConfigurationA.GainCalibrationFileName))
                     {
                         throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeA} with serial number {probeAMetadata.ProbeSerialNumber}");
@@ -268,8 +270,6 @@ namespace OpenEphys.Onix1
 
                     gainCorrectionA = gainCorrection.Value.GainCorrectionFactor;
 
-                    probeGroupA = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationA.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
-
                     SelectProbe(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeA);
                     probeControl.WriteConfiguration(probeConfigurationA, probeGroupA);
                     ConfigureProbeStreaming(probeControl);
@@ -284,9 +284,11 @@ namespace OpenEphys.Onix1
                             $" for {NeuropixelsV2Probe.ProbeB}.");
                     }
 
-                    if (string.IsNullOrEmpty(probeConfigurationB.ProbeInterfaceFileName))
-                        throw new ArgumentException($"ProbeInterface file name must be specified in {nameof(ConfigureNeuropixelsV2eBeta)}.{nameof(probeConfigurationB)}.");
-                        
+                    if (File.Exists(probeConfigurationB.ProbeInterfaceFileName))
+                    {
+                        probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
+                    }
+
                     if (!File.Exists(probeConfigurationB.GainCalibrationFileName))
                     {
                         throw new ArgumentException($"A gain calibration file must be specified for {NeuropixelsV2Probe.ProbeB} with serial number {probeBMetadata.ProbeSerialNumber}");
@@ -306,8 +308,6 @@ namespace OpenEphys.Onix1
                     }
 
                     gainCorrectionB = gainCorrection.Value.GainCorrectionFactor;
-
-                    probeGroupB = ProbeInterfaceHelper.LoadExternalProbeInterfaceFile(probeConfigurationB.ProbeInterfaceFileName, typeof(NeuropixelsV2eQuadShankProbeGroup)) as NeuropixelsV2eProbeGroup;
 
                     SelectProbe(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeB);
                     probeControl.WriteConfiguration(probeConfigurationB, probeGroupB);


### PR DESCRIPTION
- Loads the default configuration, which is typically the first 384 channels enabled
- For NeuropixelsV2e, the default probe type is the quad-shank 2.0 probe