### PR TITLE
Set default ReadSize to 8192

### DIFF
--- a/OpenEphys.Onix1/StartAcquisition.cs
+++ b/OpenEphys.Onix1/StartAcquisition.cs
@@ -41,7 +41,7 @@ namespace OpenEphys.Onix1
     [Description("Starts data acquisition and frame distribution on a ContextTask.")]
     public class StartAcquisition : Combinator<ContextTask, IGroupedObservable<uint, oni.Frame>>
     {
-        int readSize = 2048;
+        int readSize = 8192;
 
         /// <summary>
         /// Gets or sets the number of bytes read per cycle of the <see cref="ContextTask"/>'s acquisition


### PR DESCRIPTION
Increasing the default read size to 8192. If the only device that is enabled is the `Heartbeat`, stopping the workflow will take a maximum of 3.4 seconds before it will finish. If any other device is enabled, such as the `AnalogIO` which is enabled by default, stopping the workflow will happen much more quickly (on the order of 10s of ms). 

Fixes #631 