### PR TITLE
Add writer task

### DIFF
--- a/OpenEphys.Onix1/AnalogOutput.cs
+++ b/OpenEphys.Onix1/AnalogOutput.cs
@@ -105,12 +105,15 @@ namespace OpenEphys.Onix1
                         outputBuffer = scaleBuffer;
                     }
 
-                    var dataSize = outputBuffer.Step * outputBuffer.Rows;
-
                     // twos-complement to offset binary
                     const short Mask = -32768;
-                    CV.XorS(outputBuffer, new Scalar(Mask, 0, 0), outputBuffer);
-                    device.Write(outputBuffer.Data, dataSize);
+                    short[] dataArray = new short[outputBuffer.Rows];
+                    fixed (short* dataArrayPtr = dataArray)
+                    {
+                        Mat mat = new(outputBuffer.Rows, outputBuffer.Cols, outputBuffer.Depth, 1, (IntPtr)dataArrayPtr, outputBuffer.Step);
+                        CV.XorS(outputBuffer, new Scalar(Mask, 0, 0), mat);
+                    }
+                    device.Write(dataArray);
                 });
             });
         }

--- a/OpenEphys.Onix1/AnalogOutput.cs
+++ b/OpenEphys.Onix1/AnalogOutput.cs
@@ -108,11 +108,8 @@ namespace OpenEphys.Onix1
                     // twos-complement to offset binary
                     const short Mask = -32768;
                     short[] dataArray = new short[outputBuffer.Rows];
-                    fixed (short* dataArrayPtr = dataArray)
-                    {
-                        Mat mat = new(outputBuffer.Rows, outputBuffer.Cols, outputBuffer.Depth, 1, (IntPtr)dataArrayPtr, outputBuffer.Step);
-                        CV.XorS(outputBuffer, new Scalar(Mask, 0, 0), mat);
-                    }
+                    Mat mat = Mat.CreateMatHeader(dataArray, outputBuffer.Rows, outputBuffer.Cols, outputBuffer.Depth, 1);
+                    CV.XorS(outputBuffer, new Scalar(Mask, 0, 0), mat);
                     device.Write(dataArray);
                 });
             });

--- a/OpenEphys.Onix1/ArrayWriterTaskAction.cs
+++ b/OpenEphys.Onix1/ArrayWriterTaskAction.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenEphys.Onix1
+{
+    sealed class ArrayWriterTaskAction<T> : WriterTaskAction where T : unmanaged
+    {
+        readonly T[] data;
+
+        public ArrayWriterTaskAction(uint deviceAddress, T[] data) : base(deviceAddress)
+        {
+            this.data = data;
+        }
+
+        internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
+    }
+}

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -462,14 +462,9 @@ namespace OpenEphys.Onix1
                     {
                         try
                         {
-                            while (!collectFramesToken.IsCancellationRequested)
+                            await foreach (var writeAction in writeQueue.Reader.ReadAllAsync(collectFramesToken))
                             {
-                                var writeAction = await writeQueue.Reader.ReadAsync(collectFramesToken);
-
-                                lock (writeLock)
-                                {
-                                    writeAction();
-                                }
+                                writeAction();
                             }
                         }
                         catch (OperationCanceledException)

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -501,7 +501,6 @@ namespace OpenEphys.Onix1
                             }
                             frameQueue?.Dispose();
                             frameQueue = null;
-                            while (writeQueue?.Reader.TryRead(out _) == true) { }
                             writeQueue = null;
                             ctx.Stop();
 

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Channels;
 
 namespace OpenEphys.Onix1
 {
@@ -55,7 +56,9 @@ namespace OpenEphys.Onix1
         bool disposed;
         Task readFrames;
         Task distributeFrames;
+        Task writeFrames;
         Task acquisition = Task.CompletedTask;
+        Channel<Action> writeQueue;
         CancellationTokenSource collectFramesCancellation;
         event Func<ContextTask, IDisposable> ConfigureAndLatchControllerEvent;
         event Func<ContextTask, IDisposable> ConfigureAndLatchLinkEvent;
@@ -291,7 +294,7 @@ namespace OpenEphys.Onix1
             }
             finally
             {
-                 Reset();
+                Reset();
             }
         }
 
@@ -449,7 +452,40 @@ namespace OpenEphys.Onix1
                     TaskCreationOptions.LongRunning,
                     TaskScheduler.Default);
 
-                    return acquisition = Task.WhenAll(distributeFrames, readFrames).ContinueWith(task =>
+                    var options = new UnboundedChannelOptions()
+                    {
+                        SingleReader = true
+                    };
+                    writeQueue = Channel.CreateUnbounded<Action>(options);
+
+                    writeFrames = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            while (!collectFramesToken.IsCancellationRequested)
+                            {
+                                var writeAction = await writeQueue.Reader.ReadAsync(collectFramesToken);
+
+                                lock (writeLock)
+                                {
+                                    writeAction();
+                                }
+                            }
+                        }
+                        catch (OperationCanceledException)
+                        {
+#if DEBUG
+                            Console.WriteLine("Frame write task has been cancelled by " + this.GetType());
+#endif
+                        }
+                        finally
+                        {
+                            writeQueue.Writer.Complete();
+                        }
+                    },
+                    collectFramesToken);
+
+                    return acquisition = Task.WhenAll(distributeFrames, readFrames, writeFrames).ContinueWith(task =>
                     {
                         if (readFrames.IsFaulted && readFrames.Exception is AggregateException ex)
                         {
@@ -470,6 +506,8 @@ namespace OpenEphys.Onix1
                             }
                             frameQueue?.Dispose();
                             frameQueue = null;
+                            while (writeQueue?.Reader.TryRead(out _) == true) { }
+                            writeQueue = null;
                             ctx.Stop();
 
                             contextConfiguration.Dispose();
@@ -555,26 +593,17 @@ namespace OpenEphys.Onix1
 
         internal void Write<T>(uint deviceAddress, T data) where T : unmanaged
         {
-            lock (writeLock)
-            {
-                ctx.Write(deviceAddress, data);
-            }
+            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data));
         }
 
         internal void Write<T>(uint deviceAddress, T[] data) where T : unmanaged
         {
-            lock (writeLock)
-            {
-                ctx.Write(deviceAddress, data);
-            }
+            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data));
         }
 
         internal void Write(uint deviceAddress, IntPtr data, int dataSize)
         {
-            lock (writeLock)
-            {
-                ctx.Write(deviceAddress, data, dataSize);
-            }
+            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data, dataSize));
         }
 
         internal oni.Hub GetHub(uint deviceAddress) => ctx.GetHub(deviceAddress);

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -58,7 +58,7 @@ namespace OpenEphys.Onix1
         Task distributeFrames;
         Task writeFrames;
         Task acquisition = Task.CompletedTask;
-        Channel<Action> writeQueue;
+        Channel<WriterTaskAction> writeActionChannel;
         CancellationTokenSource collectFramesCancellation;
         event Func<ContextTask, IDisposable> ConfigureAndLatchControllerEvent;
         event Func<ContextTask, IDisposable> ConfigureAndLatchLinkEvent;
@@ -456,15 +456,15 @@ namespace OpenEphys.Onix1
                     {
                         SingleReader = true
                     };
-                    writeQueue = Channel.CreateUnbounded<Action>(options);
+                    writeActionChannel = Channel.CreateUnbounded<WriterTaskAction>(options);
 
                     writeFrames = Task.Run(async () =>
                     {
                         try
                         {
-                            await foreach (var writeAction in writeQueue.Reader.ReadAllAsync(collectFramesToken))
+                            await foreach (var writeAction in writeActionChannel.Reader.ReadAllAsync(collectFramesToken))
                             {
-                                writeAction();
+                                writeAction.Write(ctx);
                             }
                         }
                         catch (OperationCanceledException)
@@ -475,7 +475,7 @@ namespace OpenEphys.Onix1
                         }
                         finally
                         {
-                            writeQueue.Writer.Complete();
+                            writeActionChannel.Writer.Complete();
                         }
                     },
                     collectFramesToken);
@@ -501,7 +501,7 @@ namespace OpenEphys.Onix1
                             }
                             frameQueue?.Dispose();
                             frameQueue = null;
-                            writeQueue = null;
+                            writeActionChannel = null;
                             ctx.Stop();
 
                             contextConfiguration.Dispose();
@@ -587,12 +587,12 @@ namespace OpenEphys.Onix1
 
         internal void Write<T>(uint deviceAddress, T data) where T : unmanaged
         {
-            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data));
+            writeActionChannel?.Writer.TryWrite(new ScalarWriterTaskAction<T>(deviceAddress, data));
         }
 
         internal void Write<T>(uint deviceAddress, T[] data) where T : unmanaged
         {
-            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data));
+            writeActionChannel?.Writer.TryWrite(new ArrayWriterTaskAction<T>(deviceAddress, data));
         }
 
         internal oni.Hub GetHub(uint deviceAddress) => ctx.GetHub(deviceAddress);

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -596,11 +596,6 @@ namespace OpenEphys.Onix1
             writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data));
         }
 
-        internal void Write(uint deviceAddress, IntPtr data, int dataSize)
-        {
-            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data, dataSize));
-        }
-
         internal oni.Hub GetHub(uint deviceAddress) => ctx.GetHub(deviceAddress);
 
         internal uint GetPassthroughDeviceAddress(uint deviceAddress)

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -411,7 +411,6 @@ namespace OpenEphys.Onix1
                                     throw;
                                 }
                                 frameQueue.Add(frame, collectFramesToken);
-
                             }
                         }
                         catch (OperationCanceledException)
@@ -421,7 +420,7 @@ namespace OpenEphys.Onix1
                             // while loop context and will be disposed.
                             Console.WriteLine("Frame collection task has been cancelled by " + this.GetType());
 #endif
-                        };
+                        }
                     },
                     collectFramesToken,
                     TaskCreationOptions.LongRunning,
@@ -452,11 +451,11 @@ namespace OpenEphys.Onix1
                     TaskCreationOptions.LongRunning,
                     TaskScheduler.Default);
 
-                    var options = new UnboundedChannelOptions()
+                    var unboundedChannelOptions = new UnboundedChannelOptions()
                     {
                         SingleReader = true
                     };
-                    writeActionChannel = Channel.CreateUnbounded<WriterTaskAction>(options);
+                    writeActionChannel = Channel.CreateUnbounded<WriterTaskAction>(unboundedChannelOptions);
 
                     writeFrames = Task.Run(async () =>
                     {
@@ -464,7 +463,15 @@ namespace OpenEphys.Onix1
                         {
                             await foreach (var writeAction in writeActionChannel.Reader.ReadAllAsync(collectFramesToken))
                             {
-                                writeAction.Write(ctx);
+                                try
+                                {
+                                    writeAction.Write(ctx);
+                                }
+                                catch (Exception)
+                                {
+                                    collectFramesCancellation.Cancel();
+                                    throw;
+                                }
                             }
                         }
                         catch (OperationCanceledException)

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -463,15 +463,7 @@ namespace OpenEphys.Onix1
                         {
                             await foreach (var writeAction in writeActionChannel.Reader.ReadAllAsync(collectFramesToken))
                             {
-                                try
-                                {
-                                    writeAction.Write(ctx);
-                                }
-                                catch (Exception)
-                                {
-                                    collectFramesCancellation.Cancel();
-                                    throw;
-                                }
+                                writeAction.Write(ctx);
                             }
                         }
                         catch (OperationCanceledException)
@@ -479,6 +471,11 @@ namespace OpenEphys.Onix1
 #if DEBUG
                             Console.WriteLine("Frame write task has been cancelled by " + this.GetType());
 #endif
+                        }
+                        catch (Exception)
+                        {
+                            collectFramesCancellation.Cancel();
+                            throw;
                         }
                         finally
                         {
@@ -489,7 +486,7 @@ namespace OpenEphys.Onix1
 
                     return acquisition = Task.WhenAll(distributeFrames, readFrames, writeFrames).ContinueWith(task =>
                     {
-                        if (readFrames.IsFaulted && readFrames.Exception is AggregateException ex)
+                        if (task.IsFaulted && task.Exception is AggregateException ex)
                         {
                             var error = ex.InnerExceptions.Count == 1 ? ex.InnerExceptions[0] : ex;
                             frameReceived.OnError(error);

--- a/OpenEphys.Onix1/DeviceContext.cs
+++ b/OpenEphys.Onix1/DeviceContext.cs
@@ -40,10 +40,5 @@ namespace OpenEphys.Onix1
         {
             _context.Write(_device.Address, data);
         }
-
-        public void Write(IntPtr data, int dataSize)
-        {
-            _context.Write(_device.Address, data, dataSize);
-        }
     }
 }

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Bcl.Numerics" Version="9.0.7" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
     <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.3.0" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenEphys.Onix1/ScalarWriterTaskAction.cs
+++ b/OpenEphys.Onix1/ScalarWriterTaskAction.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenEphys.Onix1
+{
+    sealed class ScalarWriterTaskAction<T> : WriterTaskAction where T : unmanaged
+    {
+        readonly T data;
+
+        public ScalarWriterTaskAction(uint deviceAddress, T data) : base(deviceAddress)
+        {
+            this.data = data;
+        }
+
+        internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
+    }
+}

--- a/OpenEphys.Onix1/WriterTaskAction.cs
+++ b/OpenEphys.Onix1/WriterTaskAction.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenEphys.Onix1
+{
+    abstract class WriterTaskAction
+    {
+        private protected readonly uint deviceAddress;
+
+        public WriterTaskAction(uint deviceAddress)
+        {
+            this.deviceAddress = deviceAddress;
+        }
+
+        internal abstract void Write(oni.Context ctx);
+    }
+}


### PR DESCRIPTION
Similar to the existing infrastructure for `readFrames` and `distributeFrames`, I added a `Task` that handles `writeFrames`. 

This uses a `Channel`, specifically an unbounded multiple-producer-single-consumer channel, which operates as a queue (first-in-first-out [FIFO]).

All write method calls now add an action to the queue, which is triggered based on events using an `async/await` pattern to minimize wasteful CPU cycles.

Fixes #632 