### PR TITLE
Update NeuropixelsV2Beta and Nric1384 data for Scale operators

### DIFF
--- a/OpenEphys.Onix1/NeuropixelsV1.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1.cs
@@ -8,6 +8,8 @@ namespace OpenEphys.Onix1
         public const int ProbeI2CAddress = 0x70;
         public const int FlexEepromI2CAddress = 0x50;
 
+        public const int SamplesPerChannelPerSecond = 30_000;
+
         public const int FramesPerSuperFrame = 13;
         public const int FramesPerRoundRobin = 12;
         public const int AdcCount = 32;

--- a/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1DataFrame.cs
@@ -5,7 +5,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from a NeuropixelsV1 probe.
     /// </summary>
-    [ExpectedSampleRate(30_000)]
+    [ExpectedSampleRate(NeuropixelsV1.SamplesPerChannelPerSecond)]
     public class NeuropixelsV1DataFrame : BufferedDataFrame
     {
         /// <summary>
@@ -46,11 +46,11 @@ namespace OpenEphys.Onix1
         /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
         /// a sample to microvolts:
         /// <code> 
-        /// Electrode Voltage (µV) = (1,171.875 / AP Gain) × (ADC Sample – 512) 
+        /// Electrode Voltage (µV) = (1,171.875 / SpikeAmplifierGain) × (ADC Sample – 512) 
         /// </code>
-        /// where <c>AP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
-        /// cref="NeuropixelsV1ProbeConfiguration.SpikeAmplifierGain"/>.
+        /// where <c>SpikeAmplifierGain</c> is a value from <see cref="NeuropixelsV1Gain"/>.
         /// </remarks>
+        /// <seealso cref="NeuropixelsV1Scale"/>
         public Mat SpikeData { get; }
 
         /// <summary>
@@ -64,11 +64,11 @@ namespace OpenEphys.Onix1
         /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
         /// a sample to microvolts:
         /// <code> 
-        /// Electrode Voltage (µV) = (1,171.875 / LFP Gain) × (ADC Sample – 512)
+        /// Electrode Voltage (µV) = (1,171.875 / LfpAmplifierGain) × (ADC Sample – 512)
         /// </code>
-        /// where <c>LFP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
-        /// cref="NeuropixelsV1ProbeConfiguration.LfpAmplifierGain"/>.
+        /// where <c>LfpAmplifierGain</c> is a value from <see cref="NeuropixelsV1Gain"/>.
         /// </remarks>
+        /// <seealso cref="NeuropixelsV1Scale"/>
         [Subsampled(divisor: 12)]
         public Mat LfpData { get; }
     }

--- a/OpenEphys.Onix1/NeuropixelsV2.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2.cs
@@ -8,6 +8,8 @@ namespace OpenEphys.Onix1
         public const int ProbeAddress = 0x10;
         public const int FlexEEPROMAddress = 0x50;
 
+        public const int SamplesPerChannelPerSecond = 30_000;
+
         public const int ChannelCount = 384;
         public const int AdcBits = 12;
         public const int AdcMidpoint = 1 << (AdcBits - 1);

--- a/OpenEphys.Onix1/NeuropixelsV2Beta.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2Beta.cs
@@ -6,8 +6,14 @@ namespace OpenEphys.Onix1
         public const int ProbeAddress = 0x70;
         public const int FlexEEPROMAddress = 0x50;
 
+        public const int ChannelCount = 384;
+        public const int AdcBits = 14;
+        public const int AdcMidpoint = 1 << (AdcBits - 1);
+        public const int BaseBitsPerChannel = 4;
+        public const int ElectrodePerShank = 1280;
+
         public const int FramesPerSuperFrame = 16;
-        public const int ADCsPerProbe = 24;
+        public const int AdcsPerProbe = 24;
         public const int SyncsPerFrame = 2;
         public const int CountersPerFrame = 2;
         public const int FrameWords = 28;
@@ -35,6 +41,21 @@ namespace OpenEphys.Onix1
         public const int SR_LENGTH1 = 0x13;
         public const int PROBE_ID = 0x14;
         public const int SOFT_RESET = 0x15;
+
+        internal static int[][] AdcChannelGroups()
+        {
+            const int channelsPerAdc = ChannelCount / AdcsPerProbe;
+            var groups = new int[AdcsPerProbe][];
+            for (int a = 0; a < AdcsPerProbe; a++)
+            {
+                int block = a / 2, parity = a % 2;
+                groups[a] = new int[channelsPerAdc];
+                for (int i = 0; i < channelsPerAdc; i++)
+                    groups[a][i] = block * 32 + parity + i * 2;
+            }
+
+            return groups;
+        }
 
         internal class NameConverter : DeviceNameConverter
         {

--- a/OpenEphys.Onix1/NeuropixelsV2BetaDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2BetaDataFrame.cs
@@ -1,22 +1,21 @@
-﻿using System.Runtime.InteropServices;
-using OpenCV.Net;
+﻿using OpenCV.Net;
 
 namespace OpenEphys.Onix1
 {
     /// <summary>
     /// Buffered data from a NeuropixelsV2-Beta probe.
     /// </summary>
-    [ExpectedSampleRate(30_000)]
-    public class NeuropixelsV2eBetaDataFrame : BufferedDataFrame
+    [ExpectedSampleRate(NeuropixelsV2.SamplesPerChannelPerSecond)]
+    public class NeuropixelsV2BetaDataFrame : BufferedDataFrame
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="NeuropixelsV2eBetaDataFrame"/> class.
+        /// Initializes a new instance of the <see cref="NeuropixelsV2BetaDataFrame"/> class.
         /// </summary>
         /// <param name="clock">An array of <see cref="DataFrame.Clock"/> values.</param>
         /// <param name="hubClock">An array of hub clock counter values.</param>
         /// <param name="amplifierData">An array of multi-channel amplifier data.</param>
         /// <param name="frameCount">An array of frame count values.</param>
-        public NeuropixelsV2eBetaDataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, int[] frameCount)
+        public NeuropixelsV2BetaDataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, int[] frameCount)
             : base(clock, hubClock)
         {
             AmplifierData = amplifierData;
@@ -37,6 +36,7 @@ namespace OpenEphys.Onix1
         /// Electrode Voltage (µV) = 0.76294 × (ADC Sample – 8192)
         /// </code>
         /// </remarks>
+        /// <seealso cref="NeuropixelsV2Scale"/>
         public Mat AmplifierData { get; }
 
         /// <summary>

--- a/OpenEphys.Onix1/NeuropixelsV2DataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2DataFrame.cs
@@ -5,7 +5,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered data from a NeuropixelsV2 probe.
     /// </summary>
-    [ExpectedSampleRate(30_000)]
+    [ExpectedSampleRate(NeuropixelsV2.SamplesPerChannelPerSecond)]
     public class NeuropixelsV2DataFrame : BufferedDataFrame
     {
         /// <summary>
@@ -34,6 +34,7 @@ namespace OpenEphys.Onix1
         /// Electrode Voltage (µV) = 3.05176 × (ADC Sample – 2048)
         /// </code>
         /// </remarks>
+        /// <seealso cref="NeuropixelsV2Scale"/>
         public Mat AmplifierData { get; }
     }
 }

--- a/OpenEphys.Onix1/NeuropixelsV2Scale.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2Scale.cs
@@ -1,9 +1,9 @@
-﻿using Bonsai;
-using OpenCV.Net;
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
+using Bonsai;
+using OpenCV.Net;
 
 namespace OpenEphys.Onix1
 {
@@ -12,15 +12,6 @@ namespace OpenEphys.Onix1
     /// referencing.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Applies the equation
-    /// <code>
-    /// Electrode Voltage (µV) = 3.05176 × (ADC Sample – 2048)
-    /// </code>
-    /// to each element of the input matrix and returns a new <see cref="Depth.F32"/> matrix in microvolts.
-    /// Connect <see cref="NeuropixelsV2DataFrame.AmplifierData"/> upstream.
-    /// </para>
-    /// <para>
     /// When <see cref="UseCommonMedianReference"/> is <see langword="true"/>, per-ADC common median
     /// referencing (CMR) is applied to the scaled output. Neuropixels probes use time-division multiplexed
     /// ADCs, each of which samples a fixed subset of channels. Because each ADC can introduce a unique DC
@@ -29,7 +20,6 @@ namespace OpenEphys.Onix1
     /// that group. Unlike mean-based referencing, the median is robust to outliers such as channels with
     /// large artifacts or atypically high firing rates. The output is always <see cref="Depth.F32"/>,
     /// allowing the CMR residual to be negative without clipping.
-    /// </para>
     /// </remarks>
     [Combinator]
     [Description("Converts NeuropixelsV2 amplifier data to microvolts and optionally applies per-ADC common median referencing.")]
@@ -47,6 +37,14 @@ namespace OpenEphys.Onix1
         /// Converts each frame in <paramref name="source"/> to microvolts and optionally applies per-ADC
         /// common median referencing.
         /// </summary>
+        /// <remarks>
+        /// Applies the equation
+        /// <code>
+        /// Electrode Voltage (µV) = 3.05176 × (ADC Sample – 2048)
+        /// </code>
+        /// to each element of the input matrix and returns a new <see cref="Depth.F32"/> matrix in microvolts.
+        /// Connect to <see cref="NeuropixelsV2DataFrame"/> upstream.
+        /// </remarks>
         /// <param name="source">
         /// A sequence of 384×N matrices of 12-bit unsigned offset-binary samples from a NeuropixelsV2 probe
         /// (<see cref="Depth.U16"/>).
@@ -62,6 +60,37 @@ namespace OpenEphys.Onix1
             return source.Select(input => {
                 var output = new Mat(input.AmplifierData.Size, Depth.F32, input.AmplifierData.Channels);
                 CV.ConvertScale(input.AmplifierData, output, 3.05176, 3.05176 * -NeuropixelsV2.AdcMidpoint);
+                return useCmr ? Neuropixels.ApplyCmrF32(output, groups) : output;
+            });
+        }
+
+        /// <summary>
+        /// Converts each frame in <paramref name="source"/> to microvolts and optionally applies per-ADC
+        /// common median referencing.
+        /// </summary>
+        /// <remarks>
+        /// Applies the equation
+        /// <code>
+        /// Electrode Voltage (µV) = 0.76294 × (ADC Sample – 8192)
+        /// </code>
+        /// to each element of the input matrix and returns a new <see cref="Depth.F32"/> matrix in microvolts.
+        /// Connect to <see cref="NeuropixelsV2BetaDataFrame"/> upstream.
+        /// </remarks>
+        /// <param name="source">
+        /// A sequence of 384×N matrices of 14-bit unsigned offset-binary samples from a NeuropixelsV2Beta
+        /// probe (<see cref="Depth.U16"/>).
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="Depth.F32"/> matrices containing electrode voltages in microvolts.
+        /// </returns>
+        public IObservable<Mat> Process(IObservable<NeuropixelsV2BetaDataFrame> source)
+        {
+            var groups = NeuropixelsV2Beta.AdcChannelGroups();
+            var useCmr = UseCommonMedianReference;
+
+            return source.Select(input => {
+                var output = new Mat(input.AmplifierData.Size, Depth.F32, input.AmplifierData.Channels);
+                CV.ConvertScale(input.AmplifierData, output, 0.76294, 0.76294 * -NeuropixelsV2Beta.AdcMidpoint);
                 return useCmr ? Neuropixels.ApplyCmrF32(output, groups) : output;
             });
         }

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
@@ -10,7 +10,7 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of <see cref="NeuropixelsV2eBetaDataFrame"/> objects from a single
+    /// Produces a sequence of <see cref="NeuropixelsV2BetaDataFrame"/> objects from a single
     /// NeuropixelsV2-Beta probe.
     /// </summary>
     /// <remarks>
@@ -18,7 +18,7 @@ namespace OpenEphys.Onix1
     /// cref="ConfigureNeuropixelsV2BetaPsbDecoder"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of NeuropixelsV2eBetaDataFrame objects from a NeuropixelsV2-Beta probe.")]
-    public class NeuropixelsV2eBetaData : Source<NeuropixelsV2eBetaDataFrame>
+    public class NeuropixelsV2eBetaData : Source<NeuropixelsV2BetaDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(NeuropixelsV2Beta.NameConverter))]
@@ -49,10 +49,10 @@ namespace OpenEphys.Onix1
         public bool OrderByDepth { get; set; } = false;
 
         /// <summary>
-        /// Generates a sequence of <see cref="NeuropixelsV2eBetaDataFrame"/> objects.
+        /// Generates a sequence of <see cref="NeuropixelsV2BetaDataFrame"/> objects.
         /// </summary>
-        /// <returns>A sequence of <see cref="NeuropixelsV2eBetaDataFrame"/> objects.</returns>
-        public unsafe override IObservable<NeuropixelsV2eBetaDataFrame> Generate()
+        /// <returns>A sequence of <see cref="NeuropixelsV2BetaDataFrame"/> objects.</returns>
+        public unsafe override IObservable<NeuropixelsV2BetaDataFrame> Generate()
         {
             var bufferSize = BufferSize;
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
@@ -70,7 +70,7 @@ namespace OpenEphys.Onix1
                     .GetDeviceFrames(passthrough.Address)
                     .Where(frame => GetProbeIndex(frame) == streamIndex);
 
-                return Observable.Create<NeuropixelsV2eBetaDataFrame>(observer =>
+                return Observable.Create<NeuropixelsV2BetaDataFrame>(observer =>
                 {
                     var sampleIndex = 0;
                     var amplifierBuffer = new ushort[NeuropixelsV2.ChannelCount, bufferSize];
@@ -89,7 +89,7 @@ namespace OpenEphys.Onix1
                             if (++sampleIndex >= bufferSize)
                             {
                                 var amplifierData = Mat.FromArray(amplifierBuffer);
-                                var dataFrame = new NeuropixelsV2eBetaDataFrame(
+                                var dataFrame = new NeuropixelsV2BetaDataFrame(
                                     clockBuffer,
                                     hubClockBuffer,
                                     amplifierData,
@@ -108,37 +108,35 @@ namespace OpenEphys.Onix1
             });
         }
 
-
-
         // ADC & frame-index to channel mapping
         // First dimension: data index
         // Second dimension: frame index within super frame
         private static readonly int[,] RawToChannel = {
-            { 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30 },                          // Data Index 9, ADC 1
-            { 96, 98, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126 },       // Data Index 10, ADC 7
-            { 192, 194, 196, 198, 200, 202, 204, 206, 208, 210, 212, 214, 216, 218, 220, 222 },     // Data Index 11, ADC 13
-            { 288, 290, 292, 294, 296, 298, 300, 302, 304, 306, 308, 310, 312, 314, 316, 318 },     // Data Index 12, ADC 19
-            { 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31 },                          // Data Index 13, ADC 2
-            { 97, 99, 101, 103, 105, 107, 109, 111, 113, 115, 117, 119, 121, 123, 125, 127 },       // Data Index 14, ADC 8
-            { 193, 195, 197, 199, 201, 203, 205, 207, 209, 211, 213, 215, 217, 219, 221, 223 },     // Data Index 15, ADC 14
-            { 289, 291, 293, 295, 297, 299, 301, 303, 305, 307, 309, 311, 313, 315, 317, 319 },     // Data Index 16, ADC 20
-            { 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62 },                     // Data Index 17, ADC 3
-            { 128, 130, 132, 134, 136, 138, 140, 142, 144, 146, 148, 150, 152, 154, 156, 158 },     // Data Index 18, ADC 9
-            { 224, 226, 228, 230, 232, 234, 236, 238, 240, 242, 244, 246, 248, 250, 252, 254 },     // Data Index 19, ADC 15
-            { 320, 322, 324, 326, 328, 330, 332, 334, 336, 338, 340, 342, 344, 346, 348, 350 },     // Data Index 20, ADC 21
-            { 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63 },                     // Data Index 21, ADC 4
-            { 129, 131, 133, 135, 137, 139, 141, 143, 145, 147, 149, 151, 153, 155, 157, 159 },     // Data Index 22, ADC 10
-            { 225, 227, 229, 231, 233, 235, 237, 239, 241, 243, 245, 247, 249, 251, 253, 255 },     // Data Index 23, ADC 16
-            { 321, 323, 325, 327, 329, 331, 333, 335, 337, 339, 341, 343, 345, 347, 349, 351 },     // Data Index 24, ADC 22
-            { 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94 },                     // Data Index 25, ADC 5
-            { 160, 162, 164, 166, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 188, 190 },     // Data Index 26, ADC 11
-            { 256, 258, 260, 262, 264, 266, 268, 270, 272, 274, 276, 278, 280, 282, 284, 286 },     // Data Index 27, ADC 17
-            { 352, 354, 356, 358, 360, 362, 364, 366, 368, 370, 372, 374, 376, 378, 380, 382 },     // Data Index 28, ADC 23
-            { 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95 },                     // Data Index 29, ADC 6
-            { 161, 163, 165, 167, 169, 171, 173, 175, 177, 179, 181, 183, 185, 187, 189, 191 },     // Data Index 30, ADC 12
-            { 257, 259, 261, 263, 265, 267, 269, 271, 273, 275, 277, 279, 281, 283, 285, 287 },     // Data Index 31, ADC 18
-            { 353, 355, 357, 359, 361, 363, 365, 367, 369, 371, 373, 375, 377, 379, 381, 383 }      // Data Index 32, ADC 24
-         };
+            { 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30 },                          // Data Index 9,  ADC 0
+            { 96, 98, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126 },       // Data Index 10, ADC 6
+            { 192, 194, 196, 198, 200, 202, 204, 206, 208, 210, 212, 214, 216, 218, 220, 222 },     // Data Index 11, ADC 12
+            { 288, 290, 292, 294, 296, 298, 300, 302, 304, 306, 308, 310, 312, 314, 316, 318 },     // Data Index 12, ADC 18
+            { 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31 },                          // Data Index 13, ADC 1
+            { 97, 99, 101, 103, 105, 107, 109, 111, 113, 115, 117, 119, 121, 123, 125, 127 },       // Data Index 14, ADC 7
+            { 193, 195, 197, 199, 201, 203, 205, 207, 209, 211, 213, 215, 217, 219, 221, 223 },     // Data Index 15, ADC 13
+            { 289, 291, 293, 295, 297, 299, 301, 303, 305, 307, 309, 311, 313, 315, 317, 319 },     // Data Index 16, ADC 19
+            { 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62 },                     // Data Index 17, ADC 2
+            { 128, 130, 132, 134, 136, 138, 140, 142, 144, 146, 148, 150, 152, 154, 156, 158 },     // Data Index 18, ADC 8
+            { 224, 226, 228, 230, 232, 234, 236, 238, 240, 242, 244, 246, 248, 250, 252, 254 },     // Data Index 19, ADC 14
+            { 320, 322, 324, 326, 328, 330, 332, 334, 336, 338, 340, 342, 344, 346, 348, 350 },     // Data Index 20, ADC 20
+            { 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63 },                     // Data Index 21, ADC 3
+            { 129, 131, 133, 135, 137, 139, 141, 143, 145, 147, 149, 151, 153, 155, 157, 159 },     // Data Index 22, ADC 9
+            { 225, 227, 229, 231, 233, 235, 237, 239, 241, 243, 245, 247, 249, 251, 253, 255 },     // Data Index 23, ADC 15
+            { 321, 323, 325, 327, 329, 331, 333, 335, 337, 339, 341, 343, 345, 347, 349, 351 },     // Data Index 24, ADC 21
+            { 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94 },                     // Data Index 25, ADC 4
+            { 160, 162, 164, 166, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 188, 190 },     // Data Index 26, ADC 10
+            { 256, 258, 260, 262, 264, 266, 268, 270, 272, 274, 276, 278, 280, 282, 284, 286 },     // Data Index 27, ADC 16
+            { 352, 354, 356, 358, 360, 362, 364, 366, 368, 370, 372, 374, 376, 378, 380, 382 },     // Data Index 28, ADC 22
+            { 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95 },                     // Data Index 29, ADC 5
+            { 161, 163, 165, 167, 169, 171, 173, 175, 177, 179, 181, 183, 185, 187, 189, 191 },     // Data Index 30, ADC 11
+            { 257, 259, 261, 263, 265, 267, 269, 271, 273, 275, 277, 279, 281, 283, 285, 287 },     // Data Index 31, ADC 17
+            { 353, 355, 357, 359, 361, 363, 365, 367, 369, 371, 373, 375, 377, 379, 381, 383 }      // Data Index 32, ADC 23
+        };
 
         internal static unsafe ushort GetProbeIndex(oni.Frame frame)
         {
@@ -163,7 +161,7 @@ namespace OpenEphys.Onix1
                 var adcDataOffset = 2 + frameOffset;
 
                 // Loop over ADC samples within each "frame" and map to channel position
-                for (var k = 0; k < NeuropixelsV2Beta.ADCsPerProbe; k++)
+                for (var k = 0; k < NeuropixelsV2Beta.AdcsPerProbe; k++)
                 {
                     amplifierBuffer[channelOrder[k, i], index] = (ushort)(offset + multiplier * superFrame[adcDataOffset + k]);
                 }

--- a/OpenEphys.Onix1/Nric1384Data.cs
+++ b/OpenEphys.Onix1/Nric1384Data.cs
@@ -10,9 +10,9 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of <see cref="Nric1384DataFrame"/> objects from a Nric1384 bioacquisition device.
+    /// Produces a sequence of <see cref="NeuropixelsV1DataFrame"/> objects from a Nric1384 bioacquisition device.
     /// </summary>
-    public class Nric1384Data : Source<Nric1384DataFrame>
+    public class Nric1384Data : Source<NeuropixelsV1DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [Description(SingleDeviceFactory.DeviceNameDescription)]
@@ -40,10 +40,10 @@ namespace OpenEphys.Onix1
         }
 
         /// <summary>
-        /// Generates a sequence of <see cref="Nric1384DataFrame"/> objects.
+        /// Generates a sequence of <see cref="NeuropixelsV1DataFrame"/> objects.
         /// </summary>
-        /// <returns>A sequence of <see cref="Nric1384DataFrame"/> objects.</returns>
-        public unsafe override IObservable<Nric1384DataFrame> Generate()
+        /// <returns>A sequence of <see cref="NeuropixelsV1DataFrame"/> objects.</returns>
+        public unsafe override IObservable<NeuropixelsV1DataFrame> Generate()
         {
             var spikeBufferSize = BufferSize;
             var lfpBufferSize = spikeBufferSize / NeuropixelsV1.FramesPerRoundRobin;
@@ -52,7 +52,7 @@ namespace OpenEphys.Onix1
             {
                 var device = deviceInfo.GetDeviceContext(typeof(Nric1384));
 
-                return Observable.Create<Nric1384DataFrame>(observer =>
+                return Observable.Create<NeuropixelsV1DataFrame>(observer =>
                 {
                     var sampleIndex = 0;
                     var spikeBuffer = new short[NeuropixelsV1.ChannelCount * spikeBufferSize];
@@ -73,7 +73,7 @@ namespace OpenEphys.Onix1
                         {
                             var lfpData = BufferHelper.CopyTranspose(lfpBuffer, lfpBufferSize, NeuropixelsV1.ChannelCount, Depth.U16);
                             var apData = BufferHelper.CopyTranspose(spikeBuffer, spikeBufferSize, NeuropixelsV1.ChannelCount, Depth.U16);
-                            observer.OnNext(new Nric1384DataFrame(clockBuffer, hubClockBuffer, frameCountBuffer, apData, lfpData));
+                            observer.OnNext(new NeuropixelsV1DataFrame(clockBuffer, hubClockBuffer, frameCountBuffer, apData, lfpData));
                             frameCountBuffer = new int[spikeBufferSize];
                             hubClockBuffer = new ulong[spikeBufferSize];
                             clockBuffer = new ulong[spikeBufferSize];

--- a/OpenEphys.Onix1/Nric1384DataFrame.cs
+++ b/OpenEphys.Onix1/Nric1384DataFrame.cs
@@ -1,79 +1,7 @@
 ﻿using System.Runtime.InteropServices;
-using OpenCV.Net;
 
 namespace OpenEphys.Onix1
 {
-    /// <summary>
-    /// Buffered data from a Nric1384 bioacquisition chip.
-    /// </summary>
-    [ExpectedSampleRate(30_000)]
-    public class Nric1384DataFrame : BufferedDataFrame
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Nric1384DataFrame"/> class.
-        /// </summary>
-        /// <param name="clock">An array of <see cref="DataFrame.Clock"/> values.</param>
-        /// <param name="hubClock">An array of hub clock counter values.</param>
-        /// <param name="frameCount">An array of frame count values.</param>
-        /// <param name="spikeData">An array of multi-channel spike data as a <see cref="Mat"/> object.</param>
-        /// <param name="lfpData">An array of multi-channel LFP data as a <see cref="Mat"/> object.</param>
-        public Nric1384DataFrame(ulong[] clock, ulong[] hubClock, int[] frameCount, Mat spikeData, Mat lfpData)
-             : base(clock, hubClock)
-        {
-            FrameCount = frameCount;
-            SpikeData = spikeData;
-            LfpData = lfpData;
-        }
-
-        /// <summary>
-        /// Gets the frame count value array.
-        /// </summary>
-        /// <remarks>
-        /// A 20-bit counter on the probe that increments its value for every "frame" produced by the probe.
-        /// Thirteen frames are produced for each 384-channel column of samples in  <see cref="SpikeData"/>.
-        /// The value ranges from 0 to 1048575 (2^20-1), and should always increment by 1 until it wraps
-        /// around back to 0. This can be used to detect dropped frames.
-        /// </remarks>
-        public int[] FrameCount { get; }
-
-        /// <summary>
-        /// Gets spike-band electrophysiology data array.
-        /// </summary>
-        /// <remarks>
-        /// Spike-band (0.3-10 kHz) samples are organized in 384xN matrix with rows representing
-        /// channel number and N columns representing samples acquired at 30 kHz. Each column is a 384-channel
-        /// vector of ADC samples whose acquisition time is indicated by the corresponding elements in <see
-        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset
-        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
-        /// a sample to microvolts:
-        /// <code> 
-        /// Electrode Voltage (µV) = (1,171.875 / AP Gain) × (ADC Sample – 512) 
-        /// </code>
-        /// where <c>AP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
-        /// cref="ConfigureNric1384.SpikeAmplifierGain"/>.
-        /// </remarks>
-        public Mat SpikeData { get; }
-
-
-        /// <summary>
-        /// Gets LFP-band electrophysiology data array.
-        /// </summary>
-        /// <remarks>
-        /// LFP-band (0.5-500 Hz) samples are organized in 384xN matrix with rows representing channel
-        /// number and N columns representing samples acquired at 2.5 kHz. Each column is a 384-channel vector
-        /// of ADC samples whose acquisition time is indicated by the corresponding elements in <see
-        /// cref="DataFrame.Clock"/> and <see cref="DataFrame.HubClock"/>. Each ADC sample is a 10-bit, offset
-        /// binary value represented as a <see cref="ushort"/>. The following equation can be used to convert
-        /// a sample to microvolts:
-        /// <code> 
-        /// Electrode Voltage (µV) = (1,171.875 / LFP Gain) × (ADC Sample – 512)
-        /// </code>
-        /// where <c>LFP Gain</c> can be 50, 125, 250, 500, 1000, 1500, 2000, or 3000 depending on the value of <see
-        /// cref="ConfigureNric1384.LfpAmplifierGain"/>.
-        /// </remarks>
-        public Mat LfpData { get; }
-    }
-
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct Nric1384Payload
     {


### PR DESCRIPTION
- Nric1384Data now emits NeuropixelsV1DataFrame rather than its own redundant DataFrame type
- NeuropixelsV2Scale overloaded to work with NeuropixelsV2BetaDataFrames
- Documentation expanded and clarified
- Expands fixes for #665 