### PR TITLE
Decrease minimum version check for Rhd2164

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.7.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.Onix1/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix1/ConfigureRhd2164.cs
@@ -125,7 +125,7 @@ namespace OpenEphys.Onix1
     static class Rhd2164
     {
         public const int ID = 3;
-        public const uint MinimumVersion = 2;
+        public const uint MinimumVersion = 1;
 
         // constants
         public const int AmplifierChannelCount = 64;


### PR DESCRIPTION
~In this PR, I assumed this belongs to the same release cycle as 0.8.0 instead of having its own 0.7.1.~

Edit, I force-pushed revision 0.7.1

Edit, fix #618