### PR TITLE
Simplify and correct Rhs2116Stimulus validation logic

### DIFF
--- a/OpenEphys.Onix1/Rhs2116Stimulus.cs
+++ b/OpenEphys.Onix1/Rhs2116Stimulus.cs
@@ -1,6 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Xml.Serialization;
-using Bonsai;
 
 namespace OpenEphys.Onix1
 {
@@ -88,64 +88,65 @@ namespace OpenEphys.Onix1
         public uint InterStimulusIntervalSamples { get; set; } = 0;
 
         /// <summary>
-        /// Gets the status of this sequence.
+        /// Validates the stimulus sequence and returns a result containing
+        /// all reasons for invalidity, if any.
         /// </summary>
-        /// <returns>True if the sequence is valid, false if it is not valid.</returns>
-        public bool IsValid()
+        Rhs2116StimulusValidationResult Validate()
         {
-            return Valid;
+            var reasons = new List<string>();
+
+            if (NumberOfStimuli == 0)
+            {
+                // A zeroed-out / disabled stimulus is valid but only if
+                // every other field is also zeroed out.
+                if (CathodicWidthSamples != 0)
+                    reasons.Add("Stimuli = 0, Cathodic Width > 0");
+                if (AnodicWidthSamples != 0)
+                    reasons.Add("Stimuli = 0, Anodic Width > 0");
+                if (InterStimulusIntervalSamples != 0)
+                    reasons.Add("Stimuli = 0, ISI > 0");
+                if (AnodicAmplitudeSteps != 0)
+                    reasons.Add("Stimuli = 0, Anodic Steps > 0");
+                if (CathodicAmplitudeSteps != 0)
+                    reasons.Add("Stimuli = 0, Cathodic Steps > 0");
+                if (DelaySamples != 0)
+                    reasons.Add("Stimuli = 0, Delay > 0");
+                if (DwellSamples != 0)
+                    reasons.Add("Stimuli = 0, Dwell (Inter-Pulse) > 0");
+            }
+            else
+            {
+                if (AnodicWidthSamples == 0 && AnodicAmplitudeSteps > 0)
+                    reasons.Add("Anodic Width = 0, Anodic Steps > 0");
+                if (CathodicWidthSamples == 0 && CathodicAmplitudeSteps > 0)
+                    reasons.Add("Cathodic Width = 0, Cathodic Steps > 0");
+                if (AnodicWidthSamples == 0 && CathodicWidthSamples == 0)
+                    reasons.Add("Pulse has zero width");
+                if (NumberOfStimuli > 1 && InterStimulusIntervalSamples == 0)
+                    reasons.Add("ISI = 0, Stimuli > 1");
+            }
+
+            return new Rhs2116StimulusValidationResult(reasons);
         }
 
         /// <summary>
-        /// Gets the status of this sequence.
+        /// Returns true if the sequence is valid.
         /// </summary>
-        /// <param name="reasonInvalid">If the return value is true, this value is an empty 
-        /// string. If the return is false, this will list the first reason why the sequence is invalid</param>
-        /// <returns>True if the sequence is valid, false if it is not valid.</returns>
+        public bool IsValid() => Validate().IsValid;
+
+        /// <summary>
+        /// Returns true if the sequence is valid, and provides the first reason
+        /// for invalidity if not. Kept for backwards compatibility.
+        /// </summary>
         public bool IsValid(out string reasonInvalid)
         {
-            reasonInvalid = "";
-
-            var valid = Valid;
-
-            if (valid == false)
-            {
-                if (NumberOfStimuli == 0)
-                {
-                    if (CathodicWidthSamples != 0)
-                        reasonInvalid = "Stimuli = 0, Cathodic Width > 0";
-
-                    else if (AnodicWidthSamples != 0)
-                        reasonInvalid = "Stimuli = 0, Anodic Width > 0";
-
-                    else if (InterStimulusIntervalSamples != 0)
-                        reasonInvalid = "Stimuli = 0, ISI > 0";
-
-                    else if (AnodicAmplitudeSteps != 0)
-                        reasonInvalid = "Stimuli = 0, Anodic Steps > 0";
-
-                    else if (CathodicAmplitudeSteps != 0)
-                        reasonInvalid = "Stimuli = 0, Cathodic Steps > 0";
-
-                    else if (DelaySamples != 0)
-                        reasonInvalid = "Stimuli = 0, Delay > 0";
-
-                    else if (DwellSamples != 0)
-                        reasonInvalid = "Stimuli = 0, Dwell (Inter-Pulse) > 0";
-                }
-                else if (AnodicWidthSamples == 0 && AnodicAmplitudeSteps > 0)
-                    reasonInvalid = "Anodic Width = 0, Anodic Steps > 0";
-
-                else if (CathodicWidthSamples == 0 && CathodicAmplitudeSteps > 0)
-                    reasonInvalid = "Cathodic Width = 0, Cathodic Steps > 0";
-
-                else if (NumberOfStimuli > 1 && InterStimulusIntervalSamples == 0)
-                    reasonInvalid = "ISI = 0, Stimuli > 1";
-
-            }
-
-            return valid;
+            var result = Validate();
+            reasonInvalid = result.IsValid ? "" : result.Reasons[0];
+            return result.IsValid;
         }
+
+        [XmlIgnore]
+        internal bool Valid => Validate().IsValid;
 
         /// <summary>
         /// Resets all properties to their default values.
@@ -163,20 +164,6 @@ namespace OpenEphys.Onix1
             InterStimulusIntervalSamples = 0;
         }
 
-        [XmlIgnore]
-        internal bool Valid
-        {
-            get
-            {
-                return NumberOfStimuli == 0
-                    ? CathodicWidthSamples == 0 && AnodicWidthSamples == 0 && InterStimulusIntervalSamples == 0 &&
-                      AnodicAmplitudeSteps == 0 && CathodicAmplitudeSteps == 0 && DelaySamples == 0 && DwellSamples == 0
-                    : !(AnodicWidthSamples == 0 && AnodicAmplitudeSteps > 0) &&
-                      !(CathodicWidthSamples == 0 && CathodicAmplitudeSteps > 0) &&
-                      ((NumberOfStimuli == 1 && InterStimulusIntervalSamples >= 0) || (NumberOfStimuli > 1 && InterStimulusIntervalSamples > 0));
-            }
-        }
-
         /// <summary>
         /// Performs a shallow copy of the sequence using <c>MemberwiseClone()</c>.
         /// </summary>
@@ -185,5 +172,33 @@ namespace OpenEphys.Onix1
         {
             return (Rhs2116Stimulus)MemberwiseClone();
         }
+    }
+
+    /// <summary>
+    /// Holds the outcome of a stimulus sequence validation, including
+    /// all reasons for invalidity.
+    /// </summary>
+    public sealed class Rhs2116StimulusValidationResult
+    {
+        /// <summary>
+        /// Represents a Rhs2116StimulusValidationResult with <see cref="IsValid"/> <lang>true</lang>.
+        /// </summary>
+        public static readonly Rhs2116StimulusValidationResult Ok = new(new List<string>());
+
+        internal Rhs2116StimulusValidationResult(IReadOnlyList<string> reasons)
+        {
+            Reasons = reasons;
+        }
+
+        /// <summary>True if the sequence is valid.</summary>
+        public bool IsValid => Reasons.Count == 0;
+
+        /// <summary>All reasons the sequence is invalid. Empty when valid.</summary>
+        public IReadOnlyList<string> Reasons { get; }
+
+        /// <summary>
+        /// Convenience: all reasons joined into a single human-readable string.
+        /// </summary>
+        public string Summary => string.Join("; ", Reasons);
     }
 }


### PR DESCRIPTION
- Perform validation in one place
- Allow multiple reasons for invalidation
- Remove horrific ternary operator

Fixes #637 