### PR TITLE
Add comments to SecondsBeforeFlush and BufferDurationSeconds variables

### DIFF
--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -12,8 +12,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
     public class DataFrameWriter : FileSink
     {
         /// <summary>
-        /// Number of seconds to wait before flushing any data in the buffer to the Arrow file.
-        /// Ensures that devices with sporadic sample rates are still saved to the file periodically.
+        /// Ensures that data produced by devices with non-uniform or slow sample rates are written to file periodically.
         /// </summary>
         const int SecondsBeforeFlush = 5;
 

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -11,6 +11,10 @@ namespace OpenEphys.Onix1.DataFrameWriter
     [WorkflowElementCategory(ElementCategory.Sink)]
     public class DataFrameWriter : FileSink
     {
+        /// <summary>
+        /// Number of seconds to wait before flushing any data in the buffer to the Arrow file.
+        /// Ensures that devices with sporadic sample rates are still saved to the file periodically.
+        /// </summary>
         const int SecondsBeforeFlush = 5;
 
         /// <summary>

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterHelper.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterHelper.cs
@@ -16,12 +16,19 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// cref="RecordBatch"/>.
         /// </summary>
         const int DefaultBufferSize = 1000;
-        
+
         /// <summary>
         /// Represents the mimumum number of <see cref="DataFrame">DataFrames</see> in a <see
         /// cref="RecordBatch"/>.
         /// </summary>
         const int MinimumBufferSize = 100;
+
+        /// <summary>
+        /// Represents the size of the buffer in seconds. This is used to calculate the number of
+        /// incoming data frames to buffer before writing to the Arrow file, based on the expected
+        /// sample rate of the incoming data.
+        /// </summary>
+        const double BufferDurationSeconds = 1.0;
 
         static readonly Dictionary<Type, IArrowType> ArrowTypeMap = new()
         {
@@ -164,7 +171,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
                 }
                 else if (memberType.IsValueType)
                 {
-                    var structMembers = GetDataMembers(memberType); 
+                    var structMembers = GetDataMembers(memberType);
                     foreach (var structMember in structMembers.Reverse())
                     {
                         if (IsMemberIgnored(current.Member, structMember))
@@ -201,7 +208,6 @@ namespace OpenEphys.Onix1.DataFrameWriter
             var sampleRateAttribute = frameType.GetCustomAttribute<ExpectedSampleRateAttribute>();
             if (sampleRateAttribute != null)
             {
-                const double BufferDurationSeconds = 1.0;
                 var bufferSize = (int)(sampleRateAttribute.SampleRateHz * BufferDurationSeconds);
                 return bufferSize >= MinimumBufferSize ? bufferSize : MinimumBufferSize;
             }


### PR DESCRIPTION
Moved `BufferDurationSeconds` to a common location for constant variables, and added comments to constant variables that did not have them.

Fixes #650 