### PR TITLE
Add remarks describing how Arrow compression works

### DIFF
--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -17,9 +17,9 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// Gets or sets a value indicating whether to enable compression when writing to the Arrow file.
         /// </summary>
         /// <remarks>
-        /// When enabled, the writer will use Zstandard (Zstd) compression to compress the record batches
-        /// before writing them to the file. This can significantly reduce the file size, especially for 
-        /// channels with redundant data. Each record batch will be compressed independently.
+        /// When enabled, record batches are compressed with Zstandard (Zstd) before writing.
+        /// This reduces file size at the cost of additional CPU overhead on read and write. 
+        /// Each record batch is compressed independently.
         /// </remarks>
         public bool EnableCompression { get; set; } = false;
 

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -20,7 +20,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// When enabled, data is compressed using the <see
         /// href="https://github.com/facebook/zstd">Zstandard</see> compression algorithm before
         /// writing. This reduces file size at the cost of additional CPU overhead on read and
-        /// write. Each block of data is compressed independently.
+        /// write.
         /// </remarks>
         public bool EnableCompression { get; set; } = false;
 

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -17,9 +17,10 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// Gets or sets a value indicating whether to enable compression when writing to the Arrow file.
         /// </summary>
         /// <remarks>
-        /// When enabled, record batches are compressed with Zstandard (Zstd) before writing.
-        /// This reduces file size at the cost of additional CPU overhead on read and write. 
-        /// Each record batch is compressed independently.
+        /// When enabled, data is compressed using the <see
+        /// href="https://github.com/facebook/zstd">Zstandard</see> compression algorithm before
+        /// writing. This reduces file size at the cost of additional CPU overhead on read and
+        /// write. Each block of data is compressed independently.
         /// </remarks>
         public bool EnableCompression { get; set; } = false;
 

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -16,6 +16,11 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// <summary>
         /// Gets or sets a value indicating whether to enable compression when writing to the Arrow file.
         /// </summary>
+        /// <remarks>
+        /// When enabled, the writer will use Zstandard (Zstd) compression to compress the record batches
+        /// before writing them to the file. This can significantly reduce the file size, especially for 
+        /// channels with redundant data. Each record batch will be compressed independently.
+        /// </remarks>
         public bool EnableCompression { get; set; } = false;
 
         /// <summary>


### PR DESCRIPTION
Specifies the compression type (Zstd) and that it operates on individual record batches.

Fixes #649 