### PR TITLE
Mark DataFrameWriter attributes as internal

### DIFF
--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterIgnoreAttribute.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterIgnoreAttribute.cs
@@ -6,7 +6,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
     /// Tells the FrameWriter to ignore this property when writing frames to disk.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class DataFrameWriterIgnoreAttribute : Attribute
+    internal sealed class DataFrameWriterIgnoreAttribute : Attribute
     {
     }
 }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterIgnoreMembersAttribute.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriterIgnoreMembersAttribute.cs
@@ -6,7 +6,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
     /// Tells the FrameWriter to ignore member types from this property when writing frames to disk.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class DataFrameWriterIgnoreMembersAttribute : Attribute
+    internal sealed class DataFrameWriterIgnoreMembersAttribute : Attribute
     {
         /// <summary>
         /// Gets the <see cref="MemberType"/> to ignore.


### PR DESCRIPTION
These attributes are only used internally, as no one is currently creating custom `DataFrame`'s.

Fixes #659 