### PR TITLE
Fix DataFrameWriter widening concrete frame types

### DIFF
--- a/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
@@ -2,12 +2,7 @@
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    interface IArrowFileSink
-    {
-        bool EnableCompression { get; set; }
-    }
-
-    abstract class ArrowFileSink<TSource, TFrame> : FileSink<TSource, ArrowBatchWriter<TFrame>>, IArrowFileSink
+    abstract class ArrowFileSink<TSource, TFrame> : FileSink<TSource, ArrowBatchWriter<TFrame>>
         where TSource : TFrame
     {
         public bool EnableCompression { get; set; } = false;

--- a/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/ArrowFileSink.cs
@@ -2,7 +2,13 @@
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    abstract class ArrowFileSink<TSource> : FileSink<TSource, ArrowBatchWriter<TSource>>
+    interface IArrowFileSink
+    {
+        bool EnableCompression { get; set; }
+    }
+
+    abstract class ArrowFileSink<TSource, TFrame> : FileSink<TSource, ArrowBatchWriter<TFrame>>, IArrowFileSink
+        where TSource : TFrame
     {
         public bool EnableCompression { get; set; } = false;
     }

--- a/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/BufferedDataFrameArrowFileSink.cs
@@ -4,7 +4,8 @@ using Apache.Arrow;
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    class BufferedDataFrameArrowFileSink : ArrowFileSink<BufferedDataFrame>
+    class BufferedDataFrameArrowFileSink<TSource> : ArrowFileSink<TSource, BufferedDataFrame>
+        where TSource : BufferedDataFrame
     {
         readonly TimeSpan timeout;
 
@@ -13,7 +14,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
             this.timeout = timeout;
         }
 
-        protected override ArrowBatchWriter<BufferedDataFrame> CreateWriter(string filename, BufferedDataFrame dataFrame)
+        protected override ArrowBatchWriter<BufferedDataFrame> CreateWriter(string filename, TSource dataFrame)
         {
             var frameType = dataFrame.GetType();
             var members = DataFrameWriterHelper.GetDataMembers(frameType);
@@ -25,7 +26,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
             return new ArrowBatchWriter<BufferedDataFrame>(filename, schema, bufferSize, timeout, createRecordBatch, EnableCompression);
         }
 
-        protected override void Write(ArrowBatchWriter<BufferedDataFrame> writer, BufferedDataFrame input)
+        protected override void Write(ArrowBatchWriter<BufferedDataFrame> writer, TSource input)
         {
             writer.Write(input);
         }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameArrowFileSink.cs
@@ -4,7 +4,8 @@ using Apache.Arrow;
 
 namespace OpenEphys.Onix1.DataFrameWriter
 {
-    class DataFrameArrowFileSink : ArrowFileSink<DataFrame>
+    class DataFrameArrowFileSink<TSource> : ArrowFileSink<TSource, DataFrame>
+        where TSource : DataFrame
     {
         readonly TimeSpan timeout;
 
@@ -13,7 +14,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
             this.timeout = timeout;
         }
 
-        protected override ArrowBatchWriter<DataFrame> CreateWriter(string filename, DataFrame frame)
+        protected override ArrowBatchWriter<DataFrame> CreateWriter(string filename, TSource frame)
         {
             var frameType = frame.GetType();
             var members = DataFrameWriterHelper.GetDataMembers(frameType);
@@ -25,7 +26,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
             return new ArrowBatchWriter<DataFrame>(filename, schema, bufferSize, timeout, createRecordBatch, EnableCompression);
         }
 
-        protected override void Write(ArrowBatchWriter<DataFrame> writer, DataFrame input)
+        protected override void Write(ArrowBatchWriter<DataFrame> writer, TSource input)
         {
             writer.Write(input);
         }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -1,5 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
 using Bonsai;
+using Bonsai.Expressions;
 using Bonsai.IO;
 
 namespace OpenEphys.Onix1.DataFrameWriter
@@ -8,13 +13,50 @@ namespace OpenEphys.Onix1.DataFrameWriter
     /// Represents an operator that writes each data frame in the sequence to an Apache Arrow file using an
     /// <see cref="ArrowWriter"/>.
     /// </summary>
+    [DefaultProperty(nameof(FileName))]
     [WorkflowElementCategory(ElementCategory.Sink)]
-    public class DataFrameWriter : FileSink
+    public class DataFrameWriter : SingleArgumentExpressionBuilder
     {
         /// <summary>
-        /// Ensures that data produced by devices with non-uniform or slow sample rates are written to file periodically.
+        /// Maximum time before data is flushed to file even if internal buffer is not yet filled.
         /// </summary>
-        const int SecondsBeforeFlush = 5;
+        public const int SecondsBeforeFlush = 5;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataFrameWriter"/> class.
+        /// </summary>
+        public DataFrameWriter()
+        {
+            Buffered = true;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the file on which to write the elements.
+        /// </summary>
+        [Description("The name of the file on which to write the elements.")]
+        [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the suffix used to generate file names.
+        /// </summary>
+        [Description("The suffix used to generate file names.")]
+        public PathSuffix Suffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether element writing should be buffered. If <see langword="true"/>,
+        /// the write commands will be queued in memory as fast as possible and will be processed
+        /// by the writer in a different thread. Otherwise, writing will be done in the same
+        /// thread in which notifications arrive.
+        /// </summary>
+        [Description("Indicates whether writing should be buffered.")]
+        public bool Buffered { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to overwrite the output file if it already exists.
+        /// </summary>
+        [Description("Indicates whether to overwrite the output file if it already exists.")]
+        public bool Overwrite { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable compression when writing to the Arrow file.
@@ -28,44 +70,56 @@ namespace OpenEphys.Onix1.DataFrameWriter
         public bool EnableCompression { get; set; } = false;
 
         /// <summary>
-        /// Writes all of the data frames in the sequence to an Apache Arrow file.
+        /// Constructs an expression that writes all of the data frames in the sequence to an Apache Arrow
+        /// file.
         /// </summary>
-        /// <param name="source">The sequence of <see cref="BufferedDataFrame">BufferedDataFrames</see> to
-        /// write.</param>
+        /// <param name="arguments">
+        /// A collection containing a single <see cref="Expression"/> node representing the sequence of data
+        /// frames to write.
+        /// </param>
         /// <returns>
-        /// An observable sequence that is identical to the source sequence but where there is an additional
-        /// side effect of writing the frames to an Apache Arrow file.
+        /// An <see cref="Expression"/> that, when compiled, returns an observable sequence identical to the
+        /// input sequence, including its element type, but where there is an additional side effect of
+        /// writing each frame to an Apache Arrow file.
         /// </returns>
-        public IObservable<BufferedDataFrame> Process(IObservable<BufferedDataFrame> source)
+        /// <exception cref="WorkflowBuildException">
+        /// Thrown if upstream sequence is not composed of <see cref="DataFrame">DataFrames</see> or <see
+        /// cref="BufferedDataFrame">BufferedDataFrames</see>.
+        /// </exception>
+        public override Expression Build(IEnumerable<Expression> arguments)
         {
-            return new BufferedDataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))
-            {
-                FileName = this.FileName,
-                Suffix = this.Suffix,
-                Buffered = this.Buffered,
-                Overwrite = this.Overwrite,
-                EnableCompression = this.EnableCompression
-            }.Process(source);
-        }
+            var source = arguments.First();
+            var elementType = source.Type.GetGenericArguments()[0];
 
-        /// <summary>
-        /// Writes all of the data frames in the sequence to an Apache Arrow file.
-        /// </summary>
-        /// <param name="source">The sequence of <see cref="DataFrame">DataFrames</see> to write.</param>
-        /// <returns>
-        /// An observable sequence that is identical to the source sequence but where
-        /// there is an additional side effect of writing the frames to an Apache Arrow file.
-        /// </returns>
-        public IObservable<DataFrame> Process(IObservable<DataFrame> source)
-        {
-            return new DataFrameArrowFileSink(TimeSpan.FromSeconds(SecondsBeforeFlush))
+            Type sinkDefinition;
+            if (typeof(BufferedDataFrame).IsAssignableFrom(elementType))
             {
-                FileName = this.FileName,
-                Suffix = this.Suffix,
-                Buffered = this.Buffered,
-                Overwrite = this.Overwrite,
-                EnableCompression = this.EnableCompression
-            }.Process(source);
+                sinkDefinition = typeof(BufferedDataFrameArrowFileSink<>);
+            }
+            else if (typeof(DataFrame).IsAssignableFrom(elementType))
+            {
+                sinkDefinition = typeof(DataFrameArrowFileSink<>);
+            }
+            else
+            {
+                throw new WorkflowBuildException(
+                    $"{nameof(DataFrameWriter)} requires a sequence of {nameof(DataFrame)} or " +
+                    $"{nameof(BufferedDataFrame)} objects, but the input sequence has element type " +
+                    $"'{elementType}'.", this);
+            }
+
+            var sinkType = sinkDefinition.MakeGenericType(elementType);
+            var timeout = TimeSpan.FromSeconds(SecondsBeforeFlush);
+            var sink = (FileSink)Activator.CreateInstance(sinkType, timeout);
+            sink.FileName = FileName;
+            sink.Suffix = Suffix;
+            sink.Buffered = Buffered;
+            sink.Overwrite = Overwrite;
+            ((IArrowFileSink)sink).EnableCompression = EnableCompression;
+
+            var processMethod = sinkType.GetMethod("Process", new[] { source.Type });
+            var instance = Expression.Constant(sink);
+            return Expression.Call(instance, processMethod, source);
         }
     }
 }

--- a/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
+++ b/OpenEphys.Onix1/DataFrameWriter/DataFrameWriter.cs
@@ -20,15 +20,7 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// <summary>
         /// Maximum time before data is flushed to file even if internal buffer is not yet filled.
         /// </summary>
-        public const int SecondsBeforeFlush = 5;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataFrameWriter"/> class.
-        /// </summary>
-        public DataFrameWriter()
-        {
-            Buffered = true;
-        }
+        const int SecondsBeforeFlush = 5;
 
         /// <summary>
         /// Gets or sets the name of the file on which to write the elements.
@@ -50,13 +42,13 @@ namespace OpenEphys.Onix1.DataFrameWriter
         /// thread in which notifications arrive.
         /// </summary>
         [Description("Indicates whether writing should be buffered.")]
-        public bool Buffered { get; set; }
+        public bool Buffered { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether to overwrite the output file if it already exists.
         /// </summary>
         [Description("Indicates whether to overwrite the output file if it already exists.")]
-        public bool Overwrite { get; set; }
+        public bool Overwrite { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable compression when writing to the Arrow file.
@@ -90,15 +82,14 @@ namespace OpenEphys.Onix1.DataFrameWriter
         {
             var source = arguments.First();
             var elementType = source.Type.GetGenericArguments()[0];
-
-            Type sinkDefinition;
+            string writeMethodName;
             if (typeof(BufferedDataFrame).IsAssignableFrom(elementType))
             {
-                sinkDefinition = typeof(BufferedDataFrameArrowFileSink<>);
+                writeMethodName = nameof(WriteBuffered);
             }
             else if (typeof(DataFrame).IsAssignableFrom(elementType))
             {
-                sinkDefinition = typeof(DataFrameArrowFileSink<>);
+                writeMethodName = nameof(Write);
             }
             else
             {
@@ -107,19 +98,82 @@ namespace OpenEphys.Onix1.DataFrameWriter
                     $"{nameof(BufferedDataFrame)} objects, but the input sequence has element type " +
                     $"'{elementType}'.", this);
             }
+            var instance = Expression.Constant(this);
+            var writeMethod = typeof(DataFrameWriter)
+                .GetMethod(writeMethodName)
+                .MakeGenericMethod(elementType);
+            return Expression.Call(writeMethod, source,
+                Expression.Property(instance, nameof(FileName)),
+                Expression.Property(instance, nameof(Suffix)),
+                Expression.Property(instance, nameof(Buffered)),
+                Expression.Property(instance, nameof(Overwrite)),
+                Expression.Property(instance, nameof(EnableCompression)));
+        }
 
-            var sinkType = sinkDefinition.MakeGenericType(elementType);
-            var timeout = TimeSpan.FromSeconds(SecondsBeforeFlush);
-            var sink = (FileSink)Activator.CreateInstance(sinkType, timeout);
-            sink.FileName = FileName;
-            sink.Suffix = Suffix;
-            sink.Buffered = Buffered;
-            sink.Overwrite = Overwrite;
-            ((IArrowFileSink)sink).EnableCompression = EnableCompression;
+        /// <summary>
+        /// Writes all of the data frames in the sequence to an Apache Arrow file.
+        /// </summary>
+        /// <typeparam name="TSource">The concrete <see cref="DataFrame"/> type in the sequence.</typeparam>
+        /// <param name="source">The sequence of data frames to write.</param>
+        /// <param name="fileName">The name of the file on which to write the elements.</param>
+        /// <param name="suffix">The suffix used to generate file names.</param>
+        /// <param name="buffered">Indicates whether writing should be buffered.</param>
+        /// <param name="overwrite">Indicates whether to overwrite the output file if it already exists.</param>
+        /// <param name="enableCompression">Indicates whether to enable compression when writing to the Arrow file.</param>
+        /// <returns>
+        /// An observable sequence identical to <paramref name="source"/>, including its element type, but where
+        /// there is an additional side effect of writing each frame to an Apache Arrow file.
+        /// </returns>
+        public static IObservable<TSource> Write<TSource>(
+            IObservable<TSource> source,
+            string fileName,
+            PathSuffix suffix = PathSuffix.None,
+            bool buffered = true,
+            bool overwrite = false,
+            bool enableCompression = false)
+            where TSource : DataFrame
+        {
+            return new DataFrameArrowFileSink<TSource>(TimeSpan.FromSeconds(SecondsBeforeFlush))
+            {
+                FileName = fileName,
+                Suffix = suffix,
+                Buffered = buffered,
+                Overwrite = overwrite,
+                EnableCompression = enableCompression
+            }.Process(source);
+        }
 
-            var processMethod = sinkType.GetMethod("Process", new[] { source.Type });
-            var instance = Expression.Constant(sink);
-            return Expression.Call(instance, processMethod, source);
+        /// <summary>
+        /// Writes all of the buffered data frames in the sequence to an Apache Arrow file.
+        /// </summary>
+        /// <typeparam name="TSource">The concrete <see cref="BufferedDataFrame"/> type in the sequence.</typeparam>
+        /// <param name="source">The sequence of buffered data frames to write.</param>
+        /// <param name="fileName">The name of the file on which to write the elements.</param>
+        /// <param name="suffix">The suffix used to generate file names.</param>
+        /// <param name="buffered">Indicates whether writing should be buffered.</param>
+        /// <param name="overwrite">Indicates whether to overwrite the output file if it already exists.</param>
+        /// <param name="enableCompression">Indicates whether to enable compression when writing to the Arrow file.</param>
+        /// <returns>
+        /// An observable sequence identical to <paramref name="source"/>, including its element type, but where
+        /// there is an additional side effect of writing each frame to an Apache Arrow file.
+        /// </returns>
+        public static IObservable<TSource> WriteBuffered<TSource>(
+            IObservable<TSource> source,
+            string fileName,
+            PathSuffix suffix = PathSuffix.None,
+            bool buffered = true,
+            bool overwrite = false,
+            bool enableCompression = false)
+            where TSource : BufferedDataFrame
+        {
+            return new BufferedDataFrameArrowFileSink<TSource>(TimeSpan.FromSeconds(SecondsBeforeFlush))
+            {
+                FileName = fileName,
+                Suffix = suffix,
+                Buffered = buffered,
+                Overwrite = overwrite,
+                EnableCompression = enableCompression
+            }.Process(source);
         }
     }
 }


### PR DESCRIPTION
## Summary
- DataFrameWriter is now a single Bonsai ExpressionBuilder that inspects upstream element type at workflow-build time, picks the matching generic Arrow sink, and emits a call directly against it.
- This preserves concrete frame type with essentially no overhead
- It raises a WorkflowBuildException at build time, so the operator cannot beincorrectly chained during workflow editing
- DataFrameArrowFileSink and BufferedDataFrameArrowFileSink are now generic over the concrete source type instead of fixed to their respective base type, and ArrowFileSink exposes a small IArrowFileSink interface so the builder can configure EnableCompression without knowing the concrete sink type at compile time.
- Fixes #676 

## Note
DataFrameWriter has lost its public `Process` method and thus it has no direct use outside of Bonsai's build system. Direct use in calling code requires using internal classes currently and we might want to remedy this by wrapping it up for use by direct callers:

### Option 1: Use internals
There are no direct callers outside of `Onix1.Design` (#675) which already has access to Onix1 internals. In that case, just use the appropriate `FileSink` directly:

```csharp
IObservable<NeuropixelsV2DataFrame> dataStream = 
    new DataFrameWriter.BufferedDataFrameArrowFileSink<NeuropixelsV2DataFrame>(
        TimeSpan.FromSeconds(DataFrameWriter.DataFrameWriter.SecondsBeforeFlush))
      {
          FileName          = recordingFilePath,
          Suffix            = Bonsai.IO.PathSuffix.None,
          Buffered          = false,
          Overwrite         = true,
          EnableCompression = true
      }.Process(rawStream);
```

### Option 2: Static helpers

```csharp
/// <summary>
/// Writes all of the data frames in the sequence to an Apache Arrow file.
/// </summary>
/// <typeparam name="TSource">The concrete <see cref="DataFrame"/> type in the sequence.</typeparam>
/// <param name="source">The sequence of data frames to write.</param>
/// <param name="fileName">The name of the file on which to write the elements.</param>
/// <param name="suffix">The suffix used to generate file names.</param>
/// <param name="buffered">Indicates whether writing should be buffered.</param>
/// <param name="overwrite">Indicates whether to overwrite the output file if it already exists.</param>
/// <param name="enableCompression">Indicates whether to enable compression when writing to the Arrow file.</param>
/// <returns>
/// An observable sequence identical to <paramref name="source"/>, including its element type, but where
/// there is an additional side effect of writing each frame to an Apache Arrow file.
/// </returns>
public static IObservable<TSource> Write<TSource>(
    IObservable<TSource> source,
    string fileName,
    PathSuffix suffix = PathSuffix.None,
    bool buffered = true,
    bool overwrite = false,
    bool enableCompression = false)
    where TSource : DataFrame
{
    return new DataFrameArrowFileSink<TSource>(TimeSpan.FromSeconds(SecondsBeforeFlush))
    {
        FileName = fileName,
        Suffix = suffix,
        Buffered = buffered,
        Overwrite = overwrite,
        EnableCompression = enableCompression
    }.Process(source);
}

/// <summary>
/// Writes all of the buffered data frames in the sequence to an Apache Arrow file.
/// </summary>
/// <typeparam name="TSource">The concrete <see cref="BufferedDataFrame"/> type in the sequence.</typeparam>
/// <param name="source">The sequence of buffered data frames to write.</param>
/// <param name="fileName">The name of the file on which to write the elements.</param>
/// <param name="suffix">The suffix used to generate file names.</param>
/// <param name="buffered">Indicates whether writing should be buffered.</param>
/// <param name="overwrite">Indicates whether to overwrite the output file if it already exists.</param>
/// <param name="enableCompression">Indicates whether to enable compression when writing to the Arrow file.</param>
/// <returns>
/// An observable sequence identical to <paramref name="source"/>, including its element type, but where
/// there is an additional side effect of writing each frame to an Apache Arrow file.
/// </returns>
public static IObservable<TSource> WriteBuffered<TSource>(
    IObservable<TSource> source,
    string fileName,
    PathSuffix suffix = PathSuffix.None,
    bool buffered = true,
    bool overwrite = false,
    bool enableCompression = false)
    where TSource : BufferedDataFrame
{
    return new BufferedDataFrameArrowFileSink<TSource>(TimeSpan.FromSeconds(SecondsBeforeFlush))
    {
        FileName = fileName,
        Suffix = suffix,
        Buffered = buffered,
        Overwrite = overwrite,
        EnableCompression = enableCompression
    }.Process(source);
}
```