### PR TITLE
Create WriteAction class

### DIFF
--- a/OpenEphys.Onix1/ArrayWriterTaskAction.cs
+++ b/OpenEphys.Onix1/ArrayWriterTaskAction.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenEphys.Onix1
+{
+    sealed class ArrayWriterTaskAction<T> : WriterTaskAction where T : unmanaged
+    {
+        readonly T[] data;
+
+        public ArrayWriterTaskAction(uint deviceAddress, T[] data) : base(deviceAddress)
+        {
+            this.data = data;
+        }
+
+        internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
+    }
+}

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -34,6 +34,42 @@ namespace OpenEphys.Onix1
     /// </remarks>
     public class ContextTask : IDisposable
     {
+        abstract class WriteAction
+        {
+            readonly uint deviceAddress;
+
+            internal abstract void Write(oni.Context ctx);
+
+            public WriteAction(uint deviceAddress)
+            {
+                this.deviceAddress = deviceAddress;
+            }
+
+            internal sealed class Scalar<T> : WriteAction where T : unmanaged
+            {
+                readonly T data;
+
+                public Scalar(uint deviceAddress, T data) : base(deviceAddress)
+                {
+                    this.data = data;
+                }
+
+                internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
+            }
+
+            internal sealed class Array<T> : WriteAction where T : unmanaged
+            {
+                readonly T[] data;
+
+                public Array(uint deviceAddress, T[] data) : base(deviceAddress)
+                {
+                    this.data = data;
+                }
+
+                internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
+            }
+        }
+
         readonly oni.Context ctx;
 
         /// <summary>
@@ -58,7 +94,7 @@ namespace OpenEphys.Onix1
         Task distributeFrames;
         Task writeFrames;
         Task acquisition = Task.CompletedTask;
-        Channel<Action> writeQueue;
+        Channel<WriteAction> writeQueue;
         CancellationTokenSource collectFramesCancellation;
         event Func<ContextTask, IDisposable> ConfigureAndLatchControllerEvent;
         event Func<ContextTask, IDisposable> ConfigureAndLatchLinkEvent;
@@ -456,7 +492,7 @@ namespace OpenEphys.Onix1
                     {
                         SingleReader = true
                     };
-                    writeQueue = Channel.CreateUnbounded<Action>(options);
+                    writeQueue = Channel.CreateUnbounded<WriteAction>(options);
 
                     writeFrames = Task.Run(async () =>
                     {
@@ -464,7 +500,7 @@ namespace OpenEphys.Onix1
                         {
                             await foreach (var writeAction in writeQueue.Reader.ReadAllAsync(collectFramesToken))
                             {
-                                writeAction();
+                                writeAction.Write(ctx);
                             }
                         }
                         catch (OperationCanceledException)
@@ -588,12 +624,12 @@ namespace OpenEphys.Onix1
 
         internal void Write<T>(uint deviceAddress, T data) where T : unmanaged
         {
-            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data));
+            writeQueue?.Writer.TryWrite(new WriteAction.Scalar<T>(deviceAddress, data));
         }
 
         internal void Write<T>(uint deviceAddress, T[] data) where T : unmanaged
         {
-            writeQueue?.Writer.TryWrite(() => ctx.Write(deviceAddress, data));
+            writeQueue?.Writer.TryWrite(new WriteAction.Array<T>(deviceAddress, data));
         }
 
         internal oni.Hub GetHub(uint deviceAddress) => ctx.GetHub(deviceAddress);

--- a/OpenEphys.Onix1/ContextTask.cs
+++ b/OpenEphys.Onix1/ContextTask.cs
@@ -34,42 +34,6 @@ namespace OpenEphys.Onix1
     /// </remarks>
     public class ContextTask : IDisposable
     {
-        abstract class WriteAction
-        {
-            readonly uint deviceAddress;
-
-            internal abstract void Write(oni.Context ctx);
-
-            public WriteAction(uint deviceAddress)
-            {
-                this.deviceAddress = deviceAddress;
-            }
-
-            internal sealed class Scalar<T> : WriteAction where T : unmanaged
-            {
-                readonly T data;
-
-                public Scalar(uint deviceAddress, T data) : base(deviceAddress)
-                {
-                    this.data = data;
-                }
-
-                internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
-            }
-
-            internal sealed class Array<T> : WriteAction where T : unmanaged
-            {
-                readonly T[] data;
-
-                public Array(uint deviceAddress, T[] data) : base(deviceAddress)
-                {
-                    this.data = data;
-                }
-
-                internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
-            }
-        }
-
         readonly oni.Context ctx;
 
         /// <summary>
@@ -94,7 +58,7 @@ namespace OpenEphys.Onix1
         Task distributeFrames;
         Task writeFrames;
         Task acquisition = Task.CompletedTask;
-        Channel<WriteAction> writeQueue;
+        Channel<WriterTaskAction> writeActionChannel;
         CancellationTokenSource collectFramesCancellation;
         event Func<ContextTask, IDisposable> ConfigureAndLatchControllerEvent;
         event Func<ContextTask, IDisposable> ConfigureAndLatchLinkEvent;
@@ -492,13 +456,13 @@ namespace OpenEphys.Onix1
                     {
                         SingleReader = true
                     };
-                    writeQueue = Channel.CreateUnbounded<WriteAction>(options);
+                    writeActionChannel = Channel.CreateUnbounded<WriterTaskAction>(options);
 
                     writeFrames = Task.Run(async () =>
                     {
                         try
                         {
-                            await foreach (var writeAction in writeQueue.Reader.ReadAllAsync(collectFramesToken))
+                            await foreach (var writeAction in writeActionChannel.Reader.ReadAllAsync(collectFramesToken))
                             {
                                 writeAction.Write(ctx);
                             }
@@ -511,7 +475,7 @@ namespace OpenEphys.Onix1
                         }
                         finally
                         {
-                            writeQueue.Writer.Complete();
+                            writeActionChannel.Writer.Complete();
                         }
                     },
                     collectFramesToken);
@@ -537,8 +501,8 @@ namespace OpenEphys.Onix1
                             }
                             frameQueue?.Dispose();
                             frameQueue = null;
-                            while (writeQueue?.Reader.TryRead(out _) == true) { }
-                            writeQueue = null;
+                            while (writeActionChannel?.Reader.TryRead(out _) == true) { }
+                            writeActionChannel = null;
                             ctx.Stop();
 
                             contextConfiguration.Dispose();
@@ -624,12 +588,12 @@ namespace OpenEphys.Onix1
 
         internal void Write<T>(uint deviceAddress, T data) where T : unmanaged
         {
-            writeQueue?.Writer.TryWrite(new WriteAction.Scalar<T>(deviceAddress, data));
+            writeActionChannel?.Writer.TryWrite(new ScalarWriterTaskAction<T>(deviceAddress, data));
         }
 
         internal void Write<T>(uint deviceAddress, T[] data) where T : unmanaged
         {
-            writeQueue?.Writer.TryWrite(new WriteAction.Array<T>(deviceAddress, data));
+            writeActionChannel?.Writer.TryWrite(new ArrayWriterTaskAction<T>(deviceAddress, data));
         }
 
         internal oni.Hub GetHub(uint deviceAddress) => ctx.GetHub(deviceAddress);

--- a/OpenEphys.Onix1/ScalarWriterTaskAction.cs
+++ b/OpenEphys.Onix1/ScalarWriterTaskAction.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenEphys.Onix1
+{
+    sealed class ScalarWriterTaskAction<T> : WriterTaskAction where T : unmanaged
+    {
+        readonly T data;
+
+        public ScalarWriterTaskAction(uint deviceAddress, T data) : base(deviceAddress)
+        {
+            this.data = data;
+        }
+
+        internal override void Write(oni.Context ctx) => ctx.Write(deviceAddress, data);
+    }
+}

--- a/OpenEphys.Onix1/WriterTaskAction.cs
+++ b/OpenEphys.Onix1/WriterTaskAction.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenEphys.Onix1
+{
+    abstract class WriterTaskAction
+    {
+        private protected readonly uint deviceAddress;
+
+        public WriterTaskAction(uint deviceAddress)
+        {
+            this.deviceAddress = deviceAddress;
+        }
+
+        internal abstract void Write(oni.Context ctx);
+    }
+}


### PR DESCRIPTION
In #642, @aacuevas brought up a good point that the infrastructure there might be too generic in that it accepts any arbitrary `Action` with no constraints.

This PR attempts to constrain the write queue to only allow `WriteAction` objects instead of generic Actions. The `WriteAction` class is a private class that holds the data to be written, and only executes a `ctx.Write()` call using a passed context, so no additional state is held other than the data to write and the device address.

If this is a valid pattern, we can merge it into the existing PR and then merge to main to keep the commit history clean, otherwise we can close this branch.