### PR TITLE
FrameWriter

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/Bno055DataFrame.cs
+++ b/OpenEphys.Onix1/Bno055DataFrame.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using OpenEphys.Onix1.FrameWriter;
 
 namespace OpenEphys.Onix1
 {
@@ -76,6 +77,7 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Gets the 3D orientation represented as a Quaternion.
         /// </summary>
+        [FrameWriterIgnoreMembers(MemberType.Properties)]
         public Quaternion Quaternion { get; }
 
         /// <summary>

--- a/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/ArrowBatchWriter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using Apache.Arrow;
+
+namespace OpenEphys.Onix1.FrameWriter
+{
+    /// <summary>
+    /// Provides buffered writing of items to an Arrow file, batching items before writing.
+    /// </summary>
+    /// <typeparam name="T">The type of items to be written and batched.</typeparam>
+    public class ArrowBatchWriter<T> : ArrowWriter
+    {
+        readonly int bufferSize;
+        readonly List<T> buffer;
+        readonly Func<IList<T>, Schema, RecordBatch> createRecordBatch;
+        readonly Schema schema;
+
+        /// <summary>
+        /// Initializes a new instance of the ArrowBatchWriter class with the specified output file, schema, buffer
+        /// size, and record batch creation delegate.
+        /// </summary>
+        /// <param name="filename">The path to the output file.</param>
+        /// <param name="schema">The schema describing the structure of the data.</param>
+        /// <param name="bufferSize">The maximum number of items to buffer before writing a batch.</param>
+        /// <param name="createRecordBatch">A delegate to create a RecordBatch from a list of items and a schema.</param>
+        public ArrowBatchWriter(string filename, Schema schema, int bufferSize, Func<IList<T>, Schema, RecordBatch> createRecordBatch)
+            : base(filename, schema)
+        {
+            this.schema = schema;
+            this.bufferSize = bufferSize;
+            buffer = new(bufferSize);
+            this.createRecordBatch = createRecordBatch;
+        }
+
+        /// <summary>
+        /// Adds an item to the buffer and flushes the buffer when it reaches its maximum size.
+        /// </summary>
+        /// <param name="item">The item to add to the buffer.</param>
+        public void Write(T item)
+        {
+            buffer.Add(item);
+
+            if (buffer.Count >= bufferSize)
+            {
+                Flush();
+            }
+        }
+
+        /// <summary>
+        /// Writes any buffered records as a batch and clears the buffer.
+        /// </summary>
+        public void Flush()
+        {
+            if (buffer.Count > 0)
+            {
+                var recordBatch = createRecordBatch(buffer, schema);
+                base.Write(recordBatch);
+                buffer.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Releases resources used by the object and flushes any buffered data.
+        /// </summary>
+        public override void Dispose()
+        {
+            if (!disposed)
+            {
+                Flush();
+                base.Dispose();
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix1/FrameWriter/ArrowWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/ArrowWriter.cs
@@ -1,0 +1,58 @@
+﻿using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using System;
+using System.IO;
+
+namespace OpenEphys.Onix1.FrameWriter
+{
+    /// <summary>
+    /// Writes Apache Arrow record batches to a stream.
+    /// </summary>
+    public class ArrowWriter : IDisposable
+    {
+        readonly Stream stream = null;
+        readonly ArrowFileWriter writer = null;
+
+        private protected bool disposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of the ArrowWriter class using the specified stream.
+        /// </summary>
+        /// <param name="filename">The name of the file on which the elements should be written.</param>
+        /// <param name="schema">A <see cref="Schema"/> that defines the current file.</param>
+        public ArrowWriter(string filename, Schema schema)
+        {
+            stream = new FileStream(filename, FileMode.Create);
+            writer = new(stream, schema);
+            writer.WriteStart();
+        }
+
+        /// <summary>
+        /// Writes the specified record batch to the underlying stream.
+        /// </summary>
+        /// <param name="batch">The record batch to write.</param>
+        public void Write(RecordBatch batch)
+        {
+            writer.WriteRecordBatch(batch);
+        }
+
+        /// <summary>
+        /// Releases the resources used by the instance.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            if (!disposed)
+            {
+                if (writer != null)
+                {
+                    writer.WriteEnd();
+                    writer.Dispose();
+                }
+
+                stream?.Dispose();
+
+                disposed = true;
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriter.cs
@@ -1,0 +1,773 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Reflection;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using Bonsai;
+using Bonsai.IO;
+using OpenCV.Net;
+
+namespace OpenEphys.Onix1.FrameWriter
+{
+    /// <summary>
+    /// Represents an operator that writes each data frame in the sequence
+    /// to an Apache Arrow file using an <see cref="ArrowWriter"/>.
+    /// </summary>
+    [WorkflowElementCategory(ElementCategory.Sink)]
+    public class FrameWriter : FileSink
+    {
+        static readonly ConstructorInfo recordBatchConstructor = typeof(RecordBatch)
+            .GetConstructor(
+                BindingFlags.Instance | BindingFlags.Public,
+                null,
+                new Type[] { typeof(Schema), typeof(IArrowArray[]), typeof(int) },
+                null);
+
+        class BufferedDataFrameSink : FileSink<RecordBatch, ArrowWriter>
+        {
+            protected override ArrowWriter CreateWriter(string filename, RecordBatch batch)
+            {
+                return new ArrowWriter(filename, batch.Schema);
+            }
+
+            protected override void Write(ArrowWriter writer, RecordBatch input)
+            {
+                writer.Write(input);
+            }
+
+            public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source, Func<BufferedDataFrame, RecordBatch> selector)
+            {
+                return base.Process(source, selector);
+            }
+        }
+
+        BufferedDataFrameSink CreateBufferedDataFrameSink()
+        {
+            return new BufferedDataFrameSink
+            {
+                FileName = this.FileName,
+                Suffix = this.Suffix,
+                Buffered = this.Buffered,
+                Overwrite = this.Overwrite
+            };
+        }
+
+        /// <summary>
+        /// Writes all of the data frames in the sequence to an Apache Arrow file.
+        /// </summary>
+        /// <param name="source">The sequence of <see cref="BufferedDataFrame">BufferedDataFrame's</see> to write.</param>
+        /// <returns>
+        /// An observable sequence that is identical to the source sequence but where
+        /// there is an additional side effect of writing the frames to an Apache Arrow file.
+        /// </returns>
+        public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source)
+        {
+            Schema schema = null;
+            Func<BufferedDataFrame, Schema, RecordBatch> createRecordBatch = null;
+
+            return source.Replay(frames => Observable.Concat(
+                frames.Take(1)
+                    .Do(frame =>
+                    {
+                        var frameType = frame.GetType();
+                        var members = GetDataMembers(frameType);
+                        schema = GenerateSchema(members, frame);
+                        createRecordBatch = CreateBufferedFrameRecordBatchBuilder(frameType, members).Compile();
+                    })
+                    .IgnoreElements(),
+                Observable.Defer(() => CreateBufferedDataFrameSink().Process(
+                    frames,
+                    frame => createRecordBatch(frame, schema)
+                ))
+            ), 1);
+        }
+
+        class DataFrameSink : FileSink<DataFrame, ArrowBatchWriter<DataFrame>>
+        {
+            readonly Schema schema;
+            readonly Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch;
+            readonly int bufferSize;
+
+            public DataFrameSink(
+                Schema schema,
+                Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch,
+                int bufferSize)
+            {
+                this.schema = schema;
+                this.createRecordBatch = createRecordBatch;
+                this.bufferSize = bufferSize;
+            }
+
+            protected override ArrowBatchWriter<DataFrame> CreateWriter(string filename, DataFrame frame)
+            {
+                return new ArrowBatchWriter<DataFrame>(filename, schema, bufferSize, createRecordBatch);
+            }
+
+            protected override void Write(ArrowBatchWriter<DataFrame> writer, DataFrame input)
+            {
+                writer.Write(input);
+            }
+        }
+
+        DataFrameSink CreateDataFrameSink(
+            Schema schema,
+            Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch,
+            int bufferSize)
+        {
+            return new DataFrameSink(schema, createRecordBatch, bufferSize)
+            {
+                FileName = this.FileName,
+                Suffix = this.Suffix,
+                Buffered = this.Buffered,
+                Overwrite = this.Overwrite
+            };
+        }
+
+        /// <summary>
+        /// Writes all of the data frames in the sequence to an Apache Arrow file.
+        /// </summary>
+        /// <param name="source">The sequence of <see cref="DataFrame">DataFrame's</see> to write.</param>
+        /// <returns>
+        /// An observable sequence that is identical to the source sequence but where
+        /// there is an additional side effect of writing the frames to an Apache Arrow file.
+        /// </returns>
+        public IObservable<DataFrame> Process(IObservable<DataFrame> source)
+        {
+            const int BufferSize = 50;
+            Schema schema = null;
+            Func<IList<DataFrame>, Schema, RecordBatch> createRecordBatch = null;
+
+            return source.Replay(frames => Observable.Concat(
+                frames.Take(1)
+                    .Do(frame =>
+                    {
+                        var frameType = frame.GetType();
+                        var members = GetDataMembers(frameType);
+                        schema = GenerateSchema(members, frame);
+                        createRecordBatch = CreateDataFrameRecordBatchBuilder(frameType, members).Compile();
+                    })
+                    .IgnoreElements(),
+                Observable.Defer(() => CreateDataFrameSink(schema, createRecordBatch, BufferSize).Process(frames))
+            ), 1);
+        }
+
+        static IEnumerable<MemberInfo> GetDataMembers(Type type)
+        {
+            var members = Enumerable.Concat<MemberInfo>(
+                type.GetFields(BindingFlags.Instance | BindingFlags.Public),
+                type.GetProperties(BindingFlags.Instance | BindingFlags.Public));
+
+            return members
+                .Where(prop => prop.GetCustomAttribute(typeof(FrameWriterIgnoreAttribute)) == null)
+                .OrderBy(member => member.MetadataToken);
+        }
+
+        static bool IsMemberIgnored(MemberInfo rootMember, MemberInfo member)
+        {
+            var attr = rootMember.GetCustomAttribute<FrameWriterIgnoreMembersAttribute>();
+
+            if (attr == null)
+                return false;
+
+            if (attr.MemberType.HasFlag(MemberType.Properties) && member is PropertyInfo)
+                return true;
+
+            else if (attr.MemberType.HasFlag(MemberType.Fields) && member is FieldInfo)
+                return true;
+
+            return false;
+        }
+
+        class MemberNode
+        {
+            public MemberInfo Member { get; set; }
+            public MemberNode Parent { get; set; }
+
+            public IEnumerable<MemberInfo> GetPath()
+            {
+                var current = this;
+                while (current != null)
+                {
+                    yield return current.Member;
+                    current = current.Parent;
+                }
+            }
+
+            public string GetFullName()
+            {
+                return string.Join("_", GetPath().Select(m => m.Name).Reverse());
+            }
+        }
+
+        static Schema GenerateSchema(IEnumerable<MemberInfo> members, object instance)
+        {
+            var fields = new List<Field>();
+            var stack = new Stack<MemberNode>(members.Select(m => new MemberNode { Member = m }));
+
+            while (stack.Count > 0)
+            {
+                var current = stack.Pop();
+                var memberType = GetMemberType(current.Member);
+
+                if (memberType.IsPrimitive)
+                {
+                    fields.Add(new Field(current.GetFullName(), GetArrowType(memberType), false));
+                }
+                else if (memberType.IsArray)
+                {
+                    fields.Add(new Field(current.GetFullName(), GetArrowType(memberType.GetElementType()), false));
+                }
+                else if (memberType.IsEnum)
+                {
+                    // TODO: See if the Dictionary type in Arrow would be better for enums
+                    fields.Add(new Field(current.GetFullName(), GetArrowType(Enum.GetUnderlyingType(memberType)), false));
+                }
+                else if (memberType.IsValueType)
+                {
+                    var structMembers = GetDataMembers(memberType);
+
+                    foreach (var structMember in structMembers.Reverse())
+                    {
+                        if (IsMemberIgnored(current.Member, structMember))
+                            continue;
+
+                        stack.Push(new MemberNode
+                        {
+                            Member = structMember,
+                            Parent = current
+                        });
+                    }
+                }
+                else if (memberType == typeof(Mat))
+                {
+                    var mat = GetMemberValue(current.Member, instance) as Mat ?? throw new NullReferenceException($"No valid Mat property on the {instance.GetType()} object.");
+
+                    for (int i = 0; i < mat.Rows; i++)
+                    {
+                        // Note: Could add an attribute to data frames properties to specify custom field naming
+                        fields.Add(new Field($"{current.GetFullName()}Ch{i}", GetArrowType(mat.Depth), false));
+                    }
+                }
+                else
+                {
+                    throw new NotSupportedException($"The member type '{memberType}' is not supported for generating schemas.");
+                }
+            }
+
+            return new Schema(fields, null);
+        }
+
+        static Type GetMemberType(MemberInfo member)
+        {
+            return member switch
+            {
+                FieldInfo fieldInfo => fieldInfo.FieldType,
+                PropertyInfo propertyInfo => propertyInfo.PropertyType,
+                _ => throw new InvalidOperationException($"Unsupported member type ({member.GetType()})."),
+            };
+        }
+
+        static object GetMemberValue(MemberInfo member, object instance)
+        {
+            return member switch
+            {
+                FieldInfo fieldInfo => fieldInfo.GetValue(instance),
+                PropertyInfo propertyInfo => propertyInfo.GetValue(instance),
+                _ => throw new InvalidOperationException($"Cannot get value of {member.GetType()} member from {instance.GetType()} object."),
+            };
+        }
+
+        static readonly Dictionary<Type, IArrowType> ArrowTypeMap = new()
+        {
+            [typeof(byte)] = UInt8Type.Default,
+            [typeof(sbyte)] = Int8Type.Default,
+            [typeof(ushort)] = UInt16Type.Default,
+            [typeof(short)] = Int16Type.Default,
+            [typeof(uint)] = UInt32Type.Default,
+            [typeof(int)] = Int32Type.Default,
+            [typeof(ulong)] = UInt64Type.Default,
+            [typeof(long)] = Int64Type.Default,
+            [typeof(float)] = FloatType.Default,
+            [typeof(double)] = DoubleType.Default,
+            [typeof(bool)] = BooleanType.Default,
+            [typeof(string)] = StringType.Default
+        };
+
+        static IArrowType GetArrowType(Type type) => ArrowTypeMap.TryGetValue(type, out var arrowType)
+            ? arrowType
+            : throw new NotSupportedException($"The type '{type}' is not supported for mapping to an ArrowType.");
+
+        static IArrowType GetArrowType(Depth depth)
+        {
+            return depth switch
+            {
+                Depth.U8 => GetArrowType(typeof(byte)),
+                Depth.S8 => GetArrowType(typeof(sbyte)),
+                Depth.U16 => GetArrowType(typeof(ushort)),
+                Depth.S16 => GetArrowType(typeof(short)),
+                Depth.S32 => GetArrowType(typeof(int)),
+                Depth.F32 => GetArrowType(typeof(float)),
+                Depth.F64 => GetArrowType(typeof(double)),
+                _ => throw new NotSupportedException($"Cannot get the ArrowType for the given depth value '{depth}'.")
+            };
+        }
+
+        static IArrowArray ConvertArrayToArrowArray<T>(T[] array, IArrowType arrowType, int length) where T : unmanaged
+        {
+            var memory = array.AsMemory();
+            var memoryAsBytes = CommunityToolkit.HighPerformance.MemoryExtensions.AsBytes(memory);
+            var arrowBuffer = new ArrowBuffer(memoryAsBytes);
+
+            var arrayData = new ArrayData(
+                arrowType,
+                length,
+                0,
+                0,
+                new[] { ArrowBuffer.Empty, arrowBuffer },
+                null,
+                null
+            );
+
+            return ArrowArrayFactory.BuildArray(arrayData);
+        }
+
+        static ArrowBuffer CreateStrideValidityBitmap(int validCount, int totalCount, int stride)
+        {
+            int byteCount = (totalCount + 7) / 8;
+            byte[] bitmap = new byte[byteCount];
+
+            for (int i = 0; i < validCount; i++)
+            {
+                int bitIndex = i * stride;
+                if (bitIndex >= totalCount) break;
+
+                bitmap[bitIndex >> 3] |= (byte)(1 << (bitIndex & 7));
+            }
+
+            return new ArrowBuffer(bitmap);
+        }
+
+        static unsafe void StrideCopy<T>(void* src, void* dest, int elementCount, int stride) where T : unmanaged
+        {
+            T* srcPtr = (T*)src;
+            T* destPtr = (T*)dest;
+
+            for (int i = 0; i < elementCount; i++)
+            {
+                *destPtr = *srcPtr++;
+                destPtr += stride;
+            }
+        }
+
+        static unsafe IArrowArray ConvertMatRowToArrowArray(Mat mat, int rowIndex, IArrowType elementType, int batchRows)
+        {
+            int length = mat.Cols;
+
+            if (batchRows < length)
+                throw new InvalidOperationException($"The number of batch rows ({batchRows}) is smaller than the number of samples in the Mat ({length}).");
+
+            if (batchRows % length != 0)
+                throw new InvalidOperationException($"The number of batch rows ({batchRows}) must be a multiple of the number of samples in the Mat ({length}).");
+
+            int stride = batchRows / length;
+
+            var rowManager = new MatRowMemoryManager(mat, rowIndex);
+            int nullCount = batchRows - length;
+            ArrowBuffer arrowBuffer;
+            ArrowBuffer nullBitmap;
+
+            if (nullCount == 0)
+            {
+                arrowBuffer = new ArrowBuffer(rowManager.Memory);
+                nullBitmap = ArrowBuffer.Empty;
+            }
+            else
+            {
+                byte[] buffer = new byte[batchRows * mat.ElementSize];
+
+                fixed (byte* bufferPtr = buffer)
+                {
+                    StrideCopy<ushort>(rowManager.Memory.Pin().Pointer, bufferPtr, length, stride);
+                }
+
+                arrowBuffer = new ArrowBuffer(buffer);
+                nullBitmap = CreateStrideValidityBitmap(length, batchRows, stride);
+            }
+
+            var arrayData = new ArrayData(
+                elementType,
+                batchRows,
+                nullCount,
+                0,
+                new[] { nullBitmap, arrowBuffer },
+                null,
+                null
+            );
+
+            return ArrowArrayFactory.BuildArray(arrayData);
+        }
+
+        static Expression InitializeArrowArrayFromSchema(ParameterExpression schema, Expression arrowArrays)
+        {
+            var fieldsList = Expression.Property(schema, nameof(Schema.FieldsList));
+            var fieldsListAsCollection = Expression.Convert(
+                fieldsList,
+                typeof(IReadOnlyCollection<Field>)
+            );
+
+            return Expression.Assign(
+                    arrowArrays,
+                    Expression.NewArrayBounds(
+                        typeof(IArrowArray),
+                        Expression.Property(fieldsListAsCollection, nameof(Schema.FieldsList.Count))
+                    )
+                );
+        }
+
+        static IArrowArray ConvertFrameMemberToArrowArray<TMember>(IList<DataFrame> frames, Func<DataFrame, TMember> getter, IArrowType arrowType, int length) where TMember : unmanaged
+        {
+            var array = new TMember[length];
+
+            for (int i = 0; i < length; i++)
+            {
+                array[i] = getter(frames[i]);
+            }
+
+            return ConvertArrayToArrowArray(array, arrowType, length);
+        }
+
+        static Expression ConvertFrameMemberExpressionBuilder(
+            Type memberType,
+            ParameterExpression frameParameter,
+            ParameterExpression arrowArrays,
+            ParameterExpression arrowArrayIndex,
+            ParameterExpression frames,
+            MemberExpression count,
+            Expression memberAccessor)
+        {
+            var convertFrameMemberMethod = typeof(FrameWriter)
+                        .GetMethod(nameof(ConvertFrameMemberToArrowArray), BindingFlags.Static | BindingFlags.NonPublic)
+                        .MakeGenericMethod(memberType);
+
+            var arrayArrowType = Expression.Constant(GetArrowType(memberType));
+            var getter = Expression.Lambda(
+                            typeof(Func<,>).MakeGenericType(typeof(DataFrame), memberType),
+                            memberAccessor,
+                            frameParameter
+                        ).Compile();
+
+            var block = Expression.Block(
+                Expression.Assign(
+                    Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
+                    Expression.Call(
+                        convertFrameMemberMethod,
+                        frames,
+                        Expression.Constant(getter, getter.GetType()),
+                        arrayArrowType,
+                        count
+                    )
+                ),
+                Expression.PostIncrementAssign(arrowArrayIndex)
+            );
+
+            return block;
+        }
+
+        static MemberExpression CreateMemberAccess(Expression instance, MemberInfo member)
+        {
+            return member is PropertyInfo property
+                ? Expression.Property(instance, property)
+                : Expression.Field(instance, (FieldInfo)member);
+        }
+
+        static MemberExpression CreateMemberAccess(Expression instance, MemberNode member)
+        {
+            if (member.Parent == null)
+                return CreateMemberAccess(instance, member.Member);
+
+            return CreateMemberAccess(CreateMemberAccess(instance, member.Parent), member.Member);
+        }
+
+        interface IRecordBatchExpressionProvider
+        {
+            ParameterExpression InputParameter { get; }
+
+            Expression GetLengthExpression();
+
+            List<Expression> GetArrayPopulationExpressions(
+                ParameterExpression arrowArrays,
+                ParameterExpression arrowArrayIndex,
+                Expression batchRows,
+                Type frameType,
+                IEnumerable<MemberInfo> members);
+        }
+
+        class DataFrameExpressionProvider : IRecordBatchExpressionProvider
+        {
+            readonly ParameterExpression inputParameter;
+
+            public DataFrameExpressionProvider()
+            {
+                inputParameter = Expression.Parameter(typeof(IList<DataFrame>), "frames");
+            }
+
+            public ParameterExpression InputParameter => inputParameter;
+
+            public Expression GetLengthExpression()
+            {
+                return Expression.Property(
+                        Expression.Convert(inputParameter, typeof(ICollection<DataFrame>)),
+                        nameof(ICollection<DataFrame>.Count));
+            }
+
+            public List<Expression> GetArrayPopulationExpressions(
+                ParameterExpression arrowArrays,
+                ParameterExpression arrowArrayIndex,
+                Expression batchRows,
+                Type frameType,
+                IEnumerable<MemberInfo> members)
+            {
+                var frameParameter = Expression.Parameter(typeof(DataFrame), "df");
+                List<Expression> expressions = new();
+
+                var stack = new Stack<MemberNode>(members.Select(m => new MemberNode { Member = m }));
+
+                while (stack.Count > 0)
+                {
+                    var current = stack.Pop();
+                    var memberType = GetMemberType(current.Member);
+
+                    if (memberType.IsPrimitive)
+                    {
+                        var memberAccessor = CreateMemberAccess(
+                            Expression.Convert(frameParameter, frameType),
+                            current);
+
+                        expressions.Add(ConvertFrameMemberExpressionBuilder(
+                            memberType, frameParameter, arrowArrays, arrowArrayIndex,
+                            inputParameter, (MemberExpression)batchRows, memberAccessor));
+                    }
+                    else if (memberType.IsEnum)
+                    {
+                        var memberAccessor = Expression.Convert(
+                            CreateMemberAccess(
+                                Expression.Convert(frameParameter, frameType),
+                                current),
+                            Enum.GetUnderlyingType(memberType));
+
+                        expressions.Add(ConvertFrameMemberExpressionBuilder(
+                            Enum.GetUnderlyingType(memberType), frameParameter,
+                            arrowArrays, arrowArrayIndex, inputParameter,
+                            (MemberExpression)batchRows, memberAccessor));
+                    }
+                    else if (memberType.IsValueType)
+                    {
+                        var structMembers = GetDataMembers(memberType);
+
+                        foreach (var structMember in structMembers.Reverse())
+                        {
+                            if (IsMemberIgnored(current.Member, structMember))
+                                continue;
+
+                            stack.Push(new MemberNode
+                            {
+                                Member = structMember,
+                                Parent = current
+                            });
+                        }
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(
+                            $"The member type '{memberType}' is not supported for generating RecordBatch builders.");
+                    }
+                }
+
+                return expressions;
+            }
+        }
+
+        class BufferedDataFrameExpressionProvider : IRecordBatchExpressionProvider
+        {
+            readonly ParameterExpression inputParameter;
+
+            public BufferedDataFrameExpressionProvider()
+            {
+                inputParameter = Expression.Parameter(typeof(BufferedDataFrame), "frame");
+            }
+
+            public ParameterExpression InputParameter => inputParameter;
+
+            public Expression GetLengthExpression()
+            {
+                return Expression.ArrayLength(
+                        Expression.Property(
+                            inputParameter,
+                            nameof(BufferedDataFrame.Clock)));
+            }
+
+            public List<Expression> GetArrayPopulationExpressions(
+                ParameterExpression arrowArrays,
+                ParameterExpression arrowArrayIndex,
+                Expression batchRows,
+                Type frameType,
+                IEnumerable<MemberInfo> members)
+            {
+                List<Expression> expressions = new();
+
+                var stack = new Stack<MemberNode>(members.Select(m => new MemberNode { Member = m }));
+
+                while (stack.Count > 0)
+                {
+                    var current = stack.Pop();
+                    var memberType = GetMemberType(current.Member);
+
+                    if (memberType.IsArray)
+                    {
+                        var convertMethod = typeof(FrameWriter)
+                            .GetMethod(nameof(ConvertArrayToArrowArray), BindingFlags.Static | BindingFlags.NonPublic)
+                            .MakeGenericMethod(memberType.GetElementType());
+
+                        var arrayProperty = Expression.Property(
+                            Expression.Convert(inputParameter, frameType),
+                            current.GetFullName());
+                        var arrayArrowType = Expression.Constant(GetArrowType(memberType.GetElementType()));
+
+                        var block = Expression.Block(
+                            Expression.Assign(
+                                Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
+                                Expression.Call(
+                                    convertMethod,
+                                    arrayProperty,
+                                    arrayArrowType,
+                                    batchRows)),
+                            Expression.PostIncrementAssign(arrowArrayIndex));
+
+                        expressions.Add(block);
+                    }
+                    else if (memberType == typeof(Mat))
+                    {
+                        var convertMatRowMethod = typeof(FrameWriter)
+                            .GetMethod(nameof(ConvertMatRowToArrowArray), BindingFlags.Static | BindingFlags.NonPublic);
+
+                        var matProperty = Expression.Property(
+                            Expression.Convert(inputParameter, frameType), current.GetFullName());
+                        var matElementType = Expression.Variable(typeof(IArrowType), "matElementType");
+                        var rowIndex = Expression.Variable(typeof(int), "rowIndex");
+                        var breakLabel = Expression.Label("break");
+
+                        var loopBody = Expression.Block(
+                            Expression.Assign(
+                                Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
+                                Expression.Call(
+                                    convertMatRowMethod,
+                                    matProperty,
+                                    rowIndex,
+                                    matElementType,
+                                    batchRows)),
+                            Expression.PostIncrementAssign(arrowArrayIndex));
+
+                        var forLoop = Expression.Block(
+                            new[] { matElementType, rowIndex },
+                            Expression.Assign(rowIndex, Expression.Constant(0)),
+                            Expression.Assign(
+                                matElementType,
+                                Expression.Call(
+                                    typeof(FrameWriter).GetMethod(
+                                        nameof(GetArrowType),
+                                        BindingFlags.Static | BindingFlags.NonPublic,
+                                        null,
+                                        new[] { typeof(Depth) },
+                                        null),
+                                    Expression.Property(matProperty, nameof(Mat.Depth)))),
+                            Expression.Loop(
+                                Expression.IfThenElse(
+                                    Expression.LessThan(
+                                        rowIndex,
+                                        Expression.Property(matProperty, nameof(Mat.Rows))),
+                                    Expression.Block(
+                                        loopBody,
+                                        Expression.PostIncrementAssign(rowIndex)),
+                                    Expression.Break(breakLabel)),
+                                breakLabel));
+
+                        expressions.Add(forLoop);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(
+                            $"The member type '{memberType}' is not supported for generating RecordBatch builders.");
+                    }
+                }
+
+                return expressions;
+            }
+        }
+
+        static class RecordBatchExpressionFactory
+        {
+            public static Expression<TDelegate> CreateBuilder<TDelegate>(
+                IRecordBatchExpressionProvider provider,
+                Type frameType,
+                IEnumerable<MemberInfo> members)
+            {
+                var expressions = new List<Expression>();
+                var parameters = new List<ParameterExpression>();
+
+                var arrowArrays = Expression.Variable(typeof(IArrowArray[]), "arrowArrays");
+                var arrowArrayIndex = Expression.Variable(typeof(int), "arrowArrayIndex");
+                var schemaParameter = Expression.Parameter(typeof(Schema), "schema");
+                var batchRowsExpression = provider.GetLengthExpression();
+
+                expressions.Add(batchRowsExpression);
+
+                parameters.Add(arrowArrays);
+                expressions.Add(InitializeArrowArrayFromSchema(schemaParameter, arrowArrays));
+
+                parameters.Add(arrowArrayIndex);
+                expressions.Add(Expression.Assign(arrowArrayIndex, Expression.Constant(0)));
+
+                expressions.AddRange(
+                    provider.GetArrayPopulationExpressions(
+                        arrowArrays, arrowArrayIndex, batchRowsExpression, frameType, members));
+
+                var recordBatch = Expression.Variable(typeof(RecordBatch), "recordBatch");
+                parameters.Add(recordBatch);
+                expressions.Add(Expression.Assign(
+                    recordBatch,
+                    Expression.New(recordBatchConstructor, schemaParameter, arrowArrays, batchRowsExpression)));
+
+                var createRecordBatch = Expression.Block(parameters, expressions);
+
+                return Expression.Lambda<TDelegate>(
+                    createRecordBatch,
+                    provider.InputParameter,
+                    schemaParameter
+                );
+            }
+        }
+
+        static Expression<Func<IList<DataFrame>, Schema, RecordBatch>> CreateDataFrameRecordBatchBuilder(
+            Type frameType,
+            IEnumerable<MemberInfo> members)
+        {
+            return RecordBatchExpressionFactory.CreateBuilder<Func<IList<DataFrame>, Schema, RecordBatch>>(
+                new DataFrameExpressionProvider(),
+                frameType,
+                members);
+        }
+
+        static Expression<Func<BufferedDataFrame, Schema, RecordBatch>> CreateBufferedFrameRecordBatchBuilder(
+            Type frameType,
+            IEnumerable<MemberInfo> members)
+        {
+            return RecordBatchExpressionFactory.CreateBuilder<Func<BufferedDataFrame, Schema, RecordBatch>>(
+                new BufferedDataFrameExpressionProvider(),
+                frameType,
+                members);
+        }
+    }
+}

--- a/OpenEphys.Onix1/FrameWriter/FrameWriterIgnoreAttribute.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriterIgnoreAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace OpenEphys.Onix1.FrameWriter
+{
+    /// <summary>
+    /// Tells the FrameWriter to ignore this property when writing frames to disk.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class FrameWriterIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/OpenEphys.Onix1/FrameWriter/FrameWriterIgnoreMembersAttribute.cs
+++ b/OpenEphys.Onix1/FrameWriter/FrameWriterIgnoreMembersAttribute.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace OpenEphys.Onix1.FrameWriter
+{
+    /// <summary>
+    /// Tells the FrameWriter to ignore member types from this property when writing frames to disk.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class FrameWriterIgnoreMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the <see cref="MemberType"/> to ignore.
+        /// </summary>
+        public MemberType MemberType { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrameWriterIgnoreMembersAttribute"/> with
+        /// <see cref="MemberType.All"/> as the <see cref="MemberType"/>
+        /// </summary>
+        public FrameWriterIgnoreMembersAttribute()
+            : this(MemberType.All)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrameWriterIgnoreMembersAttribute"/> with the
+        /// given <see cref="MemberType"/>
+        /// </summary>
+        /// <param name="memberType">Selected <see cref="MemberType"/> to ignore.</param>
+        public FrameWriterIgnoreMembersAttribute(MemberType memberType)
+        {
+            MemberType = memberType;
+        }
+    }
+
+    /// <summary>
+    /// Specifies types of members.
+    /// </summary>
+    [Flags]
+    public enum MemberType
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Specifies all field members.
+        /// </summary>
+        Fields,
+        /// <summary>
+        /// Specifies all property members.
+        /// </summary>
+        Properties,
+        /// <summary>
+        /// Specifies all field and property members.
+        /// </summary>
+        All = Fields | Properties
+    }
+}

--- a/OpenEphys.Onix1/FrameWriter/MatRowMemoryManager.cs
+++ b/OpenEphys.Onix1/FrameWriter/MatRowMemoryManager.cs
@@ -1,0 +1,61 @@
+﻿using OpenCV.Net;
+using System;
+using System.Buffers;
+
+namespace OpenEphys.Onix1.FrameWriter
+{
+    /// <summary>
+    /// Provides a MemoryManager implementation for accessing a specific row of a Mat object as a span or memory
+    /// block.
+    /// </summary>
+    public sealed class MatRowMemoryManager : MemoryManager<byte>
+    {
+        readonly Mat mat;
+        readonly int row;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MatRowMemoryManager"/> class.
+        /// </summary>
+        /// <param name="mat">Existing <see cref="Mat"/> object.</param>
+        /// <param name="row">Row of the <see cref="Mat"/> object to access.</param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public MatRowMemoryManager(Mat mat, int row)
+        {
+            if (row >= mat.Rows)
+                throw new ArgumentOutOfRangeException(nameof(row));
+
+            this.mat = mat;
+            this.row = row;
+        }
+
+        /// <inheritdoc/>
+        public unsafe override Span<byte> GetSpan()
+        {
+            return new((byte*)mat.Data.ToPointer() + row * mat.Step, mat.Step);
+        }
+
+        /// <inheritdoc/>
+        public unsafe override MemoryHandle Pin(int elementIndex = 0)
+        {
+            if (elementIndex < 0 || elementIndex >= mat.Step)
+                throw new ArgumentOutOfRangeException(nameof(elementIndex));
+
+            // NB: Return a MemoryHandle to the location of the row of data
+            byte* ptr = (byte*)mat.Data.ToPointer();
+            ptr += row * mat.Step + elementIndex;
+            return new MemoryHandle(ptr);
+        }
+
+        /// <inheritdoc/>
+        public override void Unpin()
+        {
+            // NB: Do nothing, as we are not managing the Mat object memory in this class
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            // NB: Do nothing, as we are not managing the Mat object memory in this class
+        }
+    }
+}

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -11,15 +11,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Apache.Arrow" Version="22.1.0" />
     <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.System" Version="2.9.0" />
     <PackageReference Include="clroni" Version="6.2.0" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageReference Include="Microsoft.Bcl.Numerics" Version="9.0.7" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
     <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.3.0" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="OpenEphys.Onix1.Design"/>
+    <InternalsVisibleTo Include="OpenEphys.Onix1.Design" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is to add the Onix1.FrameWriter as a potential new method for saving data frames. Any of the data frames (or buffered data frames) from Onix1 can be an input to the node. Reflection and expression trees are utilized to build the conversion from a frame to an Arrow array, which is then written to the file.

This uses `Apache.Arrow` as the file writer. 

Fixes #247 