### PR TITLE
Add compression option for DataFrameWriter

### DIFF
--- a/OpenEphys.Onix1/DataFrameWriter/ArrowBatchWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/ArrowBatchWriter.cs
@@ -26,8 +26,9 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// <param name="bufferSize">The maximum number of items to buffer before writing a batch.</param>
         /// <param name="timeout">The maximum time to wait before writing a batch.</param>
         /// <param name="createRecordBatch">A delegate to create a RecordBatch from a list of items and a schema.</param>
-        public ArrowBatchWriter(string filename, Schema schema, int bufferSize, TimeSpan timeout, Func<IList<T>, Schema, RecordBatch> createRecordBatch)
-            : base(filename, schema)
+        /// <param name="enableCompression">A boolean indicating whether to enable compression.</param>
+        public ArrowBatchWriter(string filename, Schema schema, int bufferSize, TimeSpan timeout, Func<IList<T>, Schema, RecordBatch> createRecordBatch, bool enableCompression = false)
+            : base(filename, schema, enableCompression)
         {
             subscription = subject
                 .Buffer(timeout, bufferSize)

--- a/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
@@ -1,0 +1,9 @@
+﻿using Bonsai.IO;
+
+namespace OpenEphys.Onix1.DataFrameWriter
+{
+    abstract class ArrowFileSink<T1, T2> : FileSink<T1, T2>, IArrowSinkOptions where T2 : ArrowWriter
+    {
+        public bool EnableCompression { get; set; } = false;
+    }
+}

--- a/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
@@ -2,7 +2,7 @@
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    abstract class ArrowFileSink<T1, T2> : FileSink<T1, T2>, IArrowSinkOptions where T2 : ArrowWriter
+    abstract class ArrowFileSink<TSource> : FileSink<TSource, ArrowBatchWriter<TSource>>
     {
         public bool EnableCompression { get; set; } = false;
     }

--- a/OpenEphys.Onix1/DataFrameWriter/ArrowWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/ArrowWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Apache.Arrow;
+using Apache.Arrow.Compression;
 using Apache.Arrow.Ipc;
 
 namespace OpenEphys.Onix1.DataFrameWriter
@@ -20,12 +21,19 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// </summary>
         /// <param name="filename">The name of the file on which the elements should be written.</param>
         /// <param name="schema">A <see cref="Schema"/> that defines the current file.</param>
-        public ArrowWriter(string filename, Schema schema)
+        /// <param name="enableCompression">A boolean indicating whether to enable compression.</param>
+        public ArrowWriter(string filename, Schema schema, bool enableCompression = false)
         {
             stream = new FileStream(filename, FileMode.Create);
-            writer = new(stream, schema);
+            writer = new(stream, schema, leaveOpen: false, enableCompression ? CompressionOptions : null);
             writer.WriteStart();
         }
+
+        static readonly IpcOptions CompressionOptions = new()
+        {
+            CompressionCodec = CompressionCodecType.Zstd,
+            CompressionCodecFactory = new CompressionCodecFactory()
+        };
 
         /// <summary>
         /// Writes the specified record batch to the underlying stream.

--- a/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
@@ -4,7 +4,7 @@ using Apache.Arrow;
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    class BufferedDataFrameArrowFileSink : ArrowFileSink<BufferedDataFrame, ArrowBatchWriter<BufferedDataFrame>>
+    class BufferedDataFrameArrowFileSink : ArrowFileSink<BufferedDataFrame>
     {
         readonly TimeSpan timeout;
 

--- a/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
@@ -1,11 +1,10 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Apache.Arrow;
-using Bonsai.IO;
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    class BufferedDataFrameArrowFileSink : FileSink<BufferedDataFrame, ArrowBatchWriter<BufferedDataFrame>>
+    class BufferedDataFrameArrowFileSink : ArrowFileSink<BufferedDataFrame, ArrowBatchWriter<BufferedDataFrame>>
     {
         readonly TimeSpan timeout;
 
@@ -22,7 +21,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
             var createRecordBatch = RecordBatchExpressionFactory.CreateBuilder<Func<IList<BufferedDataFrame>, Schema, RecordBatch>>(
                 new BufferedDataFrameExpressionProvider(), frameType, members).Compile();
             var bufferSize = (int)Math.Ceiling((double)DataFrameWriterHelper.GetBufferSize(frameType) / dataFrame.Clock.Length);
-            return new ArrowBatchWriter<BufferedDataFrame>(filename, schema, bufferSize, timeout, createRecordBatch);
+            return new ArrowBatchWriter<BufferedDataFrame>(filename, schema, bufferSize, timeout, createRecordBatch, EnableCompression);
         }
 
         protected override void Write(ArrowBatchWriter<BufferedDataFrame> writer, BufferedDataFrame input)

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
@@ -4,7 +4,7 @@ using Apache.Arrow;
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    class DataFrameArrowFileSink : ArrowFileSink<DataFrame, ArrowBatchWriter<DataFrame>>
+    class DataFrameArrowFileSink : ArrowFileSink<DataFrame>
     {
         readonly TimeSpan timeout;
 

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using Apache.Arrow;
-using Bonsai.IO;
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    class DataFrameArrowFileSink : FileSink<DataFrame, ArrowBatchWriter<DataFrame>>
+    class DataFrameArrowFileSink : ArrowFileSink<DataFrame, ArrowBatchWriter<DataFrame>>
     {
         readonly TimeSpan timeout;
 
@@ -21,7 +20,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
             var schema = DataFrameWriterHelper.GenerateSchema(members, frame);
             var createRecordBatch = RecordBatchExpressionFactory.CreateBuilder<Func<IList<DataFrame>, Schema, RecordBatch>>( new DataFrameExpressionProvider(), frameType, members).Compile();
             var bufferSize = DataFrameWriterHelper.GetBufferSize(frameType);
-            return new ArrowBatchWriter<DataFrame>(filename, schema, bufferSize, timeout, createRecordBatch);
+            return new ArrowBatchWriter<DataFrame>(filename, schema, bufferSize, timeout, createRecordBatch, EnableCompression);
         }
 
         protected override void Write(ArrowBatchWriter<DataFrame> writer, DataFrame input)

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -9,7 +9,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
     /// to an Apache Arrow file using an <see cref="ArrowWriter"/>.
     /// </summary>
     [WorkflowElementCategory(ElementCategory.Sink)]
-    public class DataFrameWriter : FileSink, IArrowSinkOptions
+    public class DataFrameWriter : FileSink
     {
         const int SecondsBeforeFlush = 5;
 
@@ -28,7 +28,14 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// </returns>
         public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source)
         {
-            return ConfigureSink(new BufferedDataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))).Process(source);
+            return new BufferedDataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))
+            {
+                FileName = this.FileName,
+                Suffix = this.Suffix,
+                Buffered = this.Buffered,
+                Overwrite = this.Overwrite,
+                EnableCompression = this.EnableCompression
+            }.Process(source);
         }
 
         /// <summary>
@@ -41,17 +48,14 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// </returns>
         public IObservable<DataFrame> Process(IObservable<DataFrame> source)
         {
-            return ConfigureSink(new DataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))).Process(source);
-        }
-
-        T ConfigureSink<T>(T sink) where T : FileSink, IArrowSinkOptions
-        {
-            sink.FileName = FileName;
-            sink.Suffix = Suffix;
-            sink.Buffered = Buffered;
-            sink.Overwrite = Overwrite;
-            sink.EnableCompression = EnableCompression;
-            return sink;
+            return new DataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))
+            {
+                FileName = this.FileName,
+                Suffix = this.Suffix,
+                Buffered = this.Buffered,
+                Overwrite = this.Overwrite,
+                EnableCompression = this.EnableCompression
+            }.Process(source);
         }
     }
 }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Bonsai;
 using Bonsai.IO;
 
@@ -9,9 +9,14 @@ namespace OpenEphys.Onix1.DataFrameWriter
     /// to an Apache Arrow file using an <see cref="ArrowWriter"/>.
     /// </summary>
     [WorkflowElementCategory(ElementCategory.Sink)]
-    public class DataFrameWriter : FileSink
+    public class DataFrameWriter : FileSink, IArrowSinkOptions
     {
         const int SecondsBeforeFlush = 5;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable compression when writing to the Arrow file.
+        /// </summary>
+        public bool EnableCompression { get; set; } = false;
 
         /// <summary>
         /// Writes all of the data frames in the sequence to an Apache Arrow file.
@@ -23,13 +28,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// </returns>
         public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source)
         {
-            return new BufferedDataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))
-            {
-                FileName = this.FileName,
-                Suffix = this.Suffix,
-                Buffered = this.Buffered,
-                Overwrite = this.Overwrite
-            }.Process(source);
+            return ConfigureSink(new BufferedDataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))).Process(source);
         }
 
         /// <summary>
@@ -42,13 +41,17 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// </returns>
         public IObservable<DataFrame> Process(IObservable<DataFrame> source)
         {
-            return new DataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))
-            {
-                FileName = this.FileName,
-                Suffix = this.Suffix,
-                Buffered = this.Buffered,
-                Overwrite = this.Overwrite
-            }.Process(source);
+            return ConfigureSink(new DataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))).Process(source);
+        }
+
+        T ConfigureSink<T>(T sink) where T : FileSink, IArrowSinkOptions
+        {
+            sink.FileName = FileName;
+            sink.Suffix = Suffix;
+            sink.Buffered = Buffered;
+            sink.Overwrite = Overwrite;
+            sink.EnableCompression = EnableCompression;
+            return sink;
         }
     }
 }

--- a/OpenEphys.Onix1/DataFrameWriter/IArrowSinkOptions.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/IArrowSinkOptions.cs
@@ -1,7 +1,0 @@
-﻿namespace OpenEphys.Onix1.DataFrameWriter
-{
-    interface IArrowSinkOptions
-    {
-        public bool EnableCompression { get; set; }
-    }
-}

--- a/OpenEphys.Onix1/DataFrameWriter/IArrowSinkOptions.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/IArrowSinkOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace OpenEphys.Onix1.DataFrameWriter
+{
+    interface IArrowSinkOptions
+    {
+        public bool EnableCompression { get; set; }
+    }
+}

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -11,7 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Arrow" Version="22.1.0" />
+    <PackageReference Include="Apache.Arrow" Version="23.0.0" />
+    <PackageReference Include="Apache.Arrow.Compression" Version="23.0.0" />
     <PackageReference Include="Bonsai.Core" Version="2.9.0" />
     <PackageReference Include="Bonsai.System" Version="2.9.0" />
     <PackageReference Include="clroni" Version="6.2.0" />


### PR DESCRIPTION
Updated `Apache.Arrow` to v23.0.0, and added a dependency on `Apache.Arrow.Compression` which allows us to compress the data frames before they are written to the file.

While adding the compression option, I realized that I did not correctly configure the inheritance structure, so the `DataFrameWriter` did not have the same contract as `DataFrameFileSink` and `BufferedDataFrameFileSink`. To ensure that all relevant classes contained the property, and could be propagated down the hierarchy correctly, I had to add the abstract `ArrowFileSink` class, and attempted to make sure that everything was correctly lined up. Jon had to simplify the structure for me, removing the unnecessary interface that I added. Now the `EnableCompression` property exists at all levels, and can be correctly pushed through the hierarchy.

Fixes #639 