### PR TITLE
Refactor DataFrameWriter and encode subsampled data as REE arrays

### DIFF
--- a/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
@@ -17,9 +17,10 @@ namespace OpenEphys.Onix1.DataFrameWriter
         {
             var frameType = dataFrame.GetType();
             var members = DataFrameWriterHelper.GetDataMembers(frameType);
-            var schema = DataFrameWriterHelper.GenerateSchema(members, dataFrame);
+            var fieldGroups = DataFrameWriterHelper.BuildFieldMappings(members, dataFrame);
+            var schema = DataFrameWriterHelper.BuildSchema(fieldGroups);
             var createRecordBatch = RecordBatchExpressionFactory.CreateBuilder<Func<IList<BufferedDataFrame>, Schema, RecordBatch>>(
-                new BufferedDataFrameExpressionProvider(), frameType, members).Compile();
+                new BufferedDataFrameExpressionProvider(), frameType, fieldGroups).Compile();
             var bufferSize = (int)Math.Ceiling((double)DataFrameWriterHelper.GetBufferSize(frameType) / dataFrame.Clock.Length);
             return new ArrowBatchWriter<BufferedDataFrame>(filename, schema, bufferSize, timeout, createRecordBatch, EnableCompression);
         }

--- a/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameExpressionProvider.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameExpressionProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Apache.Arrow;
@@ -15,7 +14,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
 
         public BufferedDataFrameExpressionProvider()
         {
-            InputParameter = Expression.Parameter(typeof(IList<BufferedDataFrame>), "frame");
+            InputParameter = Expression.Parameter(typeof(IList<BufferedDataFrame>), "bufferedDataFrames");
         }
 
         public Expression GetLengthExpression()
@@ -28,8 +27,8 @@ namespace OpenEphys.Onix1.DataFrameWriter
             var clockArray = Expression.Property(firstFrame, nameof(BufferedDataFrame.Clock));
             var clockArrayLength = Expression.ArrayLength(clockArray);
             var numberOfFrames = Expression.Property(
-                    Expression.Convert(InputParameter, typeof(ICollection<BufferedDataFrame>)),
-                    nameof(ICollection<BufferedDataFrame>.Count));
+                Expression.Convert(InputParameter, typeof(ICollection<BufferedDataFrame>)),
+                nameof(ICollection<BufferedDataFrame>.Count));
             return Expression.Multiply(clockArrayLength, numberOfFrames);
         }
 
@@ -38,104 +37,175 @@ namespace OpenEphys.Onix1.DataFrameWriter
             ParameterExpression arrowArrayIndex,
             ParameterExpression batchRows,
             Type frameType,
-            IEnumerable<MemberInfo> members)
+            IEnumerable<MemberFieldGroup> fieldGroups)
         {
-            var frameParameter = Expression.Parameter(typeof(BufferedDataFrame), "df");
-            List<Expression> expressions = new();
+            var frameParameter = Expression.Parameter(typeof(BufferedDataFrame), "bufferedDataFrame");
+            var expressions = new List<Expression>();
 
-            var stack = new Stack<MemberNode>(members.Select(m => new MemberNode { Member = m }));
-
-            while (stack.Count > 0)
+            foreach (var group in fieldGroups)
             {
-                var current = stack.Pop();
-                var memberType = DataFrameWriterHelper.GetMemberType(current.Member);
+                var memberType = DataFrameWriterHelper.GetMemberType(group.Member.Member);
 
-                if (memberType.IsArray)
+                switch (memberType)
                 {
-                    var memberAccessor = DataFrameWriterHelper.CreateMemberAccess(
-                        Expression.Convert(frameParameter, frameType),
-                        current);
+                    case { IsArray: true }:
+                        expressions.Add(BuildArrayExpression(group, frameType, frameParameter, arrowArrays, arrowArrayIndex));
+                        break;
 
-                    var convertFrameMemberMethod = typeof(BufferedDataFrameExpressionProvider)
-                                .GetMethod(nameof(ConvertFrameMemberToArrowArray), BindingFlags.Static | BindingFlags.NonPublic)
-                                .MakeGenericMethod(memberType.GetElementType());
+                    case var t when t == typeof(Mat):
+                        if (group.Fields[0].DataType is RunEndEncodedType)
+                            expressions.Add(BuildRunEndEncodedMatExpression(group, frameType, frameParameter, arrowArrays, arrowArrayIndex));
+                        else
+                            expressions.Add(BuildMatExpression(group, frameType, frameParameter, arrowArrays, arrowArrayIndex, batchRows));
+                        break;
 
-                    expressions.Add(ConvertFrameMemberExpressionBuilder(
-                        memberType, frameParameter, arrowArrays, arrowArrayIndex,
-                        InputParameter, memberAccessor,
-                        convertFrameMemberMethod));
-                }
-                else if (memberType == typeof(Mat))
-                {
-                    var combineMatMethod = typeof(BufferedDataFrameExpressionProvider)
-                        .GetMethod(nameof(CombineMatObjects), BindingFlags.Static | BindingFlags.NonPublic);
-
-                    var combinedMat = Expression.Variable(typeof(Mat), "combinedMat");
-                    var combineMatCall = Expression.Call(
-                        combineMatMethod,
-                        InputParameter,
-                        Expression.Lambda<Func<BufferedDataFrame, Mat>>(
-                            DataFrameWriterHelper.CreateMemberAccess(
-                                Expression.Convert(frameParameter, frameType),
-                                current),
-                            frameParameter));
-
-                    var convertMatRowMethod = typeof(BufferedDataFrameExpressionProvider)
-                        .GetMethod(nameof(ConvertMatRowToArrowArray), BindingFlags.Static | BindingFlags.NonPublic);
-
-                    var matElementType = Expression.Variable(typeof(IArrowType), "matElementType");
-                    var rowIndex = Expression.Variable(typeof(int), "rowIndex");
-                    var breakLabel = Expression.Label("break");
-
-                    var loopBody = Expression.Block(
-                        Expression.Assign(
-                            Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
-                            Expression.Call(
-                                convertMatRowMethod,
-                                combinedMat,
-                                rowIndex,
-                                matElementType,
-                                batchRows)),
-                        Expression.PostIncrementAssign(arrowArrayIndex));
-
-                    var forLoop = Expression.Block(
-                        new[] { matElementType, rowIndex },
-                        Expression.Assign(rowIndex, Expression.Constant(0)),
-                        Expression.Assign(
-                            matElementType,
-                            Expression.Call(
-                                typeof(DataFrameWriterHelper).GetMethod(
-                                    nameof(DataFrameWriterHelper.GetArrowType),
-                                    BindingFlags.Static | BindingFlags.NonPublic,
-                                    null,
-                                    new[] { typeof(Depth) },
-                                    null),
-                                Expression.Property(combinedMat, nameof(Mat.Depth)))),
-                        Expression.Loop(
-                            Expression.IfThenElse(
-                                Expression.LessThan(
-                                    rowIndex,
-                                    Expression.Property(combinedMat, nameof(Mat.Rows))),
-                                Expression.Block(
-                                    loopBody,
-                                    Expression.PostIncrementAssign(rowIndex)),
-                                Expression.Break(breakLabel)),
-                            breakLabel));
-
-                    expressions.Add(Expression.Block(
-                        new[] { combinedMat },
-                        Expression.Assign(combinedMat, combineMatCall),
-                        forLoop
-                    ));
-                }
-                else
-                {
-                    throw new NotSupportedException(
+                    default:
+                        throw new NotSupportedException(
                         $"The member type '{memberType}' is not supported for generating RecordBatch builders.");
                 }
             }
 
             return expressions;
+        }
+
+        Expression BuildArrayExpression(
+            MemberFieldGroup group,
+            Type frameType,
+            ParameterExpression frameParameter,
+            ParameterExpression arrowArrays,
+            ParameterExpression arrowArrayIndex)
+        {
+            var memberType = DataFrameWriterHelper.GetMemberType(group.Member.Member);
+            var memberAccessor = DataFrameWriterHelper.CreateMemberAccess(
+                Expression.Convert(frameParameter, frameType), group.Member);
+
+            var convertFrameMemberMethod = typeof(BufferedDataFrameExpressionProvider)
+                .GetMethod(nameof(ConvertFrameMemberToArrowArray), BindingFlags.Static | BindingFlags.NonPublic)
+                .MakeGenericMethod(memberType.GetElementType());
+
+            return ConvertFrameMemberExpressionBuilder(
+                memberType, frameParameter, arrowArrays, arrowArrayIndex,
+                InputParameter, memberAccessor, convertFrameMemberMethod);
+        }
+
+        Expression BuildMatExpression(
+            MemberFieldGroup group,
+            Type frameType,
+            ParameterExpression frameParameter,
+            ParameterExpression arrowArrays,
+            ParameterExpression arrowArrayIndex,
+            ParameterExpression batchRows)
+        {
+            var combineMatMethod = typeof(BufferedDataFrameExpressionProvider)
+                .GetMethod(nameof(CombineMatObjects), BindingFlags.Static | BindingFlags.NonPublic);
+            var convertMatRowMethod = typeof(BufferedDataFrameExpressionProvider)
+                .GetMethod(nameof(ConvertMatRowToArrowArray), BindingFlags.Static | BindingFlags.NonPublic);
+            var getArrowTypeMethod = typeof(DataFrameWriterHelper).GetMethod(
+                nameof(DataFrameWriterHelper.GetArrowType),
+                BindingFlags.Static | BindingFlags.NonPublic,
+                null, new[] { typeof(Depth) }, null);
+
+            var combinedMat = Expression.Variable(typeof(Mat), "combinedMat");
+            var matElementType = Expression.Variable(typeof(IArrowType), "matElementType");
+            var rowIndex = Expression.Variable(typeof(int), "rowIndex");
+            var breakLabel = Expression.Label("break");
+
+            var combineMatCall = Expression.Call(
+                combineMatMethod,
+                InputParameter,
+                Expression.Lambda<Func<BufferedDataFrame, Mat>>(
+                    DataFrameWriterHelper.CreateMemberAccess(
+                        Expression.Convert(frameParameter, frameType), group.Member),
+                    frameParameter));
+
+            var loopBody = Expression.Block(
+                Expression.Assign(
+                    Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
+                    Expression.Call(convertMatRowMethod, combinedMat, rowIndex, matElementType, batchRows)),
+                Expression.PostIncrementAssign(arrowArrayIndex));
+
+            var forLoop = Expression.Block(
+                new[] { matElementType, rowIndex },
+                Expression.Assign(rowIndex, Expression.Constant(0)),
+                Expression.Assign(
+                    matElementType,
+                    Expression.Call(getArrowTypeMethod, Expression.Property(combinedMat, nameof(Mat.Depth)))),
+                Expression.Loop(
+                    Expression.IfThenElse(
+                        Expression.LessThan(rowIndex, Expression.Property(combinedMat, nameof(Mat.Rows))),
+                        Expression.Block(loopBody, Expression.PostIncrementAssign(rowIndex)),
+                        Expression.Break(breakLabel)),
+                    breakLabel));
+
+            return Expression.Block(
+                new[] { combinedMat },
+                Expression.Assign(combinedMat, combineMatCall),
+                forLoop);
+        }
+
+        Expression BuildRunEndEncodedMatExpression(
+            MemberFieldGroup group,
+            Type frameType,
+            ParameterExpression frameParameter,
+            ParameterExpression arrowArrays,
+            ParameterExpression arrowArrayIndex)
+        {
+            var combineMatMethod = typeof(BufferedDataFrameExpressionProvider)
+                .GetMethod(nameof(CombineMatObjects), BindingFlags.Static | BindingFlags.NonPublic);
+            var convertMatRowMethod = typeof(BufferedDataFrameExpressionProvider)
+                .GetMethod(nameof(ConvertMatRowToRunEndEncodedArrowArray), BindingFlags.Static | BindingFlags.NonPublic);
+            var getArrowTypeMethod = typeof(DataFrameWriterHelper).GetMethod(
+                nameof(DataFrameWriterHelper.GetArrowType),
+                BindingFlags.Static | BindingFlags.NonPublic,
+                null, new[] { typeof(Depth) }, null);
+
+            var attr = group.Member.Member.GetCustomAttribute<SubsampledAttribute>();
+            var stride = Expression.Constant(attr.Divisor);
+
+            var combinedMat = Expression.Variable(typeof(Mat), "combinedMat");
+            var matElementType = Expression.Variable(typeof(IArrowType), "matElementType");
+            var rowIndex = Expression.Variable(typeof(int), "rowIndex");
+            var runEndsArray = Expression.Variable(typeof(IArrowArray), "runEndArray");
+            var breakLabel = Expression.Label("break");
+
+            var combineMatCall = Expression.Call(
+                combineMatMethod,
+                InputParameter,
+                Expression.Lambda<Func<BufferedDataFrame, Mat>>(
+                    DataFrameWriterHelper.CreateMemberAccess(
+                        Expression.Convert(frameParameter, frameType), group.Member),
+                    frameParameter));
+
+            var runEndsArrayCall = Expression.Call(
+                typeof(BufferedDataFrameExpressionProvider)
+                    .GetMethod(nameof(CreateRunEnds), BindingFlags.Static | BindingFlags.NonPublic),
+                Expression.Property(combinedMat, nameof(Mat.Cols)),
+                stride);
+
+            var loopBody = Expression.Block(
+                Expression.Assign(
+                    Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
+                    Expression.Call(convertMatRowMethod, combinedMat, rowIndex, matElementType, runEndsArray)),
+                Expression.PostIncrementAssign(arrowArrayIndex));
+
+            var forLoop = Expression.Block(
+                new[] { matElementType, rowIndex, runEndsArray },
+                Expression.Assign(runEndsArray, runEndsArrayCall),
+                Expression.Assign(rowIndex, Expression.Constant(0)),
+                Expression.Assign(
+                    matElementType,
+                    Expression.Call(getArrowTypeMethod, Expression.Property(combinedMat, nameof(Mat.Depth)))),
+                Expression.Loop(
+                    Expression.IfThenElse(
+                        Expression.LessThan(rowIndex, Expression.Property(combinedMat, nameof(Mat.Rows))),
+                        Expression.Block(loopBody, Expression.PostIncrementAssign(rowIndex)),
+                        Expression.Break(breakLabel)),
+                    breakLabel));
+
+            return Expression.Block(
+                new[] { combinedMat },
+                Expression.Assign(combinedMat, combineMatCall),
+                forLoop);
         }
 
         static int GetTotalSamples(IList<BufferedDataFrame> frames)
@@ -146,7 +216,10 @@ namespace OpenEphys.Onix1.DataFrameWriter
             return frames.Count * samplesPerFrame;
         }
 
-        static IArrowArray ConvertFrameMemberToArrowArray<TMember>(IList<BufferedDataFrame> frames, Func<BufferedDataFrame, TMember[]> getter, IArrowType arrowType) where TMember : unmanaged
+        static IArrowArray ConvertFrameMemberToArrowArray<TMember>(
+            IList<BufferedDataFrame> frames, 
+            Func<BufferedDataFrame, TMember[]> getter, 
+            IArrowType arrowType) where TMember : unmanaged
         {
             int length = GetTotalSamples(frames);
 
@@ -185,7 +258,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
                             frameParameter
                         );
 
-            var block = Expression.Block(
+            return Expression.Block(
                 Expression.Assign(
                     Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
                     Expression.Call(
@@ -197,51 +270,18 @@ namespace OpenEphys.Onix1.DataFrameWriter
                 ),
                 Expression.PostIncrementAssign(arrowArrayIndex)
             );
-
-            return block;
         }
 
-        static ArrowBuffer CreateStrideValidityBitmap(int validCount, int totalCount, int stride)
+        static IArrowArray CreateRunEnds(int dataLength, int runLength)
         {
-            int byteCount = (totalCount + 7) / 8;
-            byte[] bitmap = new byte[byteCount];
+            var runEndsBuilder = new Int32Array.Builder().Reserve(dataLength);
 
-            for (int i = 0; i < validCount; i++)
+            for (int i = 0; i < dataLength; i++)
             {
-                int bitIndex = i * stride;
-                if (bitIndex >= totalCount) break;
-
-                bitmap[bitIndex >> 3] |= (byte)(1 << (bitIndex & 7));
+                runEndsBuilder.Append((i + 1) * runLength);
             }
 
-            return new ArrowBuffer(bitmap);
-        }
-
-        static unsafe void StrideCopy<T>(void* src, void* dest, int elementCount, int stride) where T : unmanaged
-        {
-            T* srcPtr = (T*)src;
-            T* destPtr = (T*)dest;
-
-            for (int i = 0; i < elementCount; i++)
-            {
-                *destPtr = *srcPtr++;
-                destPtr += stride;
-            }
-        }
-
-        static unsafe void StrideCopyFromDepth(Depth depth, void* src, void* dest, int elementCount, int stride)
-        {
-            switch (depth)
-            {
-                case Depth.U8: StrideCopy<byte>(src, dest, elementCount, stride); break;
-                case Depth.S8: StrideCopy<sbyte>(src, dest, elementCount, stride); break;
-                case Depth.U16: StrideCopy<ushort>(src, dest, elementCount, stride); break;
-                case Depth.S16: StrideCopy<short>(src, dest, elementCount, stride); break;
-                case Depth.S32: StrideCopy<int>(src, dest, elementCount, stride); break;
-                case Depth.F32: StrideCopy<float>(src, dest, elementCount, stride); break;
-                case Depth.F64: StrideCopy<double>(src, dest, elementCount, stride); break;
-                default: throw new NotSupportedException($"Cannot StrideCopy for depth '{depth}'.");
-            }
+            return runEndsBuilder.Build();
         }
 
         static Mat CombineMatObjects(IList<BufferedDataFrame> frames, Func<BufferedDataFrame, Mat> getter)
@@ -267,53 +307,45 @@ namespace OpenEphys.Onix1.DataFrameWriter
             return dest;
         }
 
-        static unsafe IArrowArray ConvertMatRowToArrowArray(Mat mat, int rowIndex, IArrowType elementType, int batchRows)
+        static IArrowArray ConvertMatRowToArrowArray(Mat mat, int rowIndex, IArrowType elementType, int batchRows)
         {
-            int length = mat.Cols;
-
-            if (batchRows < length)
-                throw new InvalidOperationException($"The number of batch rows ({batchRows}) is smaller than the number of samples in the Mat ({length}).");
-
-            if (batchRows % length != 0)
-                throw new InvalidOperationException($"The number of batch rows ({batchRows}) must be a multiple of the number of samples in the Mat ({length}).");
-
-            int stride = batchRows / length;
+            if (batchRows != mat.Cols)
+                throw new InvalidOperationException($"The number of batch rows ({batchRows}) is not equal to the number of samples in the Mat ({mat.Cols}).");
 
             var rowManager = new MatRowMemoryManager(mat, rowIndex);
-            int nullCount = batchRows - length;
-            ArrowBuffer arrowBuffer;
-            ArrowBuffer nullBitmap;
-
-            if (nullCount == 0)
-            {
-                arrowBuffer = new ArrowBuffer(rowManager.Memory);
-                nullBitmap = ArrowBuffer.Empty;
-            }
-            else
-            {
-                byte[] buffer = new byte[batchRows * mat.ElementSize];
-
-                fixed (byte* bufferPtr = buffer)
-                {
-                    using var handle = rowManager.Memory.Pin();
-                    StrideCopyFromDepth(mat.Depth, handle.Pointer, bufferPtr, length, stride);
-                }
-
-                arrowBuffer = new ArrowBuffer(buffer);
-                nullBitmap = CreateStrideValidityBitmap(length, batchRows, stride);
-            }
 
             var arrayData = new ArrayData(
                 elementType,
                 batchRows,
-                nullCount,
                 0,
-                new[] { nullBitmap, arrowBuffer },
+                0,
+                new[] { ArrowBuffer.Empty, new ArrowBuffer(rowManager.Memory) },
                 null,
                 null
             );
 
             return ArrowArrayFactory.BuildArray(arrayData);
+        }
+
+        static IArrowArray ConvertMatRowToRunEndEncodedArrowArray(Mat mat, int rowIndex, IArrowType elementType, IArrowArray runEnds)
+        {
+            int length = mat.Cols;
+
+            if (runEnds.Length != length)
+                throw new InvalidOperationException($"The number of run ends ({runEnds.Length}) is smaller than the number of samples in the Mat ({length}).");
+
+            var rowManager = new MatRowMemoryManager(mat, rowIndex);
+            var values = new ArrayData(
+                elementType,
+                length,
+                0,
+                0,
+                new[] { ArrowBuffer.Empty, new ArrowBuffer(rowManager.Memory) },
+                null,
+                null
+            );
+
+            return new RunEndEncodedArray(runEnds, ArrowArrayFactory.BuildArray(values));
         }
     }
 }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
@@ -17,8 +17,10 @@ namespace OpenEphys.Onix1.DataFrameWriter
         {
             var frameType = frame.GetType();
             var members = DataFrameWriterHelper.GetDataMembers(frameType);
-            var schema = DataFrameWriterHelper.GenerateSchema(members, frame);
-            var createRecordBatch = RecordBatchExpressionFactory.CreateBuilder<Func<IList<DataFrame>, Schema, RecordBatch>>( new DataFrameExpressionProvider(), frameType, members).Compile();
+            var fieldGroups = DataFrameWriterHelper.BuildFieldMappings(members, frame);
+            var schema = DataFrameWriterHelper.BuildSchema(fieldGroups);
+            var createRecordBatch = RecordBatchExpressionFactory.CreateBuilder<Func<IList<DataFrame>, Schema, RecordBatch>>(
+                new DataFrameExpressionProvider(), frameType, fieldGroups).Compile();
             var bufferSize = DataFrameWriterHelper.GetBufferSize(frameType);
             return new ArrowBatchWriter<DataFrame>(filename, schema, bufferSize, timeout, createRecordBatch, EnableCompression);
         }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameExpressionProvider.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameExpressionProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Apache.Arrow;
@@ -20,8 +19,8 @@ namespace OpenEphys.Onix1.DataFrameWriter
         public Expression GetLengthExpression()
         {
             return Expression.Property(
-                    Expression.Convert(InputParameter, typeof(ICollection<DataFrame>)),
-                    nameof(ICollection<DataFrame>.Count));
+                Expression.Convert(InputParameter, typeof(ICollection<DataFrame>)),
+                nameof(ICollection<DataFrame>.Count));
         }
 
         public List<Expression> GetArrayPopulationExpressions(
@@ -29,68 +28,49 @@ namespace OpenEphys.Onix1.DataFrameWriter
             ParameterExpression arrowArrayIndex,
             ParameterExpression batchRows,
             Type frameType,
-            IEnumerable<MemberInfo> members)
+            IEnumerable<MemberFieldGroup> fieldGroups)
         {
-            var frameParameter = Expression.Parameter(typeof(DataFrame), "df");
-            List<Expression> expressions = new();
+            var frameParameter = Expression.Parameter(typeof(DataFrame), "dataFrame");
+            var expressions = new List<Expression>();
 
-            var stack = new Stack<MemberNode>(members.Select(m => new MemberNode { Member = m }));
-
-            while (stack.Count > 0)
+            foreach (var group in fieldGroups)
             {
-                var current = stack.Pop();
-                var memberType = DataFrameWriterHelper.GetMemberType(current.Member);
+                var memberType = DataFrameWriterHelper.GetMemberType(group.Member.Member);
 
-                if (memberType.IsPrimitive)
+                switch (memberType)
                 {
-                    var memberAccessor = DataFrameWriterHelper.CreateMemberAccess(
-                        Expression.Convert(frameParameter, frameType),
-                        current);
-
-                    expressions.Add(ConvertFrameMemberExpressionBuilder(
-                        memberType, frameParameter, arrowArrays, arrowArrayIndex,
-                        InputParameter, batchRows, memberAccessor));
-                }
-                else if (memberType.IsEnum)
-                {
-                    var memberAccessor = Expression.Convert(
-                        DataFrameWriterHelper.CreateMemberAccess(
-                            Expression.Convert(frameParameter, frameType),
-                            current),
-                        Enum.GetUnderlyingType(memberType));
-
-                    expressions.Add(ConvertFrameMemberExpressionBuilder(
-                        Enum.GetUnderlyingType(memberType), frameParameter,
-                        arrowArrays, arrowArrayIndex, InputParameter,
-                        batchRows, memberAccessor));
-                }
-                else if (memberType.IsValueType)
-                {
-                    var structMembers = DataFrameWriterHelper.GetDataMembers(memberType);
-
-                    foreach (var structMember in structMembers.Reverse())
+                    case { IsPrimitive: true }:
+                    { 
+                        var memberAccessor = DataFrameWriterHelper.CreateMemberAccess(
+                        Expression.Convert(frameParameter, frameType), group.Member);
+                        expressions.Add(ConvertFrameMemberExpressionBuilder(
+                            memberType, frameParameter, arrowArrays, arrowArrayIndex,
+                            InputParameter, batchRows, memberAccessor));
+                        break;
+                     }
+                    case { IsEnum: true }:
                     {
-                        if (DataFrameWriterHelper.IsMemberIgnored(current.Member, structMember))
-                            continue;
-
-                        stack.Push(new MemberNode
-                        {
-                            Member = structMember,
-                            Parent = current
-                        });
+                        var memberAccessor = Expression.Convert(
+                            DataFrameWriterHelper.CreateMemberAccess(
+                                Expression.Convert(frameParameter, frameType), group.Member),
+                            Enum.GetUnderlyingType(memberType));
+                        expressions.Add(ConvertFrameMemberExpressionBuilder(
+                            Enum.GetUnderlyingType(memberType), frameParameter,
+                            arrowArrays, arrowArrayIndex, InputParameter, batchRows, memberAccessor));
+                        break;
                     }
-                }
-                else
-                {
-                    throw new NotSupportedException(
-                        $"The member type '{memberType}' is not supported for generating RecordBatch builders.");
+                    default:
+                        throw new NotSupportedException($"The member type '{memberType}' is not supported for generating RecordBatch builders.");
                 }
             }
 
             return expressions;
         }
 
-        static IArrowArray ConvertFrameMemberToArrowArray<TMember>(IList<DataFrame> frames, Func<DataFrame, TMember> getter, IArrowType arrowType, int length) where TMember : unmanaged
+        static IArrowArray ConvertFrameMemberToArrowArray<TMember>(
+            IList<DataFrame> frames,
+            Func<DataFrame, TMember> getter, 
+            IArrowType arrowType, int length) where TMember : unmanaged
         {
             var array = new TMember[length];
 
@@ -122,7 +102,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
                             frameParameter
                         );
 
-            var block = Expression.Block(
+            return Expression.Block(
                 Expression.Assign(
                     Expression.ArrayAccess(arrowArrays, arrowArrayIndex),
                     Expression.Call(
@@ -135,8 +115,6 @@ namespace OpenEphys.Onix1.DataFrameWriter
                 ),
                 Expression.PostIncrementAssign(arrowArrayIndex)
             );
-
-            return block;
         }
     }
 }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -5,8 +5,8 @@ using Bonsai.IO;
 namespace OpenEphys.Onix1.DataFrameWriter
 {
     /// <summary>
-    /// Represents an operator that writes each data frame in the sequence
-    /// to an Apache Arrow file using an <see cref="ArrowWriter"/>.
+    /// Represents an operator that writes each data frame in the sequence to an Apache Arrow file using an
+    /// <see cref="ArrowWriter"/>.
     /// </summary>
     [WorkflowElementCategory(ElementCategory.Sink)]
     public class DataFrameWriter : FileSink
@@ -21,10 +21,11 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// <summary>
         /// Writes all of the data frames in the sequence to an Apache Arrow file.
         /// </summary>
-        /// <param name="source">The sequence of <see cref="BufferedDataFrame">BufferedDataFrame's</see> to write.</param>
+        /// <param name="source">The sequence of <see cref="BufferedDataFrame">BufferedDataFrame's</see> to
+        /// write.</param>
         /// <returns>
-        /// An observable sequence that is identical to the source sequence but where
-        /// there is an additional side effect of writing the frames to an Apache Arrow file.
+        /// An observable sequence that is identical to the source sequence but where there is an additional
+        /// side effect of writing the frames to an Apache Arrow file.
         /// </returns>
         public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source)
         {

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterHelper.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterHelper.cs
@@ -16,27 +16,40 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// cref="RecordBatch"/>.
         /// </summary>
         const int DefaultBufferSize = 1000;
-        
+
         /// <summary>
         /// Represents the mimumum number of <see cref="DataFrame">DataFrames</see> in a <see
         /// cref="RecordBatch"/>.
         /// </summary>
         const int MinimumBufferSize = 100;
 
-        static readonly Dictionary<Type, IArrowType> ArrowTypeMap = new()
+        internal static IArrowType GetArrowType(Type type) => type switch
         {
-            [typeof(byte)] = UInt8Type.Default,
-            [typeof(sbyte)] = Int8Type.Default,
-            [typeof(ushort)] = UInt16Type.Default,
-            [typeof(short)] = Int16Type.Default,
-            [typeof(uint)] = UInt32Type.Default,
-            [typeof(int)] = Int32Type.Default,
-            [typeof(ulong)] = UInt64Type.Default,
-            [typeof(long)] = Int64Type.Default,
-            [typeof(float)] = FloatType.Default,
-            [typeof(double)] = DoubleType.Default,
-            [typeof(bool)] = BooleanType.Default,
-            [typeof(string)] = StringType.Default
+            _ when type == typeof(byte) => UInt8Type.Default,
+            _ when type == typeof(sbyte) => Int8Type.Default,
+            _ when type == typeof(ushort) => UInt16Type.Default,
+            _ when type == typeof(short) => Int16Type.Default,
+            _ when type == typeof(uint) => UInt32Type.Default,
+            _ when type == typeof(int) => Int32Type.Default,
+            _ when type == typeof(ulong) => UInt64Type.Default,
+            _ when type == typeof(long) => Int64Type.Default,
+            _ when type == typeof(float) => FloatType.Default,
+            _ when type == typeof(double) => DoubleType.Default,
+            _ when type == typeof(bool) => BooleanType.Default,
+            _ when type == typeof(string) => StringType.Default,
+            _ => throw new NotSupportedException($"The type '{type}' is not supported for mapping to an ArrowType.")
+        };
+
+        internal static IArrowType GetArrowType(Depth depth) => depth switch
+        {
+            Depth.U8 => GetArrowType(typeof(byte)),
+            Depth.S8 => GetArrowType(typeof(sbyte)),
+            Depth.U16 => GetArrowType(typeof(ushort)),
+            Depth.S16 => GetArrowType(typeof(short)),
+            Depth.S32 => GetArrowType(typeof(int)),
+            Depth.F32 => GetArrowType(typeof(float)),
+            Depth.F64 => GetArrowType(typeof(double)),
+            _ => throw new NotSupportedException($"Cannot get the ArrowType for the given depth value '{depth}'.")
         };
 
         internal static IArrowArray ConvertArrayToArrowArray<T>(T[] array, IArrowType arrowType, int length) where T : unmanaged
@@ -71,25 +84,6 @@ namespace OpenEphys.Onix1.DataFrameWriter
                 return CreateMemberAccess(instance, member.Member);
 
             return CreateMemberAccess(CreateMemberAccess(instance, member.Parent), member.Member);
-        }
-
-        internal static IArrowType GetArrowType(Type type) => ArrowTypeMap.TryGetValue(type, out var arrowType)
-            ? arrowType
-            : throw new NotSupportedException($"The type '{type}' is not supported for mapping to an ArrowType.");
-
-        internal static IArrowType GetArrowType(Depth depth)
-        {
-            return depth switch
-            {
-                Depth.U8 => GetArrowType(typeof(byte)),
-                Depth.S8 => GetArrowType(typeof(sbyte)),
-                Depth.U16 => GetArrowType(typeof(ushort)),
-                Depth.S16 => GetArrowType(typeof(short)),
-                Depth.S32 => GetArrowType(typeof(int)),
-                Depth.F32 => GetArrowType(typeof(float)),
-                Depth.F64 => GetArrowType(typeof(double)),
-                _ => throw new NotSupportedException($"Cannot get the ArrowType for the given depth value '{depth}'.")
-            };
         }
 
         internal static IEnumerable<MemberInfo> GetDataMembers(Type type)
@@ -129,19 +123,46 @@ namespace OpenEphys.Onix1.DataFrameWriter
             return false;
         }
 
-        static object GetMemberValue(MemberInfo member, object instance)
+        static object GetMemberValue(MemberInfo member, object instance) => member switch
         {
-            return member switch
+            FieldInfo fieldInfo => fieldInfo.GetValue(instance),
+            PropertyInfo propertyInfo => propertyInfo.GetValue(instance),
+            _ => throw new InvalidOperationException($"Cannot get value of {member.GetType()} member from {instance.GetType()} object."),
+
+        };
+
+        static Field CreatePrimitiveField(MemberNode node, Type type) =>
+            new(node.GetFullName(), GetArrowType(type), false);
+
+        static Field CreateArrayField(MemberNode node, Type arrayType) =>
+            new(node.GetFullName(), GetArrowType(arrayType.GetElementType()), false);
+
+        static Field CreateEnumField(MemberNode node, Type enumType) =>
+            new(node.GetFullName(), GetArrowType(Enum.GetUnderlyingType(enumType)), false);
+
+        static IReadOnlyList<Field> CreateMatFields(MemberNode node, object instance)
+        {
+            var mat = GetMemberValue(node.Member, instance) as Mat
+                ?? throw new NullReferenceException($"No valid Mat property on the {instance.GetType()} object.");
+            var reeAttr = node.Member.GetCustomAttribute<SubsampledAttribute>();
+            var fields = new List<Field>(mat.Rows);
+
+            for (int i = 0; i < mat.Rows; i++)
             {
-                FieldInfo fieldInfo => fieldInfo.GetValue(instance),
-                PropertyInfo propertyInfo => propertyInfo.GetValue(instance),
-                _ => throw new InvalidOperationException($"Cannot get value of {member.GetType()} member from {instance.GetType()} object."),
-            };
+                var fieldName = $"{node.GetFullName()}{i}";
+                fields.Add(reeAttr != null
+                    ? new Field(fieldName, new RunEndEncodedType(
+                        new Field($"runEnds{i}", Int32Type.Default, false),
+                        new Field($"values{i}", GetArrowType(mat.Depth), false)), false)
+                    : new Field(fieldName, GetArrowType(mat.Depth), false));
+            }
+
+            return fields;
         }
 
-        internal static Schema GenerateSchema(IEnumerable<MemberInfo> members, object instance)
+        internal static IReadOnlyList<MemberFieldGroup> BuildFieldMappings(IEnumerable<MemberInfo> members, object instance)
         {
-            var fields = new List<Field>();
+            var groups = new List<MemberFieldGroup>();
             var stack = new Stack<MemberNode>(members.Select(m => new MemberNode { Member = m }));
 
             while (stack.Count > 0)
@@ -149,52 +170,42 @@ namespace OpenEphys.Onix1.DataFrameWriter
                 var current = stack.Pop();
                 var memberType = GetMemberType(current.Member);
 
-                if (memberType.IsPrimitive)
+                switch (memberType)
                 {
-                    fields.Add(new Field(current.GetFullName(), GetArrowType(memberType), false));
-                }
-                else if (memberType.IsArray)
-                {
-                    fields.Add(new Field(current.GetFullName(), GetArrowType(memberType.GetElementType()), false));
-                }
-                else if (memberType.IsEnum)
-                {
-                    // TODO: See if the Dictionary type in Arrow would be better for enums
-                    fields.Add(new Field(current.GetFullName(), GetArrowType(Enum.GetUnderlyingType(memberType)), false));
-                }
-                else if (memberType.IsValueType)
-                {
-                    var structMembers = GetDataMembers(memberType); 
-                    foreach (var structMember in structMembers.Reverse())
-                    {
-                        if (IsMemberIgnored(current.Member, structMember))
-                            continue;
+                    case { IsPrimitive: true }:
+                        groups.Add(new MemberFieldGroup(current, new[] { CreatePrimitiveField(current, memberType) }));
+                        break;
 
-                        stack.Push(new MemberNode
+                    case { IsArray: true }:
+                        groups.Add(new MemberFieldGroup(current, new[] { CreateArrayField(current, memberType) }));
+                        break;
+
+                    case { IsEnum: true }:
+                        groups.Add(new MemberFieldGroup(current, new[] { CreateEnumField(current, memberType) }));
+                        break;
+
+                    case { IsValueType: true }:
+                        foreach (var structMember in GetDataMembers(memberType).Reverse())
                         {
-                            Member = structMember,
-                            Parent = current
-                        });
-                    }
-                }
-                else if (memberType == typeof(Mat))
-                {
-                    var mat = GetMemberValue(current.Member, instance) as Mat ?? throw new NullReferenceException($"No valid Mat property on the {instance.GetType()} object.");
+                            if (!IsMemberIgnored(current.Member, structMember))
+                                stack.Push(new MemberNode { Member = structMember, Parent = current });
+                        }
+                        break;
 
-                    for (int i = 0; i < mat.Rows; i++)
-                    {
-                        // Note: Could add an attribute to data frames properties to specify custom field naming
-                        fields.Add(new Field($"{current.GetFullName()}Ch{i}", GetArrowType(mat.Depth), false));
-                    }
-                }
-                else
-                {
-                    throw new NotSupportedException($"The member type '{memberType}' is not supported for generating schemas.");
+                    case var t when t == typeof(Mat):
+                        groups.Add(new MemberFieldGroup(current, CreateMatFields(current, instance)));
+                        break;
+
+                    default:
+                        throw new NotSupportedException($"The member type '{memberType}' is not supported for generating schema mappings.");
                 }
             }
 
-            return new Schema(fields, null);
+            return groups;
         }
+
+        internal static Schema BuildSchema(IReadOnlyList<MemberFieldGroup> fieldGroups) => 
+            new(fieldGroups.SelectMany(g => g.Fields), null);
 
         internal static int GetBufferSize(Type frameType)
         {

--- a/OpenEphys.Onix1/DataFrameWriter/IRecordBatchExpressionProvider.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/IRecordBatchExpressionProvider.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
@@ -16,6 +15,6 @@ namespace OpenEphys.Onix1.DataFrameWriter
             ParameterExpression arrowArrayIndex,
             ParameterExpression batchRows,
             Type frameType,
-            IEnumerable<MemberInfo> members);
+            IEnumerable<MemberFieldGroup> fieldGroups);
     }
 }

--- a/OpenEphys.Onix1/DataFrameWriter/RecordBatchExpressionFactory.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/RecordBatchExpressionFactory.cs
@@ -24,18 +24,18 @@ namespace OpenEphys.Onix1.DataFrameWriter
             );
 
             return Expression.Assign(
-                    arrowArrays,
-                    Expression.NewArrayBounds(
-                        typeof(IArrowArray),
-                        Expression.Property(fieldsListAsCollection, nameof(Schema.FieldsList.Count))
-                    )
-                );
+                arrowArrays,
+                Expression.NewArrayBounds(
+                    typeof(IArrowArray),
+                    Expression.Property(fieldsListAsCollection, nameof(Schema.FieldsList.Count))
+                )
+            );
         }
 
         internal static Expression<TDelegate> CreateBuilder<TDelegate>(
             IRecordBatchExpressionProvider provider,
             Type frameType,
-            IEnumerable<MemberInfo> members)
+            IReadOnlyList<MemberFieldGroup> fieldGroups)
         {
             var expressions = new List<Expression>();
             var parameters = new List<ParameterExpression>();
@@ -43,14 +43,10 @@ namespace OpenEphys.Onix1.DataFrameWriter
             var arrowArrays = Expression.Variable(typeof(IArrowArray[]), "arrowArrays");
             var arrowArrayIndex = Expression.Variable(typeof(int), "arrowArrayIndex");
             var schemaParameter = Expression.Parameter(typeof(Schema), "schema");
-            var batchRowsExpression = provider.GetLengthExpression();
             var batchRowsVariable = Expression.Variable(typeof(int), "batchRows");
 
             parameters.Add(batchRowsVariable);
-            expressions.Add(Expression.Assign(
-                batchRowsVariable,
-                batchRowsExpression
-            ));
+            expressions.Add(Expression.Assign(batchRowsVariable, provider.GetLengthExpression()));
 
             parameters.Add(arrowArrays);
             expressions.Add(InitializeArrowArrayFromSchema(schemaParameter, arrowArrays));
@@ -60,7 +56,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
 
             expressions.AddRange(
                 provider.GetArrayPopulationExpressions(
-                    arrowArrays, arrowArrayIndex, batchRowsVariable, frameType, members));
+                    arrowArrays, arrowArrayIndex, batchRowsVariable, frameType, fieldGroups));
 
             var recordBatch = Expression.Variable(typeof(RecordBatch), "recordBatch");
             parameters.Add(recordBatch);

--- a/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
@@ -1,4 +1,5 @@
 ﻿using OpenCV.Net;
+using OpenEphys.Onix1.DataFrameWriter;
 
 namespace OpenEphys.Onix1
 {
@@ -69,6 +70,7 @@ namespace OpenEphys.Onix1
         /// where <c>LFP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
         /// cref="NeuropixelsV1ProbeConfiguration.LfpAmplifierGain"/>.
         /// </remarks>
+        [Subsampled(divisor: 12)]
         public Mat LfpData { get; }
     }
 }

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -20,9 +20,11 @@
     <PackageReference Include="Microsoft.Bcl.Numerics" Version="9.0.7" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
     <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.3.0" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="OpenEphys.Onix1.Design" />
   </ItemGroup>
+
 </Project>

--- a/OpenEphys.Onix1/SubsampledAttribute.cs
+++ b/OpenEphys.Onix1/SubsampledAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Marks a <see cref="BufferedDataFrame"/> property as sub-sampled relative to the frame's clock arrays.
+    /// </summary>
+    /// <remarks>
+    /// Apply this attribute when a property contains data that is sampled at a fixed integer fraction of the
+    /// rate used by other members in the same frame. For example, if the primary rate is 30 kHz and this
+    /// member is sampled at 2.5 kHz, set <see cref="Divisor"/> to 12.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class SubsampledAttribute : Attribute
+    {
+        /// <summary>
+        /// The number of primary-rate samples that correspond to each sub-sampled value.
+        /// </summary>
+        public int Divisor { get; }
+
+        /// <param name="divisor">
+        /// Number of primary-rate samples per sub-sampled value. Must be greater than zero.
+        /// </param>
+        public SubsampledAttribute(int divisor)
+        {
+            if (divisor <= 0)
+                throw new ArgumentOutOfRangeException(nameof(divisor), "Divisor must be greater than zero.");
+
+            Divisor = divisor;
+        }
+    }
+}


### PR DESCRIPTION
- Replace naive Arrow array encoding for sub-sampled BufferedDataFrame members with run-end encoded (REE) arrays (available since Apache.Arrow 23.0.0).
- ForNeuropixelsV1 LFP data:
    - Absolute best case, e.g. using separate file for LFP: 1.0x file size
    - REE: 1.15x file size (with all run ends pre-calculated, zero runtime computational overhead)
    - Null-mask array encoding: 1.85x file size (with large bitmask runtime computational overhead)
- Introduce new [Subsampled(divisor: N)] attribute, where N is the number of primary-rate samples per sub-sampled value. LfpData is decorated with [Subsampled(divisor: 12)].
- DataFrameWriter internals are restructured to eliminate redundant reflection traversals.
- Introduce MemberFieldGroup, pairing each leaf MemberNode with its Arrow schema Field(s). Mats with N rows produce N fields; all other members produce one, making the schema the single source of truth for how each member encodes.
- Replace GenerateSchema with BuildFieldMappings, which produces MemberFieldGroup entries in a single traversal. BuildSchema derives the schema from those groups directly, so schema generation and expression generation share one member walk instead of two independent reflection passes.
- Update IRecordBatchExpressionProvider.GetArrayPopulationExpressions to accept IEnumerable<MemberFieldGroup>.
- Decompose BufferedDataFrameExpressionProvider.GetArrayPopulationExpressions into three focused methods: BuildArrayExpression, BuildMatExpression, and BuildRunEndEncodedMatExpression.
- Simplify DataFrameExpressionProvider: struct expansion now happens in BuildFieldMappings, so the expression provider iterates only leaf groups.

- Fixes #654 
- Fixes #651 